### PR TITLE
[FE] input 리팩터링

### DIFF
--- a/frontend/src/components/common/Input/Input.styles.ts
+++ b/frontend/src/components/common/Input/Input.styles.ts
@@ -17,7 +17,7 @@ const inputStatusCss = {
     border: 1px solid ${({ theme }) => theme.color.black[40]};
   `,
   ERROR: css`
-    background-color: ${({ theme }) => theme.color.danger[100]};
+    background-color: ${({ theme }) => theme.color.danger[50]};
     border: 1px solid ${({ theme }) => theme.color.danger[600]};
   `,
   SUCCESS: css`
@@ -31,7 +31,7 @@ const inputStatusMessageCss = {
     color: ${({ theme }) => theme.color.black[80]};
   `,
   ERROR: css`
-    color: ${({ theme }) => theme.color.danger[700]};
+    color: ${({ theme }) => theme.color.danger[600]};
   `,
 
   SUCCESS: css`
@@ -42,7 +42,7 @@ const inputStatusMessageCss = {
 export const Layout = styled.div<LayoutProps>`
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.45rem;
   width: ${({ $width }) => $width};
 `;
 

--- a/frontend/src/components/common/Input/Input.styles.ts
+++ b/frontend/src/components/common/Input/Input.styles.ts
@@ -78,5 +78,9 @@ export const Input = styled.input<InputProps>`
     border: 1px solid ${({ theme }) => theme.color.black[40]};
   }
 
+  &::placeholder {
+    color: ${({ theme }) => theme.color.primary[700]};
+  }
+
   ${(props) => props.$css}
 `;

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -56,6 +56,7 @@ const color = {
     900: '#7A5400',
   },
   danger: {
+    50: '#FFF4F1',
     100: '#FFEEDD',
     200: '#FFD9BB',
     300: '#FFBF99',


### PR DESCRIPTION
## 연관된 이슈

- closes: #204 

## 구현한 기능
input 리팩터링

## 상세 설명
1. placeholder 색 조정
<img width="555" alt="스크린샷 2024-08-01 오전 11 47 13" src="https://github.com/user-attachments/assets/c5c363cd-c938-464e-9f4e-261105a50a1f">

드롭다운이랑 border 색도 다르던데 일단 placeholder 만 수정했습니다.

2. 에러상태, 간격 조정
<img width="1280" alt="스크린샷 2024-08-01 오전 11 44 00" src="https://github.com/user-attachments/assets/bd45016c-c426-4e7e-96e2-ed45e9bd0268">

에러 상태 테마에서 가장 밝은 색으로 했던거라서, 50 으로 해서 더 밝은 색 추가했습니다.