### PR TITLE
[BE] 페어 이름 예외처리 추가 & 테스트

### DIFF
--- a/backend/src/main/java/site/coduo/pairroom/domain/PairName.java
+++ b/backend/src/main/java/site/coduo/pairroom/domain/PairName.java
@@ -42,7 +42,7 @@ public class PairName {
         }
     }
 
-    private boolean isPatternMatch(String value) {
+    private boolean isPatternMatch(final String value) {
         return VALID_REGEX.matcher(value).matches();
     }
 

--- a/backend/src/main/java/site/coduo/pairroom/domain/PairName.java
+++ b/backend/src/main/java/site/coduo/pairroom/domain/PairName.java
@@ -38,7 +38,7 @@ public class PairName {
             throw new InvalidNameFormatException("이름은 10자 이하여야 합니다.");
         }
         if (!isPatternMatch(value)) {
-            throw new InvalidNameFormatException("한글, 영어, 특수문자, 이모지가 아닌 문자는 혀용하지 않습니다.");
+            throw new InvalidNameFormatException("한글, 영어, 특수문자, 이모지가 아닌 문자는 허용하지 않습니다.");
         }
     }
 

--- a/backend/src/main/java/site/coduo/pairroom/domain/PairName.java
+++ b/backend/src/main/java/site/coduo/pairroom/domain/PairName.java
@@ -1,6 +1,7 @@
 package site.coduo.pairroom.domain;
 
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
@@ -15,6 +16,7 @@ import site.coduo.pairroom.exception.InvalidNameFormatException;
 public class PairName {
 
     private static final int MAX_LENGTH = 10;
+    private static final Pattern VALID_REGEX = Pattern.compile("^[a-zA-Zㄱ-ㅣ가-힣~`!@#$%^&*()_\\-+=\\[\\]{}|;:'\",.<>/?\\s\\p{So}]*$");
 
     @Column(length = MAX_LENGTH, nullable = false)
     private final String value;
@@ -35,6 +37,13 @@ public class PairName {
         if (value.length() > MAX_LENGTH) {
             throw new InvalidNameFormatException("이름은 10자 이하여야 합니다.");
         }
+        if (!isPatternMatch(value)) {
+            throw new InvalidNameFormatException("한글, 영어, 특수문자, 이모지가 아닌 문자는 혀용하지 않습니다.");
+        }
+    }
+
+    private boolean isPatternMatch(String value) {
+        return VALID_REGEX.matcher(value).matches();
     }
 
     @Override

--- a/backend/src/test/java/site/coduo/pairroom/domain/PairNameTest.java
+++ b/backend/src/test/java/site/coduo/pairroom/domain/PairNameTest.java
@@ -5,32 +5,43 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import site.coduo.pairroom.exception.InvalidNameFormatException;
 
 class PairNameTest {
 
-    @Test
-    @DisplayName("이름을 생성한다.")
-    void create_name() {
-        // given
-        final String value = "레디";
-
-        // when
-        final PairName pairName = new PairName(value);
+    @ParameterizedTest
+    @ValueSource(strings = {"레디!", "파슬리 🌿", "ㄹ ㅔ ㅁ ㄴ ㅔ", "lemone"})
+    @DisplayName("한글, 한글 자음 & 모음, 영어, 기호, 이모지가 들어간 이름을 생성한다.")
+    void create_name_contains_special_character(String validName) {
+        // given & when
+        final PairName pairName = new PairName(validName);
 
         // then
-        assertThat(pairName.getValue()).isEqualTo(value);
+        assertThat(pairName.getValue()).isEqualTo(validName);
     }
 
     @Test
     @DisplayName("이름이 10자를 초과하면 예외를 발생시킨다.")
     void throw_exception_when_name_is_over_10_characters() {
         // given
-        final String value = "abcdefghijk";
+        final String invalidName = "abcdefghijk";
 
         // when & then
-        assertThatThrownBy(() -> new PairName(value))
+        assertThatThrownBy(() -> new PairName(invalidName))
+                .isExactlyInstanceOf(InvalidNameFormatException.class);
+    }
+
+    @Test
+    @DisplayName("이름에 한글, 영어가 아닌 언어가 존재하면 예외를 발생시킨다.")
+    void throw_exception_when_name_contains_non_korean_and_non_english() {
+        // given
+        final String invalidName = "號 이름";
+
+        // when & then
+        assertThatThrownBy(() -> new PairName(invalidName))
                 .isExactlyInstanceOf(InvalidNameFormatException.class);
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- closes: #38 

## 구현한 기능
- PairName에 정규식 사용해서 이름 예외처리
- 예외처리 검증을 위한 테스트

## 상세 설명
- 한글, 영어, 기호, 이모지 허용. 그 외 불가