### PR TITLE
[FE] 에러 페이지 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from 'styled-components';
 
+import PageNotFound from '@/pages/Error/PageNotFound';
 import HowToPair from '@/pages/HowToPair/HowToPair';
 import Layout from '@/pages/Layout';
 import Main from '@/pages/Main/Main';
@@ -35,6 +36,10 @@ const App = () => {
         {
           path: 'room/:accessCode/onboarding',
           element: <PairRoomOnboarding />,
+        },
+        {
+          path: '*',
+          element: <PageNotFound />,
         },
       ],
     },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ const App = () => {
     {
       path: '/',
       element: <Layout />,
+      errorElement: <PageNotFound />,
       children: [
         {
           path: '',
@@ -36,10 +37,6 @@ const App = () => {
         {
           path: 'room/:accessCode/onboarding',
           element: <PairRoomOnboarding />,
-        },
-        {
-          path: '*',
-          element: <PageNotFound />,
         },
       ],
     },

--- a/frontend/src/pages/Error/PageNotFound.styles.ts
+++ b/frontend/src/pages/Error/PageNotFound.styles.ts
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+
+export const Layout = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  align-items: center;
+
+  height: 100vh;
+  padding: 10rem;
+
+  background-color: ${({ theme }) => theme.color.primary[100]};
+`;
+
+export const Title = styled.h1`
+  font-size: ${({ theme }) => theme.fontSize.h1};
+  font-weight: bold;
+`;
+
+export const Description = styled.p`
+  margin-bottom: 2rem;
+
+  font-size: ${({ theme }) => theme.fontSize.base};
+  line-height: 1.5;
+  color: ${({ theme }) => theme.color.primary[800]};
+  text-align: center;
+`;

--- a/frontend/src/pages/Error/PageNotFound.tsx
+++ b/frontend/src/pages/Error/PageNotFound.tsx
@@ -1,0 +1,26 @@
+import { Link } from 'react-router-dom';
+
+import { LuHome } from 'react-icons/lu';
+
+import Button from '@/components/common/Button/Button';
+
+import * as S from './PageNotFound.styles';
+
+const PageNotFound = () => {
+  return (
+    <S.Layout>
+      <S.Title>🚨 404 🚨</S.Title>
+      <S.Description>
+        존재하지 않는 페이지이거나 잘못된 접근입니다. <br />
+        주소를 다시 확인해주세요. 😥
+      </S.Description>
+      <Link to="/">
+        <Button rounded={true} size="lg" aria-label="홈으로 이동">
+          <LuHome size="2rem" />
+        </Button>
+      </Link>
+    </S.Layout>
+  );
+};
+
+export default PageNotFound;


### PR DESCRIPTION
## 연관된 이슈

- closes: #329 

## 구현한 기능

404 에러 페이지 구현

## 상세 설명

404 에러 페이지를 구현해 라우터에 추가했습니다.
추후 `방 들어가기` 로 방에 접근하는 것이 아닌, 직접 주소창에 링크를 입력해 접근을 시도하는 경우도 핸들링할 예정입니다.
