### PR TITLE
[BE] 닉네임 검증 정규표현식 삭제 및 앞 뒤 공백 제거 로직 추가

### DIFF
--- a/backend/src/main/java/site/coduo/pairroom/domain/PairName.java
+++ b/backend/src/main/java/site/coduo/pairroom/domain/PairName.java
@@ -1,7 +1,6 @@
 package site.coduo.pairroom.domain;
 
 import java.util.Objects;
-import java.util.regex.Pattern;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
@@ -16,7 +15,6 @@ import site.coduo.pairroom.exception.InvalidNameFormatException;
 public class PairName {
 
     private static final int MAX_LENGTH = 10;
-    private static final Pattern VALID_REGEX = Pattern.compile("^[a-zA-Zㄱ-ㅣ가-힣~`!@#$%^&*()_\\-+=\\[\\]{}|;:'\",.<>/?\\s\\p{So}]*$");
 
     @Column(length = MAX_LENGTH, nullable = false)
     private final String value;
@@ -27,23 +25,16 @@ public class PairName {
 
     public PairName(final String value) {
         validate(value);
-        this.value = value;
+        this.value = value.trim();
     }
 
     private void validate(final String value) {
         if (StringUtils.isBlank(value)) {
             throw new InvalidNameFormatException("페어의 이름이 비어있습니다.");
         }
-        if (value.length() > MAX_LENGTH) {
-            throw new InvalidNameFormatException("이름은 10자 이하여야 합니다.");
+        if (value.trim().length() > MAX_LENGTH) {
+            throw new InvalidNameFormatException(String.format("이름은 %d자 이하여야 합니다.", MAX_LENGTH));
         }
-        if (!isPatternMatch(value)) {
-            throw new InvalidNameFormatException("한글, 영어, 특수문자, 이모지가 아닌 문자는 허용하지 않습니다.");
-        }
-    }
-
-    private boolean isPatternMatch(final String value) {
-        return VALID_REGEX.matcher(value).matches();
     }
 
     @Override

--- a/backend/src/test/java/site/coduo/pairroom/domain/PairNameTest.java
+++ b/backend/src/test/java/site/coduo/pairroom/domain/PairNameTest.java
@@ -13,7 +13,7 @@ import site.coduo.pairroom.exception.InvalidNameFormatException;
 class PairNameTest {
 
     @ParameterizedTest
-    @ValueSource(strings = {"레디!", "파슬리 🌿", "ㄹ ㅔ ㅁ ㄴ ㅔ", "lemone"})
+    @ValueSource(strings = {"레디!", "파슬리 🌿", "여 왕 님", "lemon", "abcdeabcde"})
     @DisplayName("한글, 한글 자음 & 모음, 영어, 기호, 이모지가 들어간 이름을 생성한다.")
     void create_name_contains_special_character(String validName) {
         // given & when
@@ -27,7 +27,7 @@ class PairNameTest {
     @DisplayName("이름이 10자를 초과하면 예외를 발생시킨다.")
     void throw_exception_when_name_is_over_10_characters() {
         // given
-        final String invalidName = "abcdefghijk";
+        final String invalidName = "abcdeabcdef";
 
         // when & then
         assertThatThrownBy(() -> new PairName(invalidName))
@@ -35,13 +35,28 @@ class PairNameTest {
     }
 
     @Test
-    @DisplayName("이름에 한글, 영어가 아닌 언어가 존재하면 예외를 발생시킨다.")
-    void throw_exception_when_name_contains_non_korean_and_non_english() {
+    @DisplayName("이름 앞 뒤 공백은 삭제된다.")
+    void trim_front_and_end_blank() {
         // given
-        final String invalidName = "號 이름";
+        final String name = " h e ll o ";
 
-        // when & then
-        assertThatThrownBy(() -> new PairName(invalidName))
-                .isExactlyInstanceOf(InvalidNameFormatException.class);
+        // when
+        final PairName pairName = new PairName(name);
+
+        // then
+        assertThat(pairName.getValue()).isEqualTo("h e ll o");
+    }
+
+    @Test
+    @DisplayName("공백이 제거 된 후 10 글자 이하 닉네임은 허용한다.")
+    void allow_10_characters_with_trim_name_length() {
+        // given
+        final String name = "    helloWorld   ";
+
+        // when
+        final PairName pairName = new PairName(name);
+
+        // then
+        assertThat(pairName.getValue()).isEqualTo("helloWorld");
     }
 }


### PR DESCRIPTION
## 연관된 이슈
- closes: #153 

## 구현한 기능
+ 닉네임 검증 정규 표현식 삭제
+ 닉네임 앞뒤 공백 제거 

## 상세 설명
닉네임은 중간 공백은 허용한다는 정책 및 러프하게 이모지, 영어, 숫자는 허용하기 위한 코드 수정입니다.