### PR TITLE
[FE] 페어룸 페이지 UI 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from 'styled-components';
 
 import Layout from '@/pages/Layout';
 import Main from '@/pages/Main/Main';
+import PairRoom from '@/pages/PairRoom/PairRoom';
 
 import GlobalStyles from './styles/Global.style';
 import { theme } from './styles/theme';
@@ -17,6 +18,10 @@ const App = () => {
         {
           path: '',
           element: <Main />,
+        },
+        {
+          path: 'room',
+          element: <PairRoom />,
         },
       ],
     },

--- a/frontend/src/components/PairRoom/MemoCard/MemoCard.stories.tsx
+++ b/frontend/src/components/PairRoom/MemoCard/MemoCard.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import MemoCard from './MemoCard';
+
+const meta = {
+  title: 'component/PairRoom/MemoCard',
+  component: MemoCard,
+} satisfies Meta<typeof MemoCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof MemoCard>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/frontend/src/components/PairRoom/MemoCard/MemoCard.tsx
+++ b/frontend/src/components/PairRoom/MemoCard/MemoCard.tsx
@@ -1,0 +1,15 @@
+import { IoMdOpen } from 'react-icons/io';
+
+import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
+
+import { theme } from '@/styles/theme';
+
+const MemoCard = () => {
+  return (
+    <PairRoomCard>
+      <PairRoomCard.Header icon={<IoMdOpen color={theme.color.primary[500]} />} title="메모" />
+    </PairRoomCard>
+  );
+};
+
+export default MemoCard;

--- a/frontend/src/components/PairRoom/MemoCard/MemoCard.tsx
+++ b/frontend/src/components/PairRoom/MemoCard/MemoCard.tsx
@@ -4,6 +4,7 @@ import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
 
 import { theme } from '@/styles/theme';
 
