### PR TITLE
[FE] 페어룸 페이지 반응형 디자인 개선

### DIFF
--- a/frontend/src/components/PairRoom/PairListCard/PairListCard.styles.ts
+++ b/frontend/src/components/PairRoom/PairListCard/PairListCard.styles.ts
@@ -8,7 +8,7 @@ export const Layout = styled.div<{ $isOpen: boolean }>`
   align-items: center;
   justify-content: center;
 
-  width: ${(props) => (props.$isOpen ? '66rem' : '6rem')};
+  min-width: ${(props) => (props.$isOpen ? '28rem' : '6rem')};
 
   white-space: nowrap;
 

--- a/frontend/src/components/PairRoom/PairRoleCard/PairRoleCard.styles.ts
+++ b/frontend/src/components/PairRoom/PairRoleCard/PairRoleCard.styles.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 export const Layout = styled.div`
   display: flex;
+  min-width: 60rem;
   height: 16rem;
 `;
 

--- a/frontend/src/components/PairRoom/PairRoomCard/PairRoomCard.styles.ts
+++ b/frontend/src/components/PairRoom/PairRoomCard/PairRoomCard.styles.ts
@@ -2,7 +2,10 @@ import styled from 'styled-components';
 
 export const Layout = styled.div`
   flex: 1;
+
   width: 100%;
+  height: 100%;
+
   background: ${({ theme }) => theme.color.black[10]};
   border-radius: 1.5rem;
 `;

--- a/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.styles.ts
+++ b/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.styles.ts
@@ -1,5 +1,11 @@
 import styled, { css } from 'styled-components';
 
+export const Layout = styled.div`
+  flex: 1;
+  min-width: 49rem;
+  max-height: calc(100vh - 13rem);
+`;
+
 export const buttonStyle = css`
   width: 9rem;
   height: 2.5rem;
@@ -29,22 +35,23 @@ export const ReferenceLink = styled.a`
   }
 `;
 
-export const ReferenceList = styled.ul`
+export const ReferenceListContainer = styled.div`
   overflow-y: auto;
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 3rem 1rem;
-  place-items: center;
+  max-height: calc(100vh - 23rem);
+  padding: 3rem;
+`;
 
-  height: calc(100vh - 30rem);
-  margin: 3rem;
+export const ReferenceList = styled.ul`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 3rem;
 
   li {
     list-style-type: none;
   }
 
