### PR TITLE
[FE] 모달 리팩토링

### DIFF
--- a/frontend/src/components/common/Modal/Modal.styles.ts
+++ b/frontend/src/components/common/Modal/Modal.styles.ts
@@ -53,8 +53,7 @@ const backdropMapper = {
     background: ${({ theme }) => theme.color.black[90]};
   `,
   BLUR: css`
-    opacity: 0.36;
-    background: ${({ theme }) => theme.color.black[90]};
+    background: #00000080;
     backdrop-filter: blur(10px);
   `,
   TRANSPARENT: css`

--- a/frontend/src/hooks/common/usePreventScroll.ts
+++ b/frontend/src/hooks/common/usePreventScroll.ts
@@ -6,7 +6,7 @@ const preventScroll = () => {
   document.body.style.position = 'fixed';
   document.body.style.width = '100%';
   document.body.style.top = `-${currentScrollY}px`;
-  document.body.style.overflowY = 'scroll';
+  document.body.style.overflowY = 'auto';
 
   return currentScrollY;
 };


### PR DESCRIPTION
## 연관된 이슈

- closes: #202 

## 구현한 기능
- `backdropType` 이 `blur` 옵션일 때 적용되지 않았던 오류를 해결했습니다.
- 모달을 열면 스크롤 바가 생기는 오류를 해결했습니다.

## 상세 설명
- `backdrop-filter` CSS 옵션이 `opacity` 와 함께 사용하면 적용되지 않는다고 하여, `background-color` 를 `#00000080` 과 같이 작성했습니다.
- `usePreventScroll` 훅에서 모달이 열렸을 때 `overflow-y` 를 `scroll` 로 설정하는 옵션이 있어 이를 제거했습니다.