+// TODO: 메모 기능 추가
 const MemoCard = () => {
   return (
     <PairRoomCard>

--- a/frontend/src/components/PairRoom/PairListCard/PairListCard.stories.tsx
+++ b/frontend/src/components/PairRoom/PairListCard/PairListCard.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import PairListCard from './PairListCard';
+
+const meta = {
+  title: 'component/PairRoom/PairListCard',
+  component: PairListCard,
+} satisfies Meta<typeof PairListCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof PairListCard>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/frontend/src/components/PairRoom/PairListCard/PairListCard.styles.ts
+++ b/frontend/src/components/PairRoom/PairListCard/PairListCard.styles.ts
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const Layout = styled.div`
+  display: flex;
+  width: 18vw;
+`;

--- a/frontend/src/components/PairRoom/PairListCard/PairListCard.tsx
+++ b/frontend/src/components/PairRoom/PairListCard/PairListCard.tsx
@@ -1,0 +1,19 @@
+import { IoPeople } from 'react-icons/io5';
+
+import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
+
+import { theme } from '@/styles/theme';
+
+import * as S from './PairListCard.styles';
+
+const PairListCard = () => {
+  return (
+    <S.Layout>
+      <PairRoomCard>
+        <PairRoomCard.Header icon={<IoPeople color={theme.color.primary[500]} />} title="페어" />
+      </PairRoomCard>
+    </S.Layout>
+  );
+};
+
+export default PairListCard;

--- a/frontend/src/components/PairRoom/PairListCard/PairListCard.tsx
+++ b/frontend/src/components/PairRoom/PairListCard/PairListCard.tsx
@@ -6,6 +6,7 @@ import { theme } from '@/styles/theme';
 
 import * as S from './PairListCard.styles';
 
+// TODO: 페어 목록 기능 추가
 const PairListCard = () => {
   return (
     <S.Layout>

--- a/frontend/src/components/PairRoom/PairRoleCard/PairRoleCard.stories.tsx
+++ b/frontend/src/components/PairRoom/PairRoleCard/PairRoleCard.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import PairRoleCard from './PairRoleCard';
+
+const meta = {
+  title: 'component/PairRoom/PairRoleCard',
+  component: PairRoleCard,
+} satisfies Meta<typeof PairRoleCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof PairRoleCard>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/frontend/src/components/PairRoom/PairRoleCard/PairRoleCard.styles.ts
+++ b/frontend/src/components/PairRoom/PairRoleCard/PairRoleCard.styles.ts
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const PairRoleCard = styled.div`
+  display: flex;
+  height: 16rem;
+`;

--- a/frontend/src/components/PairRoom/PairRoleCard/PairRoleCard.styles.ts
+++ b/frontend/src/components/PairRoom/PairRoleCard/PairRoleCard.styles.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const PairRoleCard = styled.div`
+export const Layout = styled.div`
   display: flex;
   height: 16rem;
 `;

--- a/frontend/src/components/PairRoom/PairRoleCard/PairRoleCard.tsx
+++ b/frontend/src/components/PairRoom/PairRoleCard/PairRoleCard.tsx
@@ -4,11 +4,11 @@ import * as S from './PairRoleCard.styles';
 
 const PairRoleCard = () => {
   return (
-    <S.PairRoleCard>
+    <S.Layout>
       <PairRoomCard>
         <div>내용</div>
       </PairRoomCard>
-    </S.PairRoleCard>
+    </S.Layout>
   );
 };
 

--- a/frontend/src/components/PairRoom/PairRoleCard/PairRoleCard.tsx
+++ b/frontend/src/components/PairRoom/PairRoleCard/PairRoleCard.tsx
@@ -1,0 +1,15 @@
+import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
+
+import * as S from './PairRoleCard.styles';
+
+const PairRoleCard = () => {
+  return (
+    <S.PairRoleCard>
+      <PairRoomCard>
+        <div>내용</div>
+      </PairRoomCard>
+    </S.PairRoleCard>
+  );
+};
+
+export default PairRoleCard;

--- a/frontend/src/components/PairRoom/PairRoleCard/PairRoleCard.tsx
+++ b/frontend/src/components/PairRoom/PairRoleCard/PairRoleCard.tsx
@@ -2,6 +2,7 @@ import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
 
 import * as S from './PairRoleCard.styles';
 
+// TODO: 드라이버 & 네비게이터 교체 기능 추가
 const PairRoleCard = () => {
   return (
     <S.Layout>

--- a/frontend/src/components/PairRoom/PairRoomCard/Header/Header.stories.tsx
+++ b/frontend/src/components/PairRoom/PairRoomCard/Header/Header.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { IoPeople } from 'react-icons/io5';
+
+import { theme } from '@/styles/theme';
+
+import Header from './Header';
+
+const meta = {
+  title: 'component/PairRoom/PairRoomCard/Header',
+  component: Header,
+} satisfies Meta<typeof Header>;
+
+export default meta;
+
+type Story = StoryObj<typeof Header>;
+
+export const Default: Story = {
+  args: {
+    icon: <IoPeople color={theme.color.primary[500]} />,
+    title: '제목',
+    children: <div>추가 컨텐츠</div>,
+  },
+};

--- a/frontend/src/components/PairRoom/PairRoomCard/Header/Header.styles.ts
+++ b/frontend/src/components/PairRoom/PairRoomCard/Header/Header.styles.ts
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+export const Layout = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  padding: 2rem;
+  font-size: ${({ theme }) => theme.fontSize.h6};
+  border-bottom: 1px solid ${({ theme }) => theme.color.black[30]};
+`;
+
+export const TitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+`;

--- a/frontend/src/components/PairRoom/PairRoomCard/Header/Header.styles.ts
+++ b/frontend/src/components/PairRoom/PairRoomCard/Header/Header.styles.ts
@@ -3,7 +3,9 @@ import styled from 'styled-components';
 export const Layout = styled.div`
   display: flex;
   justify-content: space-between;
+  align-items: center;
   width: 100%;
+  height: 7rem;
   padding: 2rem;
   font-size: ${({ theme }) => theme.fontSize.h6};
   border-bottom: 1px solid ${({ theme }) => theme.color.black[30]};

--- a/frontend/src/components/PairRoom/PairRoomCard/Header/Header.tsx
+++ b/frontend/src/components/PairRoom/PairRoomCard/Header/Header.tsx
@@ -1,0 +1,20 @@
+import * as S from './Header.styles';
+
+interface HeaderProps {
+  icon: React.ReactNode;
+  title: string;
+}
+
+const Header = ({ icon, title, children }: React.PropsWithChildren<HeaderProps>) => {
+  return (
+    <S.Layout>
+      <S.TitleContainer>
+        {icon}
+        <p>{title}</p>
+      </S.TitleContainer>
+      {children}
+    </S.Layout>
+  );
+};
+
+export default Header;

--- a/frontend/src/components/PairRoom/PairRoomCard/PairRoomCard.stories.tsx
+++ b/frontend/src/components/PairRoom/PairRoomCard/PairRoomCard.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { IoPeople } from 'react-icons/io5';
+
+import { theme } from '@/styles/theme';
+
+import Header from './Header/Header';
+import PairRoomCard from './PairRoomCard';
+
+const meta = {
+  title: 'component/PairRoom/PairRoomCard',
+  component: PairRoomCard,
+} satisfies Meta<typeof PairRoomCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof PairRoomCard>;
+
+const CHILDREN_EXAMPLE = (
+  <>
+    <Header icon={<IoPeople color={theme.color.primary[500]} />} title="제목" />
+    <div style={{ padding: '4rem', fontSize: theme.fontSize.base }}>본문</div>
+  </>
+);
+
+export const Default: Story = {
+  args: {
+    children: CHILDREN_EXAMPLE,
+  },
+};

--- a/frontend/src/components/PairRoom/PairRoomCard/PairRoomCard.styles.ts
+++ b/frontend/src/components/PairRoom/PairRoomCard/PairRoomCard.styles.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const Layout = styled.div`
+  flex: 1;
+  width: 100%;
+  background: ${({ theme }) => theme.color.black[10]};
+  border-radius: 1.5rem;
+`;

--- a/frontend/src/components/PairRoom/PairRoomCard/PairRoomCard.tsx
+++ b/frontend/src/components/PairRoom/PairRoomCard/PairRoomCard.tsx
@@ -1,0 +1,7 @@
+import * as S from './PairRoomCard.styles';
+
+const PairRoomCard = ({ children }: React.PropsWithChildren) => {
+  return <S.Layout>{children}</S.Layout>;
+};
+
+export default PairRoomCard;

--- a/frontend/src/components/PairRoom/PairRoomCard/index.ts
+++ b/frontend/src/components/PairRoom/PairRoomCard/index.ts
@@ -1,0 +1,6 @@
+import Header from '@/components/PairRoom/PairRoomCard/Header/Header';
+import Layout from '@/components/PairRoom/PairRoomCard/PairRoomCard';
+
+export const PairRoomCard = Object.assign(Layout, {
+  Header,
+});

--- a/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.stories.tsx
+++ b/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import ReferenceCard from './ReferenceCard';
+
+const meta = {
+  title: 'component/PairRoom/ReferenceCard',
+  component: ReferenceCard,
+} satisfies Meta<typeof ReferenceCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof ReferenceCard>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.styles.ts
+++ b/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.styles.ts
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  gap: 0.5rem;
+`;

--- a/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.styles.ts
+++ b/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.styles.ts
@@ -1,6 +1,7 @@
-import styled from 'styled-components';
+import { css } from 'styled-components';
 
-export const ButtonWrapper = styled.div`
-  display: flex;
-  gap: 0.5rem;
+export const buttonStyle = css`
+  width: 9rem;
+  height: 2.5rem;
+  font-size: ${({ theme }) => theme.fontSize.sm};
 `;

--- a/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.tsx
+++ b/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.tsx
@@ -1,25 +1,18 @@
 import { IoIosLink } from 'react-icons/io';
-import { css } from 'styled-components';
 
 import Button from '@/components/common/Button/Button';
 import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
 
 import { theme } from '@/styles/theme';
 
+import * as S from './ReferenceCard.styles';
+
 // TODO: 레퍼런스 모음 기능 추가
 const ReferenceCard = () => {
   return (
     <PairRoomCard>
       <PairRoomCard.Header icon={<IoIosLink color={theme.color.primary[500]} />} title="링크">
-        <Button
-          css={css`
-            width: 9rem;
-            height: 2.5rem;
-            font-size: ${({ theme }) => theme.fontSize.sm};
-          `}
-          color="secondary"
-          rounded={true}
-        >
+        <Button css={S.buttonStyle} color="secondary" rounded={true}>
           링크 추가하기
         </Button>
       </PairRoomCard.Header>

--- a/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.tsx
+++ b/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.tsx
@@ -1,0 +1,15 @@
+import { IoIosLink } from 'react-icons/io';
+
+import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
+
+import { theme } from '@/styles/theme';
+
+const ReferenceCard = () => {
+  return (
+    <PairRoomCard>
+      <PairRoomCard.Header icon={<IoIosLink color={theme.color.primary[500]} />} title="링크" />
+    </PairRoomCard>
+  );
+};
+
+export default ReferenceCard;

--- a/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.tsx
+++ b/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.tsx
@@ -1,13 +1,28 @@
 import { IoIosLink } from 'react-icons/io';
+import { css } from 'styled-components';
 
+import Button from '@/components/common/Button/Button';
 import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
 
 import { theme } from '@/styles/theme';
 
+// TODO: 레퍼런스 모음 기능 추가
 const ReferenceCard = () => {
   return (
     <PairRoomCard>
-      <PairRoomCard.Header icon={<IoIosLink color={theme.color.primary[500]} />} title="링크" />
+      <PairRoomCard.Header icon={<IoIosLink color={theme.color.primary[500]} />} title="링크">
+        <Button
+          css={css`
+            width: 9rem;
+            height: 2.5rem;
+            font-size: ${({ theme }) => theme.fontSize.sm};
+          `}
+          color="secondary"
+          rounded={true}
+        >
+          링크 추가하기
+        </Button>
+      </PairRoomCard.Header>
     </PairRoomCard>
   );
 };

--- a/frontend/src/components/PairRoom/TimerCard/TimerCard.stories.tsx
+++ b/frontend/src/components/PairRoom/TimerCard/TimerCard.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import TimerCard from './TimerCard';
+
+const meta = {
+  title: 'component/PairRoom/TimerCard',
+  component: TimerCard,
+} satisfies Meta<typeof TimerCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof TimerCard>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/frontend/src/components/PairRoom/TimerCard/TimerCard.tsx
+++ b/frontend/src/components/PairRoom/TimerCard/TimerCard.tsx
@@ -1,0 +1,11 @@
+import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
+
+const TimerCard = () => {
+  return (
+    <PairRoomCard>
+      <div>내용</div>
+    </PairRoomCard>
+  );
+};
+
+export default TimerCard;

--- a/frontend/src/components/PairRoom/TimerCard/TimerCard.tsx
+++ b/frontend/src/components/PairRoom/TimerCard/TimerCard.tsx
@@ -1,5 +1,6 @@
 import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
 
+// TODO: 타이머 기능 추가
 const TimerCard = () => {
   return (
     <PairRoomCard>

--- a/frontend/src/components/common/Input/Input.stories.tsx
+++ b/frontend/src/components/common/Input/Input.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import Input from '@/components/common/Input/Input';
 
 const meta = {
-  title: 'component/common/TitleContainer',
+  title: 'component/common/Input',
   component: Input,
 } satisfies Meta<typeof Input>;
 

--- a/frontend/src/pages/PairRoom/PairRoom.styles.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.styles.tsx
@@ -16,11 +16,6 @@ export const Container = styled.div`
   width: 41vw;
 `;
 
-export const PairListCard = styled.div`
-  display: flex;
-  width: 18vw;
-`;
-
 export const PairRoleCard = styled.div`
   display: flex;
   height: 16rem;

--- a/frontend/src/pages/PairRoom/PairRoom.styles.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.styles.tsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const Layout = styled.div`
+  min-height: calc(100vh - 7rem);
+  background: ${({ theme }) => theme.color.primary[100]};
+`;

--- a/frontend/src/pages/PairRoom/PairRoom.styles.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.styles.tsx
@@ -15,8 +15,3 @@ export const Container = styled.div`
   gap: 3rem;
   width: 41vw;
 `;
-
-export const PairRoleCard = styled.div`
-  display: flex;
-  height: 16rem;
-`;

--- a/frontend/src/pages/PairRoom/PairRoom.styles.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.styles.tsx
@@ -1,6 +1,27 @@
 import styled from 'styled-components';
 
 export const Layout = styled.div`
+  display: flex;
+  gap: 3rem;
+  width: 100%;
   min-height: calc(100vh - 7rem);
+  padding: 3rem;
   background: ${({ theme }) => theme.color.primary[100]};
+`;
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+  width: 41vw;
+`;
+
+export const PairListCard = styled.div`
+  display: flex;
+  width: 18vw;
+`;
+
+export const PairRoleCard = styled.div`
+  display: flex;
+  height: 16rem;
 `;

--- a/frontend/src/pages/PairRoom/PairRoom.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.tsx
@@ -3,6 +3,7 @@ import { IoPeople } from 'react-icons/io5';
 import PairListCard from '@/components/PairRoom/PairListCard/PairListCard';
 import PairRoleCard from '@/components/PairRoom/PairRoleCard/PairRoleCard';
 import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
+import TimerCard from '@/components/PairRoom/TimerCard/TimerCard';
 
 import { theme } from '@/styles/theme';
 
@@ -14,9 +15,7 @@ const PairRoom = () => {
       <PairListCard />
       <S.Container>
         <PairRoleCard />
-        <PairRoomCard>
-          <div>내용</div>
-        </PairRoomCard>
+        <TimerCard />
       </S.Container>
       <S.Container>
         <PairRoomCard>

--- a/frontend/src/pages/PairRoom/PairRoom.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.tsx
@@ -1,6 +1,7 @@
 import { IoPeople } from 'react-icons/io5';
 
 import PairListCard from '@/components/PairRoom/PairListCard/PairListCard';
+import PairRoleCard from '@/components/PairRoom/PairRoleCard/PairRoleCard';
 import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
 
 import { theme } from '@/styles/theme';
@@ -12,11 +13,7 @@ const PairRoom = () => {
     <S.Layout>
       <PairListCard />
       <S.Container>
-        <S.PairRoleCard>
-          <PairRoomCard>
-            <div>내용</div>
-          </PairRoomCard>
-        </S.PairRoleCard>
+        <PairRoleCard />
         <PairRoomCard>
           <div>내용</div>
         </PairRoomCard>

--- a/frontend/src/pages/PairRoom/PairRoom.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.tsx
@@ -1,12 +1,8 @@
-import { IoPeople } from 'react-icons/io5';
-
+import MemoCard from '@/components/PairRoom/MemoCard/MemoCard';
 import PairListCard from '@/components/PairRoom/PairListCard/PairListCard';
 import PairRoleCard from '@/components/PairRoom/PairRoleCard/PairRoleCard';
-import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
 import ReferenceCard from '@/components/PairRoom/ReferenceCard/ReferenceCard';
 import TimerCard from '@/components/PairRoom/TimerCard/TimerCard';
-
-import { theme } from '@/styles/theme';
 
 import * as S from './PairRoom.styles';
 
@@ -20,9 +16,7 @@ const PairRoom = () => {
       </S.Container>
       <S.Container>
         <ReferenceCard />
-        <PairRoomCard>
-          <PairRoomCard.Header icon={<IoPeople color={theme.color.primary[500]} />} title="메모" />
-        </PairRoomCard>
+        <MemoCard />
       </S.Container>
     </S.Layout>
   );

--- a/frontend/src/pages/PairRoom/PairRoom.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.tsx
@@ -1,5 +1,6 @@
 import { IoPeople } from 'react-icons/io5';
 
+import PairListCard from '@/components/PairRoom/PairListCard/PairListCard';
 import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
 
 import { theme } from '@/styles/theme';
@@ -9,11 +10,7 @@ import * as S from './PairRoom.styles';
 const PairRoom = () => {
   return (
     <S.Layout>
-      <S.PairListCard>
-        <PairRoomCard>
-          <PairRoomCard.Header icon={<IoPeople color={theme.color.primary[500]} />} title="페어" />
-        </PairRoomCard>
-      </S.PairListCard>
+      <PairListCard />
       <S.Container>
         <S.PairRoleCard>
           <PairRoomCard>

--- a/frontend/src/pages/PairRoom/PairRoom.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.tsx
@@ -3,6 +3,7 @@ import { IoPeople } from 'react-icons/io5';
 import PairListCard from '@/components/PairRoom/PairListCard/PairListCard';
 import PairRoleCard from '@/components/PairRoom/PairRoleCard/PairRoleCard';
 import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
+import ReferenceCard from '@/components/PairRoom/ReferenceCard/ReferenceCard';
 import TimerCard from '@/components/PairRoom/TimerCard/TimerCard';
 
 import { theme } from '@/styles/theme';
@@ -18,9 +19,7 @@ const PairRoom = () => {
         <TimerCard />
       </S.Container>
       <S.Container>
-        <PairRoomCard>
-          <PairRoomCard.Header icon={<IoPeople color={theme.color.primary[500]} />} title="링크" />
-        </PairRoomCard>
+        <ReferenceCard />
         <PairRoomCard>
           <PairRoomCard.Header icon={<IoPeople color={theme.color.primary[500]} />} title="메모" />
         </PairRoomCard>

--- a/frontend/src/pages/PairRoom/PairRoom.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.tsx
@@ -1,7 +1,39 @@
+import { IoPeople } from 'react-icons/io5';
+
+import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
+
+import { theme } from '@/styles/theme';
+
 import * as S from './PairRoom.styles';
 
 const PairRoom = () => {
-  return <S.Layout>페어룸</S.Layout>;
+  return (
+    <S.Layout>
+      <S.PairListCard>
+        <PairRoomCard>
+          <PairRoomCard.Header icon={<IoPeople color={theme.color.primary[500]} />} title="페어" />
+        </PairRoomCard>
+      </S.PairListCard>
+      <S.Container>
+        <S.PairRoleCard>
+          <PairRoomCard>
+            <div>내용</div>
+          </PairRoomCard>
+        </S.PairRoleCard>
+        <PairRoomCard>
+          <div>내용</div>
+        </PairRoomCard>
+      </S.Container>
+      <S.Container>
+        <PairRoomCard>
+          <PairRoomCard.Header icon={<IoPeople color={theme.color.primary[500]} />} title="링크" />
+        </PairRoomCard>
+        <PairRoomCard>
+          <PairRoomCard.Header icon={<IoPeople color={theme.color.primary[500]} />} title="메모" />
+        </PairRoomCard>
+      </S.Container>
+    </S.Layout>
+  );
 };
 
 export default PairRoom;

--- a/frontend/src/pages/PairRoom/PairRoom.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.tsx
@@ -1,0 +1,7 @@
+import * as S from './PairRoom.styles';
+
+const PairRoom = () => {
+  return <S.Layout>페어룸</S.Layout>;
+};
+
+export default PairRoom;


### PR DESCRIPTION
## 연관된 이슈

- closes: #59 

## 구현한 기능
- 페어룸 페이지 UI를 구현하였습니다.

## 상세 설명
<img width="705" alt="스크린샷 2024-07-24 오전 11 04 11" src="https://github.com/user-attachments/assets/e8daeb01-59dd-416a-85bf-b14ac2d9a004">

- PairRoomCard
  - 페어룸 페이지를 구성하는 카드들을 우선 `PairRoomCard` 라는 공통 컴포넌트로 생성했습니다.
  - `Header` 가 있는 컴포넌트와, 없는 컴포넌트가 나뉘어져 있어 사용처에서 조합할 수 있도록 합성 컴포넌트로 구현했습니다.

<img width="1043" alt="스크린샷 2024-07-24 오전 11 06 17" src="https://github.com/user-attachments/assets/67cee2e8-995d-4654-8f2e-c9063a32e2ad">

- 파생 컴포넌트
  - `PairRoomCard` 를 확장하여 각각의 기능에 맞는 파생 컴포넌트를 생성했습니다.
  - 추후 기능을 추가하실 때 해당 파생 컴포넌트에 작업하시면 됩니다.