### PR TITLE
[FE] 브랜치 생성 로직 재 추가

### DIFF
--- a/frontend/src/components/PairRoom/StartMission/StartMission.tsx
+++ b/frontend/src/components/PairRoom/StartMission/StartMission.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { BsArrowReturnRight } from 'react-icons/bs';
 
@@ -37,13 +37,17 @@ const StartMission = ({ handleStartMission }: StartMissionProps) => {
   };
 
   const { isModalOpen, closeModal, openModal } = useModal();
-  const { isAlreadyCreated } = useGetBranches(currentRepo);
+  const { isAlreadyCreated, refetch } = useGetBranches(currentRepo);
   const { value, message, handleChange, status } = useInput();
 
   const validate = (name: string): { status: InputStatus; message: string } => {
     if (isAlreadyCreated(name)) return { status: 'ERROR', message: '중복된 브랜치 이름 입니다.' };
     return { status: 'DEFAULT', message: '' };
   };
+
+  useEffect(() => {
+    if (currentRepo !== '') refetch();
+  }, [currentRepo]);
 
   return (
     <>

--- a/frontend/src/pages/PairRoomOnboarding/PairRoomOnboarding.tsx
+++ b/frontend/src/pages/PairRoomOnboarding/PairRoomOnboarding.tsx
@@ -1,17 +1,20 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
+import StartMission from '@/components/PairRoom/StartMission/StartMission';
 import FooterButtons from '@/components/PairRoomOnboarding/FooterButtons/FooterButtons';
 import ProgressBar from '@/components/PairRoomOnboarding/ProgressBar/ProgressBar';
 import RoleSettingSection from '@/components/PairRoomOnboarding/RoleSettingSection/RoleSettingSection';
 
+import useCreateBranch from '@/queries/github/useCreateBranch';
 import useGetPairRoomInformation from '@/queries/PairRoom/useGetPairRoomInformation';
 
 import * as S from './PairRoomOnboarding.styles';
-import type { Role } from './PairRoomOnboarding.type';
+import type { Role, Step } from './PairRoomOnboarding.type';
 
 const PairRoomOnboarding = () => {
-  const step = 'ROLE';
+  const [step, setStep] = useState<Step>('MISSION');
+  const { handleStartMission } = useCreateBranch(() => setStep('ROLE'));
 
   const navigate = useNavigate();
   const { accessCode } = useParams();
@@ -66,6 +69,7 @@ const PairRoomOnboarding = () => {
           <>
             <div>
               <ProgressBar step={step} />
+              {step === 'MISSION' && <StartMission handleStartMission={handleStartMission} />}
               {step === 'ROLE' && pairNames && (
                 <RoleSettingSection
                   driver={driver}

--- a/frontend/src/queries/github/useGetBranches.ts
+++ b/frontend/src/queries/github/useGetBranches.ts
@@ -9,9 +9,11 @@ const useGetBranches = (repository: string) => {
     data: branches,
     isFetching,
     error,
+    refetch,
   } = useQuery({
     queryKey: [QUERY_KEYS.GET_BRANCHES, repository],
     queryFn: () => getBranches(repository),
+    enabled: false,
   });
 
   interface BranchResponse {
@@ -23,7 +25,7 @@ const useGetBranches = (repository: string) => {
     return branchesName.includes(branchName);
   };
 
-  return { branches, isFetching, error, isAlreadyCreated };
+  return { branches, isFetching, error, isAlreadyCreated, refetch };
 };
 
 export default useGetBranches;


### PR DESCRIPTION
## 연관된 이슈

- closes: #244 

## 구현한 기능
브랜치 생성 로직 재 추가

## 상세 설명
- 미션 시작 시 브랜치 생성 로직 온보딩 컴포넌트에 추가
- 레포지토리에 대한 브랜치 가져오는 부분을 refetch 사용하여 레포지토리를 선택해야 get 요청을 보내도록 수정