### PR TITLE
[FE] 방 코드 복사 로직 훅으로 분리

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -78,6 +78,11 @@ module.exports = {
             position: 'after',
           },
           {
+            pattern: '@/apis/**',
+            group: 'internal',
+            position: 'after',
+          },
+          {
             pattern: '@/hooks/**',
             group: 'internal',
             position: 'after',

--- a/frontend/src/components/CreatePairRoomModal/CompleteCreatePairRoom.tsx
+++ b/frontend/src/components/CreatePairRoomModal/CompleteCreatePairRoom.tsx
@@ -5,6 +5,8 @@ import { FaRegPaste } from 'react-icons/fa6';
 import Button from '@/components/common/Button/Button';
 import { Modal } from '@/components/common/Modal';
 
+import useCopyClipBoard from '@/hooks/useCopyClipboard';
+
 import * as S from './CreatePairRoomModal.styles';
 
 interface CompleteCreatePairRoomProps {
@@ -12,22 +14,20 @@ interface CompleteCreatePairRoomProps {
   closeModal: () => void;
 }
 const CompleteCreatePairRoom = ({ accessCode, closeModal }: CompleteCreatePairRoomProps) => {
-  const handleCopyClipBoard = async (text: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      alert('코드가 복사되었습니다.');
-    } catch (event) {
-      alert('코드 복사에 실패했습니다.');
-    }
+  const [isCopy, onCopy] = useCopyClipBoard();
+
+  const handleCopyClipBoard = (text: string) => {
+    onCopy(text);
+    console.log(isCopy); // TODO: 토스트 알림 로직 추가 필요
   };
 
   return (
     <>
       <S.ModalBodyWrapper>
         <Modal.Body>
-          <S.Content>
+          <S.Content onClick={() => handleCopyClipBoard(accessCode)}>
             <S.PairRoomCode>{accessCode}</S.PairRoomCode>
-            <S.IconBox onClick={() => handleCopyClipBoard(accessCode)}>
+            <S.IconBox>
               <FaRegPaste size={'1.8rem'} />
             </S.IconBox>
           </S.Content>

--- a/frontend/src/components/CreatePairRoomModal/CreatePairRoomModal.styles.ts
+++ b/frontend/src/components/CreatePairRoomModal/CreatePairRoomModal.styles.ts
@@ -10,21 +10,11 @@ export const Content = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-
+  padding: 1.2rem 3.2rem;
   gap: 1.2rem;
-`;
-export const PairRoomCode = styled.p`
-  font-size: ${({ theme }) => theme.fontSize.h1};
-  font-weight: ${({ theme }) => theme.fontWeight.semibold};
-`;
-
-export const IconBox = styled.div`
   cursor: pointer;
-  color: ${({ theme }) => theme.color.primary[500]};
-
-  padding: 0.5rem;
-  padding-bottom: 0;
-  border-radius: 0.5rem;
+  border-radius: 5rem;
+  transition: background-color 0.2s ease-in-out;
 
   &:hover {
     background-color: ${({ theme }) => theme.color.black[30]};
@@ -33,6 +23,18 @@ export const IconBox = styled.div`
   &:active {
     background-color: ${({ theme }) => theme.color.black[40]};
   }
+`;
+export const PairRoomCode = styled.p`
+  font-size: ${({ theme }) => theme.fontSize.h1};
+  font-weight: ${({ theme }) => theme.fontWeight.semibold};
+`;
+
+export const IconBox = styled.div`
+  color: ${({ theme }) => theme.color.primary[500]};
+
+  padding: 0.5rem;
+  padding-bottom: 0;
+  border-radius: 0.5rem;
 `;
 
 export const ModalBodyWrapper = styled.div`

--- a/frontend/src/components/PairRoom/OnboardingModal/OnboardingModal.tsx
+++ b/frontend/src/components/PairRoom/OnboardingModal/OnboardingModal.tsx
@@ -3,9 +3,9 @@ import { useNavigate } from 'react-router-dom';
 
 import { useQuery } from '@tanstack/react-query';
 
-import { getPairNames } from '@/apis/pairName';
-
 import { Modal } from '@/components/common/Modal';
+
+import { getPairNames } from '@/apis/pairName';
 
 import FooterButtons from './FooterButtons/FooterButtons';
 import type { Role, Step } from './OnboardingModal.type';

--- a/frontend/src/components/PairRoom/PairListCard/PairListCard.tsx
+++ b/frontend/src/components/PairRoom/PairListCard/PairListCard.tsx
@@ -20,17 +20,12 @@ const PairListCard = ({ driver, navigator, roomCode, onRoomDelete }: PairListCar
 
   const toggleOpen = () => setIsOpen(!isOpen);
 
-  const handleCopy = () => {
-    window.navigator.clipboard.writeText(roomCode);
-    alert('방 코드가 복사되었습니다.');
-  };
-
   return (
     <S.Layout $isOpen={isOpen} onMouseOver={() => setIsOpen(true)} onMouseLeave={() => setIsOpen(false)}>
       <PairRoomCard>
         <Header isOpen={isOpen} toggleOpen={toggleOpen} />
         <S.Sidebar>
-          <RoomCodeSection isOpen={isOpen} roomCode={roomCode} onCopy={handleCopy} />
+          <RoomCodeSection isOpen={isOpen} roomCode={roomCode} />
           <PairListSection isOpen={isOpen} driver={driver} navigator={navigator} />
           <DeleteButton isOpen={isOpen} onRoomDelete={onRoomDelete} />
         </S.Sidebar>

--- a/frontend/src/components/PairRoom/PairListCard/RoomCodeSection/RoomCodeSection.stories.tsx
+++ b/frontend/src/components/PairRoom/PairListCard/RoomCodeSection/RoomCodeSection.stories.tsx
@@ -15,7 +15,6 @@ export const Default: Story = {
   args: {
     isOpen: true,
     roomCode: 'IUUIASDFJK',
-    onCopy: () => alert('Room code copied'),
   },
 };
 
@@ -23,6 +22,5 @@ export const Closed: Story = {
   args: {
     isOpen: false,
     roomCode: 'IUUIASDFJK',
-    onCopy: () => alert('Room code copied'),
   },
 };

--- a/frontend/src/components/PairRoom/PairListCard/RoomCodeSection/RoomCodeSection.tsx
+++ b/frontend/src/components/PairRoom/PairListCard/RoomCodeSection/RoomCodeSection.tsx
@@ -1,23 +1,33 @@
 import { FaRegPaste } from 'react-icons/fa6';
 
+import useCopyClipBoard from '@/hooks/useCopyClipboard';
+
 import * as S from './RoomCodeSection.styles';
 
 interface RoomCodeSectionProps {
   isOpen: boolean;
   roomCode: string;
-  onCopy: () => void;
 }
 
-const RoomCodeSection = ({ isOpen, roomCode, onCopy }: RoomCodeSectionProps) => (
-  <S.Layout $isOpen={isOpen} onClick={onCopy}>
-    {isOpen && (
-      <S.RoomCodeWrapper>
-        <S.RoomCodeTitle>방 코드</S.RoomCodeTitle>
-        <S.RoomCode>{roomCode}</S.RoomCode>
-      </S.RoomCodeWrapper>
-    )}
-    <FaRegPaste size="1.5rem" />
-  </S.Layout>
-);
+const RoomCodeSection = ({ isOpen, roomCode }: RoomCodeSectionProps) => {
+  const [isCopy, onCopy] = useCopyClipBoard();
+
+  const handleCopyClipBoard = (text: string) => {
+    onCopy(text);
+    console.log(isCopy); // TODO: 토스트 알림 로직 추가 필요
+  };
+
+  return (
+    <S.Layout $isOpen={isOpen} onClick={() => handleCopyClipBoard(roomCode)}>
+      {isOpen && (
+        <S.RoomCodeWrapper>
+          <S.RoomCodeTitle>방 코드</S.RoomCodeTitle>
+          <S.RoomCode>{roomCode}</S.RoomCode>
+        </S.RoomCodeWrapper>
+      )}
+      <FaRegPaste size="1.5rem" />
+    </S.Layout>
+  );
+};
 
 export default RoomCodeSection;

--- a/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.stories.tsx
+++ b/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.stories.tsx
@@ -21,7 +21,7 @@ export const Default: Story = {
   render: () => (
     <ThemeProvider theme={theme}>
       <QueryClientProvider client={queryClient}>
-        <ReferenceCard />
+        <ReferenceCard accessCode="1234" />
       </QueryClientProvider>
     </ThemeProvider>
   ),

--- a/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.tsx
+++ b/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.tsx
@@ -6,13 +6,13 @@ import Input from '@/components/common/Input/Input';
 import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
 import Reference from '@/components/PairRoom/ReferenceCard/Reference';
 
+import { getReferenceLinks, addReferenceLink } from '@/apis/referenceLink';
+
 import useInput from '@/hooks/useInput';
 
 import { theme } from '@/styles/theme';
 
 import * as S from './ReferenceCard.styles';
-
-import { getReferenceLinks, addReferenceLink } from '@/apis/referenceLink';
 
 type Status = 'error' | 'default';
 

--- a/frontend/src/components/PairRoomEntryModal/PairRoomEntryModal.tsx
+++ b/frontend/src/components/PairRoomEntryModal/PairRoomEntryModal.tsx
@@ -6,9 +6,9 @@ import Button from '@/components/common/Button/Button';
 import Input from '@/components/common/Input/Input';
 import { Modal } from '@/components/common/Modal';
 
-import useInput from '@/hooks/useInput';
-
 import { addRoomCode } from '@/apis/roomCode';
+
+import useInput from '@/hooks/useInput';
 
 interface PairRoomEntryModal {
   isOpen: boolean;

--- a/frontend/src/hooks/useCopyClipboard.ts
+++ b/frontend/src/hooks/useCopyClipboard.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+type onCopyFn = (text: string) => Promise<boolean>;
+
+const useCopyClipBoard = (): [boolean, onCopyFn] => {
+  const [isCopy, setIsCopy] = useState<boolean>(false);
+
+  const onCopy: onCopyFn = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setIsCopy(true);
+      alert('클립보드에 복사되었습니다.');
+      return true;
+    } catch (error) {
+      console.error(error);
+      setIsCopy(false);
+      alert('클립보드 복사에 실패했습니다.');
+
+      return false;
+    }
+  };
+
+  return [isCopy, onCopy];
+};
+
+export default useCopyClipBoard;

--- a/frontend/src/hooks/useCopyClipboard.ts
+++ b/frontend/src/hooks/useCopyClipboard.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-type onCopyFn = (text: string) => Promise<boolean>;
+type onCopyFn = (text: string) => Promise<void>;
 
 const useCopyClipBoard = (): [boolean, onCopyFn] => {
   const [isCopy, setIsCopy] = useState<boolean>(false);
@@ -10,13 +10,10 @@ const useCopyClipBoard = (): [boolean, onCopyFn] => {
       await navigator.clipboard.writeText(text);
       setIsCopy(true);
       alert('클립보드에 복사되었습니다.');
-      return true;
     } catch (error) {
       console.error(error);
       setIsCopy(false);
       alert('클립보드 복사에 실패했습니다.');
-
-      return false;
     }
   };
 


### PR DESCRIPTION
## 연관된 이슈

- closes: #160 

## 구현한 기능

방 코드 복사 로직 useCopyClipboard.ts로 분리

## 상세 설명

배포 시 복사가 되지 않는 오류는 http로 배포했기 때문이라는 글을 확인했습니다. (관련 링크:[블로그]( https://habitual-history.tistory.com/266))
따라서 일단은 복사 로직을 훅으로 분리해 한 번에 관리하도록 리팩토링했습니다.
