### PR TITLE
[FE] Toast 컴포넌트 구현

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,8 @@
     "react-dom": "^18.3.1",
     "react-icons": "^5.2.1",
     "react-router-dom": "^6.25.1",
-    "styled-components": "^6.1.12"
+    "styled-components": "^6.1.12",
+    "zustand": "^4.5.4"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.6.1",

--- a/frontend/src/components/common/Toast/Toast.stories.tsx
+++ b/frontend/src/components/common/Toast/Toast.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Toast from './Toast';
+
+const meta = {
+  title: 'component/common/Toast',
+  component: Toast,
+  argTypes: {
+    isOpen: {
+      control: { type: 'boolean' },
+    },
+    status: {
+      options: ['SUCCESS', 'INFO', 'WARNING', 'ERROR'],
+      control: { type: 'radio' },
+    },
+  },
+} satisfies Meta<typeof Toast>;
+
+export default meta;
+
+type Story = StoryObj<typeof Toast>;
+
+export const Default: Story = {
+  args: {
+    message: '에러 메시지',
+  },
+};

--- a/frontend/src/components/common/Toast/Toast.styles.ts
+++ b/frontend/src/components/common/Toast/Toast.styles.ts
@@ -49,12 +49,15 @@ const backgroundMapper: Record<Status, RuleSet<object>> = {
 };
 
 export const Layout = styled.div<{ $isOpen: boolean; $isPush: boolean; $status: Status }>`
+  display: flex;
+  align-items: center;
+
   width: 30rem;
   min-height: 5rem;
   padding: 1.2rem 1.8rem;
 
   font-size: ${({ theme }) => theme.fontSize.md};
-  line-height: 1.6;
+  line-height: 1.5;
   color: ${({ theme }) => theme.color.black[10]};
 
   border-radius: 1.5rem;

--- a/frontend/src/components/common/Toast/Toast.styles.ts
+++ b/frontend/src/components/common/Toast/Toast.styles.ts
@@ -24,6 +24,15 @@ const slideOut = keyframes`
   }
 `;
 
+const pushDown = keyframes`
+  from {
+    transform: translateY(-5.6rem);
+  }
+  to {
+    transform: translateY(0);
+  }
+`;
+
 const backgroundMapper: Record<Status, RuleSet<object>> = {
   SUCCESS: css`
     background-color: ${({ theme }) => theme.color.success[500]};