-  @media (width >= 1600px) {
-    grid-template-columns: repeat(3, 1fr);
+  @media (width < 1600px) {
+    grid-template-columns: repeat(2, 1fr);
   }
 `;
 

--- a/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.tsx
+++ b/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.tsx
@@ -1,5 +1,7 @@
 import { IoIosLink } from 'react-icons/io';
 
+import useReferenceLinks from '@/queries/PairRoom/useReferenceLinks';
+
 import Bookmark from '@/components/common/Bookmark/Bookmark';
 import Button from '@/components/common/Button/Button';
 import Input from '@/components/common/Input/Input';
@@ -10,8 +12,6 @@ import useInput from '@/hooks/common/useInput';
 import { theme } from '@/styles/theme';
 
 import * as S from './ReferenceCard.styles';
-
-import useReferenceLinks from '@/queries/PairRoom/useReferenceLinks';
 
 interface ReferenceCardProps {
   accessCode: string;
@@ -33,47 +33,50 @@ const ReferenceCard = ({ accessCode }: ReferenceCardProps) => {
     'contentcontentcontentcontecontentcontentcontentcontentcocontentcontentcontentconcontentcontentcontentcontentcontentcontentcontentconntentconntcontentcontentcontentcontent';
 
   return (
-    <PairRoomCard>
-      <PairRoomCard.Header icon={<IoIosLink color={theme.color.primary[500]} />} title="링크">
-        <S.ReferenceLinkForm onSubmit={handleSubmit}>
-          <Input
-            placeholder="링크를 입력해주세요."
-            value={value}
-            status={status}
-            message={message}
-            onChange={handleChange}
-          />
-          <Button
-            disabled={!isButtonActive}
-            css={S.buttonStyle}
-            color="secondary"
-            rounded={true}
-            onClick={() => addReferenceLink({ accessCode, url: value })}
-          >
-            링크 추가
-          </Button>
-        </S.ReferenceLinkForm>
-      </PairRoomCard.Header>
-      <S.ReferenceList>
-        {referenceLinks.length > 0 ? (
-          referenceLinks.map(({ url, id }) => {
-            // url, title, description, image
-            return (
-              <Bookmark
-                url={url}
-                image={IMAGE}
-                key={id}
-                title={BOOKMARK_TITLE}
-                description={BOOKMARK_CONTENTS}
-                deleteReferenceLink={() => deleteReferenceLink({ accessCode, id })}
-              />
-            );
-          })
-        ) : (
-          <S.EmptyText>저장된 링크가 없습니다.</S.EmptyText>
-        )}
-      </S.ReferenceList>
-    </PairRoomCard>
+    <S.Layout>
+      <PairRoomCard>
+        <PairRoomCard.Header icon={<IoIosLink color={theme.color.primary[500]} />} title="링크">
+          <S.ReferenceLinkForm onSubmit={handleSubmit}>
+            <Input
+              placeholder="링크를 입력해주세요."
+              value={value}
+              status={status}
+              message={message}
+              onChange={handleChange}
+            />
+            <Button
+              disabled={!isButtonActive}
+              css={S.buttonStyle}
+              color="secondary"
+              rounded={true}
+              onClick={() => addReferenceLink({ accessCode, url: value })}
+            >
+              링크 추가
+            </Button>
+          </S.ReferenceLinkForm>
+        </PairRoomCard.Header>
+        <S.ReferenceListContainer>
+          {referenceLinks.length > 0 ? (
+            <S.ReferenceList>
+              {referenceLinks.map(({ url, id }) => {
+                return (
+                  <Bookmark
+                    key={id}
+                    url={url}
+                    image={IMAGE}
+                    title={BOOKMARK_TITLE}
+                    description={BOOKMARK_CONTENTS}
+                    deleteReferenceLink={() => deleteReferenceLink({ accessCode, id })}
+                  />
+                );
+              })}
+            </S.ReferenceList>
+          ) : (
+            <S.EmptyText>저장된 링크가 없습니다.</S.EmptyText>
+          )}
+        </S.ReferenceListContainer>
+      </PairRoomCard>
+    </S.Layout>
   );
 };
 

--- a/frontend/src/components/PairRoom/TimerCard/TimerCard.styles.ts
+++ b/frontend/src/components/PairRoom/TimerCard/TimerCard.styles.ts
@@ -8,7 +8,7 @@ export const Layout = styled.div`
   align-items: center;
   justify-content: center;
 
-  width: 100%;
+  min-width: 60rem;
   height: 100%;
   padding: 3rem;
 `;

--- a/frontend/src/components/PairRoom/TimerCard/TimerCard.styles.ts
+++ b/frontend/src/components/PairRoom/TimerCard/TimerCard.styles.ts
@@ -18,12 +18,8 @@ export const ProgressBar = styled.div<{ $progress: number }>`
   align-items: center;
   justify-content: center;
 
-  width: 25vw;
-  min-width: 30rem;
-  max-width: 100%;
-  height: 25vw;
-  min-height: 30rem;
-  max-height: 100%;
+  min-width: 45vh;
+  min-height: 45vh;
 
   background-image: linear-gradient(white, white),
     conic-gradient(

--- a/frontend/src/pages/Layout.styles.ts
+++ b/frontend/src/pages/Layout.styles.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const Layout = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-width: fit-content;
+`;

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -2,14 +2,16 @@ import { Outlet } from 'react-router-dom';
 
 import Header from '@/components/common/Header/Header';
 
+import * as S from './Layout.styles';
+
 const Layout = () => {
   return (
-    <div>
+    <S.Layout>
       <Header />
       <main>
         <Outlet />
       </main>
-    </div>
+    </S.Layout>
   );
 };
 

--- a/frontend/src/pages/PairRoom/PairRoom.styles.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.styles.tsx
@@ -4,8 +4,7 @@ export const Layout = styled.div`
   display: flex;
   gap: 3rem;
 
-  width: 100%;
-  height: calc(100vh - 7rem);
+  min-height: calc(100vh - 7rem);
   padding: 3rem;
 
   background: ${({ theme }) => theme.color.primary[100]};

--- a/frontend/src/pages/PairRoom/PairRoom.styles.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.styles.tsx
@@ -4,6 +4,7 @@ export const Layout = styled.div`
   display: flex;
   gap: 3rem;
 
+  min-width: fit-content;
   min-height: calc(100vh - 7rem);
   padding: 3rem;
 


### PR DESCRIPTION
## 연관된 이슈

- closes: #243 

## 구현한 기능
- 페어룸 페이지에서 반응형 디자인이 깨지는 부분을 개선했습니다.
- 최소 너비를 설정하여 페이지 안의 내용들이 끝없이 작아지는 현상을 개선했습니다.
- `ReferenceCard` 안의 북마크가 가운데로 추가되는 현상을 개선했습니다.

## 상세 설명
<img width="1257" alt="스크린샷 2024-08-05 오후 5 22 06" src="https://github.com/user-attachments/assets/c9ab6968-3e75-4526-aabe-042407bfa0ef">

<br />
<br />

- 최소 너비에서의 레이아웃은 위와 같습니다.
- 추후 모바일 환경에서의 레이아웃을 새로 고민해 봐야 할듯 싶습니다.