@@ -39,8 +48,9 @@ const backgroundMapper: Record<Status, RuleSet<object>> = {
   `,
 };
 
-export const Layout = styled.div<{ $isOpen: boolean; $status: Status }>`
-  max-width: 40rem;
+export const Layout = styled.div<{ $isOpen: boolean; $isPush: boolean; $status: Status }>`
+  width: 30rem;
+  min-height: 5rem;
   padding: 1.2rem 1.8rem;
 
   font-size: ${({ theme }) => theme.fontSize.md};
@@ -49,7 +59,9 @@ export const Layout = styled.div<{ $isOpen: boolean; $status: Status }>`
 
   border-radius: 1.5rem;
 
-  animation: ${({ $isOpen }) => ($isOpen ? slideIn : slideOut)} 0.5s none;
+  animation:
+    ${({ $isOpen }) => ($isOpen ? slideIn : slideOut)} 0.5s none,
+    ${({ $isPush }) => $isPush && pushDown} 0.5s none;
 
   ${({ $status }) => backgroundMapper[$status]};
 `;

--- a/frontend/src/components/common/Toast/Toast.styles.ts
+++ b/frontend/src/components/common/Toast/Toast.styles.ts
@@ -40,10 +40,6 @@ const backgroundMapper: Record<Status, RuleSet<object>> = {
 };
 
 export const Layout = styled.div<{ $isOpen: boolean; $status: Status }>`
-  position: fixed;
-  top: 9rem;
-  right: 2rem;
-
   max-width: 40rem;
   padding: 1.2rem 1.8rem;
 

--- a/frontend/src/components/common/Toast/Toast.styles.ts
+++ b/frontend/src/components/common/Toast/Toast.styles.ts
@@ -1,0 +1,59 @@
+import styled, { css, keyframes, RuleSet } from 'styled-components';
+
+import type { Status } from './Toast';
+
+const slideIn = keyframes`
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+`;
+
+const slideOut = keyframes`
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+`;
+
+const backgroundMapper: Record<Status, RuleSet<object>> = {
+  SUCCESS: css`
+    background-color: ${({ theme }) => theme.color.success[500]};
+  `,
+  INFO: css`
+    background-color: ${({ theme }) => theme.color.info[500]};
+  `,
+  WARNING: css`
+    background-color: ${({ theme }) => theme.color.warning[500]};
+  `,
+  ERROR: css`
+    background-color: ${({ theme }) => theme.color.danger[500]};
+  `,
+};
+
+export const Layout = styled.div<{ $isOpen: boolean; $status: Status }>`
+  position: fixed;
+  top: 9rem;
+  right: 2rem;
+
+  max-width: 40rem;
+  padding: 1.2rem 1.8rem;
+
+  font-size: ${({ theme }) => theme.fontSize.md};
+  line-height: 1.6;
+  color: ${({ theme }) => theme.color.black[10]};
+
+  border-radius: 1.5rem;
+
+  animation: ${({ $isOpen }) => ($isOpen ? slideIn : slideOut)} 0.5s none;
+
+  ${({ $status }) => backgroundMapper[$status]};
+`;

--- a/frontend/src/components/common/Toast/Toast.styles.ts
+++ b/frontend/src/components/common/Toast/Toast.styles.ts
@@ -26,7 +26,7 @@ const slideOut = keyframes`
 
 const pushDown = keyframes`
   from {
-    transform: translateY(-5.6rem);
+    transform: translateY(-50%);
   }
   to {
     transform: translateY(0);
@@ -63,7 +63,7 @@ export const Layout = styled.div<{ $isOpen: boolean; $isPush: boolean; $status: 
   border-radius: 1.5rem;
 
   animation:
-    ${({ $isOpen }) => ($isOpen ? slideIn : slideOut)} 0.5s none,
+    ${({ $isOpen }) => ($isOpen ? slideIn : slideOut)} 0.8s none,
     ${({ $isPush }) => $isPush && pushDown} 0.5s none;
 
   ${({ $status }) => backgroundMapper[$status]};

--- a/frontend/src/components/common/Toast/Toast.tsx
+++ b/frontend/src/components/common/Toast/Toast.tsx
@@ -1,0 +1,19 @@
+import * as S from './Toast.styles';
+
+export type Status = 'SUCCESS' | 'INFO' | 'WARNING' | 'ERROR';
+
+interface ToastProps {
+  isOpen: boolean;
+  message: string;
+  status?: Status;
+}
+
+const Toast = ({ isOpen, message, status = 'ERROR' }: ToastProps) => {
+  return (
+    <S.Layout $isOpen={isOpen} $status={status}>
+      {message}
+    </S.Layout>
+  );
+};
+
+export default Toast;

--- a/frontend/src/components/common/Toast/Toast.tsx
+++ b/frontend/src/components/common/Toast/Toast.tsx
@@ -9,10 +9,17 @@ interface ToastProps {
   status?: Status;
 }
 
+const TOAST_IMOJI: Record<Status, string> = {
+  SUCCESS: '✅',
+  INFO: '📖',
+  WARNING: '👀',
+  ERROR: '⛔️',
+};
+
 const Toast = ({ isOpen, isPush, message, status = 'ERROR' }: ToastProps) => {
   return (
     <S.Layout $isOpen={isOpen} $isPush={isPush} $status={status}>
-      {message}
+      {`${TOAST_IMOJI[status]} ${message}`}
     </S.Layout>
   );
 };

--- a/frontend/src/components/common/Toast/Toast.tsx
+++ b/frontend/src/components/common/Toast/Toast.tsx
@@ -4,13 +4,14 @@ export type Status = 'SUCCESS' | 'INFO' | 'WARNING' | 'ERROR';
 
 interface ToastProps {
   isOpen: boolean;
+  isPush: boolean;
   message: string;
   status?: Status;
 }
 
-const Toast = ({ isOpen, message, status = 'ERROR' }: ToastProps) => {
+const Toast = ({ isOpen, isPush, message, status = 'ERROR' }: ToastProps) => {
   return (
-    <S.Layout $isOpen={isOpen} $status={status}>
+    <S.Layout $isOpen={isOpen} $isPush={isPush} $status={status}>
       {message}
     </S.Layout>
   );

--- a/frontend/src/components/common/ToastList/ToastList.styles.ts
+++ b/frontend/src/components/common/ToastList/ToastList.styles.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+export const Layout = styled.div`
+  position: fixed;
+  top: 9rem;
+  right: 2rem;
+
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+`;

--- a/frontend/src/components/common/ToastList/ToastList.tsx
+++ b/frontend/src/components/common/ToastList/ToastList.tsx
@@ -1,0 +1,17 @@
+import Toast from '@/components/common/Toast/Toast';
+
+import * as S from './ToastList.styles';
+
+const TOAST_LIST = ['에러 메시지 1', '에러 메시지 2', '에러 메시지 3'];
+
+const ToastList = () => {
+  return (
+    <S.Layout>
+      {TOAST_LIST.map((message) => (
+        <Toast key={message} isOpen={true} message={message} />
+      ))}
+    </S.Layout>
+  );
+};
+
+export default ToastList;

--- a/frontend/src/components/common/ToastList/ToastList.tsx
+++ b/frontend/src/components/common/ToastList/ToastList.tsx
@@ -1,14 +1,16 @@
+import useToastStore from '@/stores/toastStore';
+
 import Toast from '@/components/common/Toast/Toast';
 
 import * as S from './ToastList.styles';
 
-const TOAST_LIST = ['에러 메시지 1', '에러 메시지 2', '에러 메시지 3'];
-
 const ToastList = () => {
+  const { toastList } = useToastStore();
+
   return (
     <S.Layout>
-      {TOAST_LIST.map((message) => (
-        <Toast key={message} isOpen={true} message={message} />
+      {toastList.map((item) => (
+        <Toast key={item.id} isOpen={item.isOpen} isPush={item.isPush} message={item.message} status={item.status} />
       ))}
     </S.Layout>
   );

--- a/frontend/src/stores/toastStore.ts
+++ b/frontend/src/stores/toastStore.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand';
+
+import type { Status } from '@/components/common/Toast/Toast';
+
+interface Toast {
+  status: Status;
+  message: string;
+}
+
+interface ToastItem extends Toast {
+  id: number;
+  isOpen: boolean;
+  isPush: boolean;
+}
+
+interface ToastStore {
+  toastList: ToastItem[];
+  addToast: (toast: Toast) => void;
+}
+
+const useToastStore = create<ToastStore>((set) => ({
+  toastList: [],
+  addToast: (toast: Toast) => {
+    const id = Date.now();
+    const toastItem = { ...toast, id, isOpen: true, isPush: false };
+
+    set((state) => {
+      return { toastList: [toastItem, ...state.toastList.map((item) => ({ ...item, isPush: true }))].slice(0, 3) };
+    });
+
+    setTimeout(() => {
+      set((state) => ({
+        toastList: state.toastList.map((item) => (item.id === id ? { ...item, isOpen: false } : item)),
+      }));
+      setTimeout(() => {
+        set((state) => ({
+          toastList: state.toastList.filter((item) => item.id !== id),
+        }));
+      }, 500);
+    }, 1500);
+  },
+}));
+
+export default useToastStore;

--- a/frontend/src/stores/toastStore.ts
+++ b/frontend/src/stores/toastStore.ts
@@ -36,8 +36,8 @@ const useToastStore = create<ToastStore>((set) => ({
         set((state) => ({
           toastList: state.toastList.filter((item) => item.id !== id),
         }));
-      }, 500);
-    }, 1500);
+      }, 750);
+    }, 3000);
   },
 }));
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8611,16 +8611,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8706,14 +8697,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9403,6 +9387,11 @@ url@^0.11.0:
     punycode "^1.4.1"
     qs "^6.11.2"
 
+use-sync-external-store@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -9773,16 +9762,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -9887,3 +9867,10 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zustand@^4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.5.4.tgz#63abdd81edfb190bc61e0bbae045cc4d52158a05"
+  integrity sha512-/BPMyLKJPtFEvVL0E9E9BTUM63MNyhPGlvxk1XjrfWTUlV+BR8jufjsovHzrtR6YNcBEcL7cMHovL1n9xHawEg==
+  dependencies:
+    use-sync-external-store "1.2.0"


### PR DESCRIPTION
## 연관된 이슈

- closes: #217 

## 구현한 기능
- Toast 컴포넌트를 구현했습니다.

## 상세 설명
- 전역 상태 관리를 위해 `Zustand` 라이브러리를 설치했습니다.
- 최대 3개의 `Toast` 컴포넌트만 뜨도록 구현했습니다.

### 상세 화면
![ezgif-2-1a7eff0f0c](https://github.com/user-attachments/assets/182f1a60-1ed4-46fc-b2f4-1759c06fef1f)

### 사용 방법
1. 사용하고자 하는 컴포넌트에서 `useToastStore` 저장소를 불러옵니다.
```js
import useToastStore from '@/stores/toastStore';
```
2. Toast 컴포넌트를 추가하는 `addToast` 함수를 불러옵니다. 
```js
const { addToast } = useToastStore();
```
3. 사용처에서 `status` 와 `message` 를 추가하여 사용합니다.
```js
addToast({ 'ERROR', '에러 메시지입니다' });
```