### PR TITLE
[BE] GitHub oauth로 login 기능 구현  (#359)

### DIFF
--- a/backend/OAUTH.md
+++ b/backend/OAUTH.md
@@ -1,0 +1,11 @@
+# Github Oauth 연동
+
+## Callback
+- [ ] GET http://www.coudo.site/api/callback
+  + state 
+  + code
+  - [ ] POST 
+     + www-authenticate-basic BASIC {clientId}:{clientSecret}
+     + code
+     + redirect_uri
+

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,70 +1,74 @@
 plugins {
-  id 'java'
-  id 'org.springframework.boot' version '3.3.1'
-  id 'io.spring.dependency-management' version '1.1.5'
+	id 'java'
+	id 'org.springframework.boot' version '3.3.1'
+	id 'io.spring.dependency-management' version '1.1.5'
 }
 
 group = 'site'
 version = '0.0.1-SNAPSHOT'
 
 java {
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
-  }
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(17)
+	}
 }
 
 configurations {
-  compileOnly {
-    extendsFrom annotationProcessor
-  }
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
 }
 
 repositories {
-  mavenCentral()
+	mavenCentral()
 }
 
 dependencies {
-  // Web
-  implementation 'org.springframework.boot:spring-boot-starter-web'
+	// Web
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 
-  // Lombok
-  annotationProcessor 'org.projectlombok:lombok'
-  compileOnly 'org.projectlombok:lombok'
+	// Lombok
+	annotationProcessor 'org.projectlombok:lombok'
+	compileOnly 'org.projectlombok:lombok'
 
-  // Jsoup
-  implementation 'org.jsoup:jsoup:1.17.2'
+	// Jsoup
+	implementation 'org.jsoup:jsoup:1.17.2'
 
-  // Validation
-  implementation 'org.springframework.boot:spring-boot-starter-validation'
+	// Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-  // JPA
-  implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	// JPA
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-  // H2
-  runtimeOnly 'com.h2database:h2'
+	// H2
+	runtimeOnly 'com.h2database:h2'
 
-  // Mysql
-  runtimeOnly 'com.mysql:mysql-connector-j'
+	// Mysql
+	runtimeOnly 'com.mysql:mysql-connector-j'
 
-  // Actuator
-  implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	// Actuator
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-  // Prometheus
-  runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+	// Prometheus
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
-  // Swagger
-  implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
-  // Test
-  testImplementation 'org.springframework.boot:spring-boot-starter-test'
-  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-  testImplementation 'io.rest-assured:rest-assured:5.5.0'
+	// Auth
+	implementation 'io.jsonwebtoken:jjwt:0.12.6'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
+
+	// Test
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'io.rest-assured:rest-assured:5.5.0'
 }
 
 tasks.named('test') {
-  useJUnitPlatform()
+	useJUnitPlatform()
 }
 
 jar {
-  enabled = false
+	enabled = false
 }

--- a/backend/http/member.http
+++ b/backend/http/member.http
@@ -1,0 +1,2 @@
+### 로그인 요청하기
+GET http://localhost:8080/api/github/callback?code=abc&state=abcd

--- a/backend/src/main/java/site/coduo/member/client/GithubApiClient.java
+++ b/backend/src/main/java/site/coduo/member/client/GithubApiClient.java
@@ -1,0 +1,40 @@
+package site.coduo.member.client;
+
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import site.coduo.member.client.dto.GithubUserRequest;
+import site.coduo.member.client.dto.GithubUserResponse;
+
+@Component
+public class GithubApiClient {
+
+    private static final int CONNECT_TIME_VALUE = 1000;
+    private static final int READ_TIME_OUT_VALUE = 10000;
+
+    private final RestClient client;
+
+    public GithubApiClient() {
+        final SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(CONNECT_TIME_VALUE);
+        requestFactory.setReadTimeout(READ_TIME_OUT_VALUE);
+
+        this.client = RestClient.builder()
+                .requestFactory(requestFactory)
+                .messageConverters(converter -> converter.add(new MappingJackson2HttpMessageConverter()))
+                .baseUrl("https://api.github.com/")
+                .build();
+    }
+
+    public GithubUserResponse getUser(final GithubUserRequest request) {
+
+        return client.get()
+                .uri("/user")
+                .accept()
+                .headers(httpHeaders -> httpHeaders.addAll(request.getHeaders()))
+                .retrieve()
+                .body(GithubUserResponse.class);
+    }
+}

--- a/backend/src/main/java/site/coduo/member/client/GithubOAuthClient.java
+++ b/backend/src/main/java/site/coduo/member/client/GithubOAuthClient.java
@@ -1,0 +1,65 @@
+package site.coduo.member.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import site.coduo.member.client.dto.TokenRequest;
+import site.coduo.member.client.dto.TokenResponse;
+import site.coduo.member.infrastructure.http.Basic;
+import site.coduo.member.infrastructure.http.Bearer;
+
+@Component
+public class GithubOAuthClient {
+
+    private static final int CONNECT_TIME_VALUE = 10000;
+    private static final int READ_TIME_OUT_VALUE = 20000;
+
+    private final RestClient client;
+
+    @Value("${oauth.github.client-id}")
+    private String oAuthClientId;
+
+    @Value("${oauth.github.client-secret}")
+    private String oAuthClientSecret;
+
+    @Value("${oauth.github.redirect-uri}")
+    private String oAuthRedirectUri;
+
+    public GithubOAuthClient() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(CONNECT_TIME_VALUE);
+        requestFactory.setReadTimeout(READ_TIME_OUT_VALUE);
+
+        this.client = RestClient.builder()
+                .requestFactory(requestFactory)
+                .messageConverters(converter -> converter.add(new FormHttpMessageConverter()))
+                .baseUrl("https://github.com/")
+                .build();
+    }
+
+    public TokenResponse grant(final TokenRequest request) {
+
+        String body = client.post()
+                .uri("/login/oauth/access_token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .header(HttpHeaders.AUTHORIZATION, new Basic(oAuthClientId, oAuthClientSecret).getValue())
+                .body(request.toQueryParams())
+                .retrieve()
+                .body(String.class);
+
+        return new TokenResponse(new Bearer(body), "scope", "tokenType");
+    }
+
+    public String getOAuthClientId() {
+        return oAuthClientId;
+    }
+
+    public String getOAuthRedirectUri() {
+        return oAuthRedirectUri;
+    }
+}

--- a/backend/src/main/java/site/coduo/member/client/dto/GithubUserRequest.java
+++ b/backend/src/main/java/site/coduo/member/client/dto/GithubUserRequest.java
@@ -1,0 +1,24 @@
+package site.coduo.member.client.dto;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import site.coduo.member.infrastructure.http.Bearer;
+
+public record GithubUserRequest(Bearer accessToken) {
+
+    public GithubUserRequest(final String token) {
+        this(new Bearer(token));
+    }
+
+    public MultiValueMap<String, String> getHeaders() {
+        final MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+        headers.add("X-GitHub-Api-Version", "2022-11-28");
+        headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+        headers.add(HttpHeaders.AUTHORIZATION, accessToken().getValue());
+
+        return headers;
+    }
+}

--- a/backend/src/main/java/site/coduo/member/client/dto/GithubUserResponse.java
+++ b/backend/src/main/java/site/coduo/member/client/dto/GithubUserResponse.java
@@ -1,0 +1,18 @@
+package site.coduo.member.client.dto;
+
+import site.coduo.member.domain.Member;
+import site.coduo.member.infrastructure.http.Bearer;
+
+public record GithubUserResponse(String userId, String longin, String avatarUrl) {
+
+    public Member toDomain(final Bearer accessToken, final String username) {
+        return Member.builder()
+                .profileImage(avatarUrl)
+                .userId(userId)
+                .loginId(longin)
+                .username(username)
+                .accessToken(accessToken.getCredential())
+                .build();
+    }
+
+}

--- a/backend/src/main/java/site/coduo/member/client/dto/TokenRequest.java
+++ b/backend/src/main/java/site/coduo/member/client/dto/TokenRequest.java
@@ -1,0 +1,14 @@
+package site.coduo.member.client.dto;
+
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+public record TokenRequest(String code, String redirectUri) {
+
+    public MultiValueMap<String, String> toQueryParams() {
+        LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", code);
+        params.add("redirect_uri", redirectUri);
+        return params;
+    }
+}

--- a/backend/src/main/java/site/coduo/member/client/dto/TokenResponse.java
+++ b/backend/src/main/java/site/coduo/member/client/dto/TokenResponse.java
@@ -1,0 +1,11 @@
+package site.coduo.member.client.dto;
+
+import site.coduo.member.infrastructure.http.Bearer;
+
+public record TokenResponse(Bearer accessToken, String scope, String tokenType) {
+
+    public String getCredential() {
+        return accessToken.getCredential();
+    }
+
+}

--- a/backend/src/main/java/site/coduo/member/controller/AuthController.java
+++ b/backend/src/main/java/site/coduo/member/controller/AuthController.java
@@ -1,0 +1,85 @@
+package site.coduo.member.controller;
+
+import static site.coduo.member.controller.GithubOAuthController.ACCESS_TOKEN_SESSION_NAME;
+
+import java.net.URI;
+import java.time.Duration;
+
+import jakarta.servlet.http.HttpSession;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
+
+import lombok.RequiredArgsConstructor;
+import site.coduo.member.controller.docs.AuthControllerDocs;
+import site.coduo.member.controller.dto.member.SignInWebResponse;
+import site.coduo.member.controller.dto.member.SignUpRequest;
+import site.coduo.member.service.AuthService;
+import site.coduo.member.service.MemberService;
+import site.coduo.member.service.dto.SignInServiceResponse;
+
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@CrossOrigin(value = {"https://coduo.site", "http://localhost:3000" })
+@RestController
+public class AuthController implements AuthControllerDocs {
+
+    private static final String SIGN_IN_COOKIE_NAME = "coduo_whoami";
+    private static final String SERVICE_DOMAIN_NAME = "coduo.site";
+
+    private final AuthService authService;
+    private final MemberService memberService;
+
+    @GetMapping("/sign-out")
+    public ResponseEntity<Void> signOut() {
+        final ResponseCookie expireCookie = ResponseCookie.from(SIGN_IN_COOKIE_NAME)
+                .maxAge(Duration.ZERO)
+                .domain(SERVICE_DOMAIN_NAME)
+                .path("/")
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, expireCookie.toString())
+                .build();
+    }
+
+    @PostMapping("/sign-up")
+    public ResponseEntity<Void> signUp(@RequestBody final SignUpRequest request,
+                                       @SessionAttribute(value = ACCESS_TOKEN_SESSION_NAME) final String accessToken) {
+        memberService.createMember(request.username(), accessToken);
+
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .location(URI.create("/api/sign-in/callback"))
+                .build();
+    }
+
+    @GetMapping("/sign-in/callback")
+    public ResponseEntity<SignInWebResponse> signInCallback(
+            @SessionAttribute(name = ACCESS_TOKEN_SESSION_NAME) final String accessToken,
+            final HttpSession session) {
+        final SignInServiceResponse serviceResponse = authService.createSignInToken(accessToken);
+
+        session.invalidate();
+
+        final ResponseCookie cookie = ResponseCookie.from(SIGN_IN_COOKIE_NAME)
+                .value(serviceResponse.token())
+                .httpOnly(true)
+                .secure(true)
+                .domain(SERVICE_DOMAIN_NAME)
+                .path("/")
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(SignInWebResponse.of(serviceResponse));
+    }
+}

--- a/backend/src/main/java/site/coduo/member/controller/GithubOAuthController.java
+++ b/backend/src/main/java/site/coduo/member/controller/GithubOAuthController.java
@@ -1,0 +1,71 @@
+package site.coduo.member.controller;
+
+import java.net.URI;
+
+import jakarta.servlet.http.HttpSession;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import site.coduo.member.client.dto.TokenResponse;
+import site.coduo.member.controller.docs.GithubOAuthControllerDocs;
+import site.coduo.member.controller.dto.oauth.GithubAuthQuery;
+import site.coduo.member.controller.dto.oauth.GithubAuthUri;
+import site.coduo.member.controller.dto.oauth.GithubCallbackQuery;
+import site.coduo.member.controller.dto.oauth.State;
+import site.coduo.member.service.GithubOAuthService;
+
+@Slf4j
+@RequiredArgsConstructor
+@CrossOrigin(value = {"https://coduo.site", "http://localhost:3000" })
+@RequestMapping("/api")
+@RestController
+public class GithubOAuthController implements GithubOAuthControllerDocs {
+
+    public static final String ACCESS_TOKEN_SESSION_NAME = "access token";
+
+    private static final String STATE_SESSION_NAME = "state";
+    private static final int STATE_SESSION_EXPIRE_IN = 30;
+    private static final int ACCESS_TOKEN_EXPIRE_IN = 300;
+
+    private final GithubOAuthService githubOAuthService;
+
+    @GetMapping("/sign-in/oauth/github")
+    public ResponseEntity<Void> getGithubAuthCode(final HttpSession session) {
+        final GithubAuthQuery query = githubOAuthService.createAuthorizationContent();
+        final GithubAuthUri githubAuthUri = new GithubAuthUri(query);
+
+        session.setAttribute(STATE_SESSION_NAME, query.state());
+        session.setMaxInactiveInterval(STATE_SESSION_EXPIRE_IN);
+
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .location(githubAuthUri.toUri())
+                .build();
+    }
+
+    @GetMapping("/github/callback")
+    public ResponseEntity<Void> getAccessToken(@ModelAttribute final GithubCallbackQuery query,
+                                               @SessionAttribute(name = STATE_SESSION_NAME) final String state,
+                                               final HttpSession session) {
+
+        State savedState = new State(state);
+        savedState.validate(new State(query.state()));
+        final TokenResponse tokenResponse = githubOAuthService.invokeOAuthCallback(query.code());
+
+        session.removeAttribute(STATE_SESSION_NAME);
+        session.setAttribute(ACCESS_TOKEN_SESSION_NAME, tokenResponse.getCredential());
+        session.setMaxInactiveInterval(ACCESS_TOKEN_EXPIRE_IN);
+
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .location(URI.create("/api/sign-in/callback"))
+                .build();
+    }
+}

--- a/backend/src/main/java/site/coduo/member/controller/MemberErrorController.java
+++ b/backend/src/main/java/site/coduo/member/controller/MemberErrorController.java
@@ -1,0 +1,41 @@
+package site.coduo.member.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.ServletRequestBindingException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+import site.coduo.common.controller.response.ApiErrorResponse;
+import site.coduo.member.controller.error.MemberApiError;
+import site.coduo.member.exception.AuthenticationException;
+import site.coduo.member.exception.AuthorizationException;
+
+@Slf4j
+@RestControllerAdvice
+public class MemberErrorController {
+    @ExceptionHandler(ServletRequestBindingException.class)
+    public ResponseEntity<ApiErrorResponse> handleServletRequestBindingException(
+            final ServletRequestBindingException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(MemberApiError.AUTHENTICATION_ERROR.getHttpStatus())
+                .body(new ApiErrorResponse(MemberApiError.AUTHENTICATION_ERROR.getMessage()));
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ApiErrorResponse> handleAuthenticationException(final AuthenticationException e) {
+        log.warn("인증 예외: {}", e.getMessage());
+
+        return ResponseEntity.status(MemberApiError.AUTHENTICATION_ERROR.getHttpStatus())
+                .body(new ApiErrorResponse(MemberApiError.AUTHENTICATION_ERROR.getMessage()));
+    }
+
+    @ExceptionHandler(AuthorizationException.class)
+    public ResponseEntity<ApiErrorResponse> handleAuthorizationException(final AuthorizationException e) {
+        log.warn("인가 예외: {}", e.getMessage());
+
+        return ResponseEntity.status(MemberApiError.AUTHORIZATION_ERROR.getHttpStatus())
+                .body(new ApiErrorResponse(MemberApiError.AUTHORIZATION_ERROR.getMessage()));
+    }
+}

--- a/backend/src/main/java/site/coduo/member/controller/docs/AuthControllerDocs.java
+++ b/backend/src/main/java/site/coduo/member/controller/docs/AuthControllerDocs.java
@@ -1,0 +1,41 @@
+package site.coduo.member.controller.docs;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import site.coduo.common.controller.response.ApiErrorResponse;
+import site.coduo.member.controller.dto.member.SignInWebResponse;
+import site.coduo.member.controller.dto.member.SignUpRequest;
+
+@Tag(name = "인증/인가 API")
+public interface AuthControllerDocs {
+
+    @Operation(summary = "로그아웃을 요청한다.")
+    @ApiResponse(responseCode = "200", description = "로그인 쿠키 삭제")
+    @ApiResponse(responseCode = "403", description = "인가 실패",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ApiErrorResponse.class)))
+    ResponseEntity<Void> signOut();
+
+    @Operation(summary = "회원가입 요청한다.",
+            requestBody = @RequestBody(
+                    required = true,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SignInWebResponse.class)
+                    )
+            )
+    )
+    @ApiResponse(responseCode = "302", description = "회원 정보(유저이름)을 등록한다.", content
+            = @Content(schema = @Schema(contentMediaType = MediaType.APPLICATION_JSON_VALUE)))
+    @ApiResponse(responseCode = "401", description = "인증 실패",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ApiErrorResponse.class)))
+    ResponseEntity<Void> signUp(SignUpRequest request, String accessToken);
+}

--- a/backend/src/main/java/site/coduo/member/controller/docs/GithubOAuthControllerDocs.java
+++ b/backend/src/main/java/site/coduo/member/controller/docs/GithubOAuthControllerDocs.java
@@ -1,0 +1,23 @@
+package site.coduo.member.controller.docs;
+
+import jakarta.servlet.http.HttpSession;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import site.coduo.common.controller.response.ApiErrorResponse;
+
+@Tag(name = "인증/인가 API")
+public interface GithubOAuthControllerDocs {
+
+    @ApiResponse(responseCode = "302", description = "회원 정보(유저이름)을 등록한다.", content
+            = @Content(schema = @Schema(contentMediaType = MediaType.APPLICATION_JSON_VALUE)))
+    @ApiResponse(responseCode = "401", description = "인증 실패",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ApiErrorResponse.class)))
+    ResponseEntity<Void> getGithubAuthCode(HttpSession session);
+}

--- a/backend/src/main/java/site/coduo/member/controller/dto/member/SignInWebResponse.java
+++ b/backend/src/main/java/site/coduo/member/controller/dto/member/SignInWebResponse.java
@@ -1,0 +1,12 @@
+package site.coduo.member.controller.dto.member;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import site.coduo.member.service.dto.SignInServiceResponse;
+
+@Schema(description = "회원가입 요청")
+public record SignInWebResponse(@Schema(description = "회원 등록 여부", example = "true") boolean signedUp) {
+
+    public static SignInWebResponse of(final SignInServiceResponse response) {
+        return new SignInWebResponse(response.signedIn());
+    }
+}

--- a/backend/src/main/java/site/coduo/member/controller/dto/member/SignUpRequest.java
+++ b/backend/src/main/java/site/coduo/member/controller/dto/member/SignUpRequest.java
@@ -1,0 +1,4 @@
+package site.coduo.member.controller.dto.member;
+
+public record SignUpRequest(String username) {
+}

--- a/backend/src/main/java/site/coduo/member/controller/dto/oauth/GithubAuthQuery.java
+++ b/backend/src/main/java/site/coduo/member/controller/dto/oauth/GithubAuthQuery.java
@@ -1,0 +1,17 @@
+package site.coduo.member.controller.dto.oauth;
+
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+
+public record GithubAuthQuery(String clientId, String redirectUri, String state) {
+
+    public MultiValueMap<String, String> toQueryParams() {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("client_id", clientId);
+        params.add("state", state);
+        params.add("redirect_uri", redirectUri);
+
+        return params;
+    }
+}

--- a/backend/src/main/java/site/coduo/member/controller/dto/oauth/GithubAuthUri.java
+++ b/backend/src/main/java/site/coduo/member/controller/dto/oauth/GithubAuthUri.java
@@ -1,0 +1,16 @@
+package site.coduo.member.controller.dto.oauth;
+
+import java.net.URI;
+
+import org.springframework.web.util.UriComponentsBuilder;
+
+public record GithubAuthUri(GithubAuthQuery query) {
+    private static final String GITHUB_AUTH_END_POINT = "https://www.github.com/login/oauth/authorize";
+
+    public URI toUri() {
+        return UriComponentsBuilder.fromHttpUrl(GITHUB_AUTH_END_POINT)
+                .queryParams(query.toQueryParams())
+                .build()
+                .toUri();
+    }
+}

--- a/backend/src/main/java/site/coduo/member/controller/dto/oauth/GithubCallbackQuery.java
+++ b/backend/src/main/java/site/coduo/member/controller/dto/oauth/GithubCallbackQuery.java
@@ -1,0 +1,4 @@
+package site.coduo.member.controller.dto.oauth;
+
+public record GithubCallbackQuery(String code, String state) {
+}

--- a/backend/src/main/java/site/coduo/member/controller/dto/oauth/State.java
+++ b/backend/src/main/java/site/coduo/member/controller/dto/oauth/State.java
@@ -1,0 +1,12 @@
+package site.coduo.member.controller.dto.oauth;
+
+import site.coduo.member.exception.AuthenticationException;
+
+public record State(String value) {
+
+    public void validate(State other) {
+        if (!(value.equals(other.value))) {
+            throw new AuthenticationException("state값 불일치!");
+        }
+    }
+}

--- a/backend/src/main/java/site/coduo/member/controller/error/MemberApiError.java
+++ b/backend/src/main/java/site/coduo/member/controller/error/MemberApiError.java
@@ -1,0 +1,16 @@
+package site.coduo.member.controller.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberApiError {
+    AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, "인증되지 않은 접근입니다."),
+    AUTHORIZATION_ERROR(HttpStatus.FORBIDDEN, "권한 밖 접근입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/backend/src/main/java/site/coduo/member/domain/Member.java
+++ b/backend/src/main/java/site/coduo/member/domain/Member.java
@@ -1,0 +1,79 @@
+package site.coduo.member.domain;
+
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.coduo.common.infrastructure.audit.entity.BaseTimeEntity;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "MEMBER")
+@Entity
+public class Member extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ID", nullable = false)
+    private Long id;
+
+    @Column(name = "ACCESS_TOKEN", nullable = false)
+    private String accessToken;
+
+    @Column(name = "PROVIDER_LOGIN_ID", nullable = false)
+    private String loginId;
+
+    @Column(name = "PROVIDER_USER_ID", nullable = false)
+    private String userId;
+
+    @Column(name = "PROFILE_IMAGE")
+    private String profileImage;
+
+    @Column(name = "USER_NAME")
+    private String username;
+
+    @Builder
+    private Member(final String accessToken, final String loginId, final String userId, final String profileImage,
+                   final String username) {
+        this.accessToken = accessToken;
+        this.loginId = loginId;
+        this.userId = userId;
+        this.profileImage = profileImage;
+        this.username = username;
+    }
+
+    public void update(final Member other) {
+        this.accessToken = other.accessToken;
+        this.loginId = other.loginId;
+        this.userId = other.userId;
+        this.profileImage = other.profileImage;
+        this.username = other.username;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final Member member = (Member) o;
+        return Objects.equals(id, member.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}
+

--- a/backend/src/main/java/site/coduo/member/domain/MemberUpdate.java
+++ b/backend/src/main/java/site/coduo/member/domain/MemberUpdate.java
@@ -1,0 +1,21 @@
+package site.coduo.member.domain;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class MemberUpdate {
+
+    private final Member member;
+
+    public void update(final String accessToken) {
+        final Member change = Member.builder()
+                .profileImage(member.getProfileImage())
+                .loginId(member.getLoginId())
+                .username(member.getUsername())
+                .userId(member.getUserId())
+                .accessToken(accessToken)
+                .build();
+
+        member.update(change);
+    }
+}

--- a/backend/src/main/java/site/coduo/member/domain/repository/MemberRepository.java
+++ b/backend/src/main/java/site/coduo/member/domain/repository/MemberRepository.java
@@ -1,0 +1,15 @@
+package site.coduo.member.domain.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import site.coduo.member.domain.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByUserId(String userId);
+
+    boolean existsByUserId(String userId);
+
+}

--- a/backend/src/main/java/site/coduo/member/exception/AuthenticationException.java
+++ b/backend/src/main/java/site/coduo/member/exception/AuthenticationException.java
@@ -1,0 +1,8 @@
+package site.coduo.member.exception;
+
+public class AuthenticationException extends MemberException {
+
+    public AuthenticationException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/site/coduo/member/exception/AuthorizationException.java
+++ b/backend/src/main/java/site/coduo/member/exception/AuthorizationException.java
@@ -1,0 +1,8 @@
+package site.coduo.member.exception;
+
+public class AuthorizationException extends MemberException {
+
+    public AuthorizationException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/site/coduo/member/exception/MemberException.java
+++ b/backend/src/main/java/site/coduo/member/exception/MemberException.java
@@ -1,0 +1,10 @@
+package site.coduo.member.exception;
+
+import site.coduo.common.exception.CoduoException;
+
+public class MemberException extends CoduoException {
+
+    public MemberException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/site/coduo/member/exception/MemberNotFoundException.java
+++ b/backend/src/main/java/site/coduo/member/exception/MemberNotFoundException.java
@@ -1,0 +1,8 @@
+package site.coduo.member.exception;
+
+public class MemberNotFoundException extends MemberException {
+
+    public MemberNotFoundException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/site/coduo/member/infrastructure/http/Basic.java
+++ b/backend/src/main/java/site/coduo/member/infrastructure/http/Basic.java
@@ -1,0 +1,19 @@
+package site.coduo.member.infrastructure.http;
+
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.http.HttpHeaders;
+
+import lombok.Getter;
+
+@Getter
+public class Basic {
+
+    private static final String SCHEME = "BASIC";
+    private final String value;
+
+    public Basic(final String identifier, final String password) {
+        final String credentials = HttpHeaders.encodeBasicAuth(identifier, password, StandardCharsets.UTF_8);
+        this.value = SCHEME + " " + credentials;
+    }
+}

--- a/backend/src/main/java/site/coduo/member/infrastructure/http/Bearer.java
+++ b/backend/src/main/java/site/coduo/member/infrastructure/http/Bearer.java
@@ -1,0 +1,19 @@
+package site.coduo.member.infrastructure.http;
+
+import lombok.Getter;
+
+@Getter
+public class Bearer {
+
+    public static final String SCHEME = "BEARER";
+
+    private final String value;
+
+    public Bearer(final String credential) {
+        this.value = SCHEME + " " + credential;
+    }
+
+    public String getCredential() {
+        return value.split(" ")[1];
+    }
+}

--- a/backend/src/main/java/site/coduo/member/infrastructure/security/JwtProvider.java
+++ b/backend/src/main/java/site/coduo/member/infrastructure/security/JwtProvider.java
@@ -1,0 +1,40 @@
+package site.coduo.member.infrastructure.security;
+
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtProvider {
+
+    @Value("${jwt.sign-key}")
+    private String key;
+
+    public String sign(final String sub) {
+        return Jwts.builder()
+                .issuedAt(new Date())
+                .subject(sub)
+                .signWith(Keys.hmacShaKeyFor(key.getBytes()))
+                .compact();
+    }
+
+    public void verify(final String token) {
+        Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(key.getBytes()))
+                .build()
+                .parse(token);
+    }
+
+    public String extractSubject(final String token) {
+        return Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(key.getBytes()))
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+}

--- a/backend/src/main/java/site/coduo/member/infrastructure/security/NanceProvider.java
+++ b/backend/src/main/java/site/coduo/member/infrastructure/security/NanceProvider.java
@@ -1,0 +1,6 @@
+package site.coduo.member.infrastructure.security;
+
+public interface NanceProvider {
+
+    String generate();
+}

--- a/backend/src/main/java/site/coduo/member/infrastructure/security/UUIDNanceProvider.java
+++ b/backend/src/main/java/site/coduo/member/infrastructure/security/UUIDNanceProvider.java
@@ -1,0 +1,14 @@
+package site.coduo.member.infrastructure.security;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class UUIDNanceProvider implements NanceProvider {
+
+    @Override
+    public String generate() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/backend/src/main/java/site/coduo/member/service/AuthService.java
+++ b/backend/src/main/java/site/coduo/member/service/AuthService.java
@@ -1,0 +1,35 @@
+package site.coduo.member.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import site.coduo.member.client.GithubApiClient;
+import site.coduo.member.client.dto.GithubUserRequest;
+import site.coduo.member.client.dto.GithubUserResponse;
+import site.coduo.member.domain.MemberUpdate;
+import site.coduo.member.domain.repository.MemberRepository;
+import site.coduo.member.infrastructure.security.JwtProvider;
+import site.coduo.member.service.dto.SignInServiceResponse;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final GithubApiClient githubApiClient;
+    private final JwtProvider jwtProvider;
+
+    @Transactional
+    public SignInServiceResponse createSignInToken(final String accessToken) {
+        final GithubUserResponse userResponse = githubApiClient.getUser(new GithubUserRequest(accessToken));
+
+        memberRepository.findByUserId(userResponse.userId())
+                .ifPresent(member -> new MemberUpdate(member).update(accessToken));
+
+        final String signInToken = jwtProvider.sign(userResponse.userId());
+
+        return new SignInServiceResponse(memberRepository.existsByUserId(userResponse.userId()), signInToken);
+    }
+}

--- a/backend/src/main/java/site/coduo/member/service/GithubOAuthService.java
+++ b/backend/src/main/java/site/coduo/member/service/GithubOAuthService.java
@@ -1,0 +1,34 @@
+package site.coduo.member.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import site.coduo.member.client.GithubOAuthClient;
+import site.coduo.member.client.dto.TokenRequest;
+import site.coduo.member.client.dto.TokenResponse;
+import site.coduo.member.controller.dto.oauth.GithubAuthQuery;
+import site.coduo.member.infrastructure.security.NanceProvider;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class GithubOAuthService {
+
+    private final GithubOAuthClient oAuthClient;
+    private final NanceProvider nanceProvider;
+
+    public GithubAuthQuery createAuthorizationContent() {
+
+        return new GithubAuthQuery(
+                oAuthClient.getOAuthClientId(),
+                oAuthClient.getOAuthRedirectUri(),
+                nanceProvider.generate()
+        );
+    }
+
+    public TokenResponse invokeOAuthCallback(final String code) {
+        String redirectUri = oAuthClient.getOAuthRedirectUri();
+        return oAuthClient.grant(new TokenRequest(code, redirectUri));
+    }
+}

--- a/backend/src/main/java/site/coduo/member/service/MemberService.java
+++ b/backend/src/main/java/site/coduo/member/service/MemberService.java
@@ -1,0 +1,29 @@
+package site.coduo.member.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import site.coduo.member.client.GithubApiClient;
+import site.coduo.member.client.dto.GithubUserRequest;
+import site.coduo.member.client.dto.GithubUserResponse;
+import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberRepository;
+import site.coduo.member.infrastructure.http.Bearer;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final GithubApiClient githubClient;
+
+    @Transactional
+    public void createMember(final String username, final String accessToken) {
+        final Bearer bearer = new Bearer(accessToken);
+        GithubUserResponse userResponse = githubClient.getUser(new GithubUserRequest(bearer));
+        Member member = userResponse.toDomain(bearer, username);
+        memberRepository.save(member);
+    }
+}

--- a/backend/src/main/java/site/coduo/member/service/dto/SignInServiceResponse.java
+++ b/backend/src/main/java/site/coduo/member/service/dto/SignInServiceResponse.java
@@ -1,0 +1,10 @@
+package site.coduo.member.service.dto;
+
+public record SignInServiceResponse(boolean signedIn, String token) {
+
+    public SignInServiceResponse(final boolean signedIn, final String token) {
+        this.signedIn = signedIn;
+        this.token = signedIn ? token : "";
+    }
+}
+

--- a/backend/src/main/java/site/coduo/pairroom/controller/docs/PairRoomDocs.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/docs/PairRoomDocs.java
@@ -1,38 +1,19 @@
 package site.coduo.pairroom.controller.docs;
 
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import site.coduo.common.controller.response.ApiErrorResponse;
 import site.coduo.pairroom.dto.PairRoomCreateRequest;
 import site.coduo.pairroom.dto.PairRoomCreateResponse;
 import site.coduo.pairroom.dto.PairRoomDeleteRequest;
-import site.coduo.pairroom.dto.PairRoomReadRequest;
-import site.coduo.pairroom.dto.PairRoomReadResponse;
 
 @Tag(name = "페어룸 API")
 public interface PairRoomDocs {
 
-    @Operation(summary = "페어룸을 조회한다.")
-    @ApiResponse(responseCode = "200", description = "페어룸 조회 성공",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = @Schema(implementation = PairRoomReadResponse.class)))
-    @ApiResponse(responseCode = "404", description = "페어룸 조회 실패 - 페어룸 접근 코드가 존재하지 않음",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = @Schema(implementation = ApiErrorResponse.class)))
-    ResponseEntity<PairRoomReadResponse> getPairRoom(
-            @Parameter(description = "페어룸 접근 코드", required = true) PairRoomReadRequest accessCode);
 
-    @Operation(summary = "페어룸을 생성한다.")
-    @ApiResponse(responseCode = "201", description = "페어룸 생성 성공",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = @Schema(implementation = PairRoomCreateResponse.class)))
     ResponseEntity<PairRoomCreateResponse> createPairRoom(
             @Parameter(description = "페어 프로그래밍에 참여하는 페어 A의 이름, 페어 B의 이름", required = true)
             PairRoomCreateRequest pairRoomCreateRequest);

--- a/backend/src/test/java/site/coduo/acceptance/AcceptanceFixture.java
+++ b/backend/src/test/java/site/coduo/acceptance/AcceptanceFixture.java
@@ -1,34 +1,34 @@
 package site.coduo.acceptance;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 
 import io.restassured.RestAssured;
+import site.coduo.config.TestConfig;
+import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.referencelink.repository.OpenGraphRepository;
 import site.coduo.referencelink.repository.ReferenceLinkRepository;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Import(TestConfig.class)
 abstract class AcceptanceFixture {
 
     @Autowired
-    private ReferenceLinkRepository referenceLinkRepository;
+    protected MemberRepository memberRepository;
 
+    @Autowired
+    private ReferenceLinkRepository referenceLinkRepository;
     @Autowired
     private PairRoomRepository pairRoomRepository;
 
     @Autowired
     private OpenGraphRepository openGraphRepository;
-
-    @PersistenceContext
-    private EntityManager entityManager;
 
     @LocalServerPort
     private int port;
@@ -40,6 +40,7 @@ abstract class AcceptanceFixture {
 
     @AfterEach
     void tearDown() {
+        memberRepository.deleteAll();
         openGraphRepository.deleteAll();
         referenceLinkRepository.deleteAll();
         pairRoomRepository.deleteAll();

--- a/backend/src/test/java/site/coduo/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/AuthAcceptanceTest.java
@@ -1,0 +1,130 @@
+package site.coduo.acceptance;
+
+import static org.hamcrest.Matchers.is;
+
+import java.util.Map;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import site.coduo.fake.FakeGithubApiClient;
+import site.coduo.fake.FakeGithubOAuthClient;
+import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberRepository;
+
+class AuthAcceptanceTest extends AcceptanceFixture {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("로그인 검증 & 로그인 토큰을 발급한다.")
+    void verify_login_and_publish_login_token() {
+        final String sessionId = GithubAcceptanceTest.createAccessTokenThenReturnSessionId();
+        final Member member = createMember();
+
+        memberRepository.save(member);
+
+        // when
+        RestAssured
+                .given()
+                .cookie("JSESSIONID", sessionId)
+
+                .when()
+                .get("/api/sign-in/callback")
+
+                .then().log().all()
+                .statusCode(HttpStatus.SC_OK)
+                .cookie("coduo_whoami")
+                .body("signedUp", is(true));
+    }
+
+    @Test
+    @DisplayName("로그인 검증 & 로그인 토큰을 발급한다. - 로그인 실패 케이스")
+    void verify_login_and_publish_login_token_dose_not_exists_case() {
+        final String sessionId = GithubAcceptanceTest.createAccessTokenThenReturnSessionId();
+
+        // when
+        RestAssured
+                .given()
+                .cookie("JSESSIONID", sessionId)
+
+                .when()
+                .get("/api/sign-in/callback")
+
+                .then().log().all()
+                .statusCode(HttpStatus.SC_OK)
+                .cookie("coduo_whoami")
+                .body("signedUp", is(false));
+    }
+
+    @Test
+    @DisplayName("로그아웃 요청을 하면 JWT 쿠키가 삭제된다.")
+    void remove_jwt_cookie_when_accept_logout_request() {
+        // given
+        final String loginToken = login();
+
+        // when & then
+        RestAssured
+                .given()
+                .cookie("coduo_whoami", loginToken)
+
+                .when()
+                .get("/api/sign-out")
+
+                .then().log().all()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    String login() {
+        final String sessionId = GithubAcceptanceTest.createAccessTokenThenReturnSessionId();
+        final Member member = createMember();
+
+        memberRepository.save(member);
+
+        return RestAssured
+                .given()
+                .cookie("JSESSIONID", sessionId)
+
+                .when()
+                .get("/api/sign-in/callback")
+
+                .thenReturn()
+                .cookie("coudo_whoami");
+    }
+
+    private Member createMember() {
+        return Member.builder()
+                .username("test user")
+                .userId(FakeGithubApiClient.USER_ID)
+                .loginId(FakeGithubApiClient.LOGIN_ID)
+                .accessToken(FakeGithubOAuthClient.ACCESS_TOKEN.getCredential())
+                .profileImage(FakeGithubApiClient.PROFILE_IMAGE)
+                .build();
+    }
+
+    @Test
+    @DisplayName("인가 정보를 통해 회원가입을 한다.")
+    void sign_up_via_authorization_info() {
+        // given
+        final String sessionId = GithubAcceptanceTest.createAccessTokenThenReturnSessionId();
+        final Map<String, String> body = Map.of("username", "닉네임");
+
+        // when & then
+        RestAssured
+                .given().log().all()
+                .contentType(ContentType.JSON)
+                .body(body)
+                .cookie("JSESSIONID", sessionId)
+
+                .when()
+                .post("/api/sign-up")
+
+                .then().log().all()
+                .statusCode(HttpStatus.SC_MOVED_TEMPORARILY);
+    }
+}

--- a/backend/src/test/java/site/coduo/acceptance/GithubAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/GithubAcceptanceTest.java
@@ -1,0 +1,146 @@
+package site.coduo.acceptance;
+
+import static org.hamcrest.Matchers.containsString;
+
+import java.util.Map;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+import io.restassured.RestAssured;
+import site.coduo.fake.FakeGithubApiClient;
+import site.coduo.fake.FakeGithubOAuthClient;
+import site.coduo.fake.FixedNanceProvider;
+import site.coduo.member.domain.Member;
+
+class GithubAcceptanceTest extends AcceptanceFixture {
+
+    static String createAccessTokenThenReturnSessionId() {
+        final String session = callAuthorizeThenReturnSessionId();
+
+        final Map<String, String> query = Map.of("code", "authorization code",
+                "state", FixedNanceProvider.FIXED_VALUE);
+
+        RestAssured
+                .given()
+                .queryParams(query)
+                .sessionId("JSESSIONID", session)
+                .redirects()
+                .follow(false)
+                .log().all()
+
+                .when()
+                .get("/api/github/callback")
+
+                .then()
+                .statusCode(HttpStatus.SC_MOVED_TEMPORARILY);
+
+        return session;
+    }
+
+    static String callAuthorizeThenReturnSessionId() {
+        return RestAssured
+                .given()
+                .redirects()
+                .follow(false)
+
+                .when()
+                .get("/api/sign-in/oauth/github")
+
+                .thenReturn()
+                .getSessionId();
+    }
+
+    @Test
+    @DisplayName("깃허브로 인가 요청을 보낸다.")
+    void request_to_github_authorization_end_point() {
+        RestAssured
+                .given()
+                .redirects()
+                .follow(false)
+
+                .when()
+                .get("/api/sign-in/oauth/github")
+
+                .then().log().all()
+                .assertThat()
+                .statusCode(org.springframework.http.HttpStatus.FOUND.value())
+                .header(HttpHeaders.LOCATION,
+                        "https://www.github.com/login/oauth/authorize?client_id=test&state=random%20number&redirect_uri=http://test.test");
+    }
+
+    @Test
+    @DisplayName("github authorize 엔드포인트 호출")
+    void call_github_authorize_endpoint() {
+        RestAssured
+                .given()
+                .redirects()
+                .follow(false)
+
+                .when()
+                .get("/api/sign-in/oauth/github")
+
+                .then().log().all()
+                .statusCode(HttpStatus.SC_MOVED_TEMPORARILY)
+                .header(HttpHeaders.SET_COOKIE, containsString("JSESSIONID"));
+    }
+
+    @Test
+    @DisplayName("callback 엔드포인트 호출")
+    void call_callback_end_point() {
+        // given
+        final String session = callAuthorizeThenReturnSessionId();
+
+        final Map<String, String> query = Map.of("code", "authorization code",
+                "state", FixedNanceProvider.FIXED_VALUE);
+
+        // when & then
+        RestAssured
+                .given()
+                .queryParams(query)
+                .sessionId("JSESSIONID", session)
+                .redirects()
+                .follow(false)
+                .log().all()
+
+                .when()
+                .get("/api/github/callback")
+
+                .then()
+                .statusCode(HttpStatus.SC_MOVED_TEMPORARILY);
+    }
+
+    @Test
+    @DisplayName("callback 엔드 포인트가 호출되면 리디렉션을 통해 로그인이 시도된다.")
+    void try_login_when_call_callback_end_point() {
+        // given
+        final Member member = Member.builder()
+                .username("test user")
+                .userId(FakeGithubApiClient.USER_ID)
+                .loginId(FakeGithubApiClient.LOGIN_ID)
+                .accessToken(FakeGithubOAuthClient.ACCESS_TOKEN.getCredential())
+                .profileImage(FakeGithubApiClient.PROFILE_IMAGE)
+                .build();
+        final String session = callAuthorizeThenReturnSessionId();
+        final Map<String, String> query = Map.of("code", "authorization code",
+                "state", FixedNanceProvider.FIXED_VALUE);
+
+        memberRepository.save(member);
+
+        // when & then
+        RestAssured
+                .given()
+                .queryParams(query)
+                .sessionId("JSESSIONID", session)
+                .log().all()
+
+                .when()
+                .get("/api/github/callback")
+
+                .then().log().all()
+                .statusCode(HttpStatus.SC_OK)
+                .cookie("coduo_whoami");
+    }
+}

--- a/backend/src/test/java/site/coduo/common/infrastructure/security/JwtProviderTest.java
+++ b/backend/src/test/java/site/coduo/common/infrastructure/security/JwtProviderTest.java
@@ -1,0 +1,49 @@
+package site.coduo.common.infrastructure.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import site.coduo.member.infrastructure.security.JwtProvider;
+
+class JwtProviderTest {
+
+    private final JwtProvider jwtProvider = new JwtProvider();
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(jwtProvider, "key", "test-key+test-key+test-key+test-key+test-key+test");
+    }
+
+    @Test
+    @DisplayName("sub으로 구성된 jwt 토큰을 생성한다.")
+    void produce_jwt_with_sub() {
+        // given
+        final String sub = "subject";
+
+        // when
+        final String jwtToken = jwtProvider.sign(sub);
+
+        // then
+        assertThatCode(() -> jwtProvider.verify(jwtToken))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("jwt 토큰에서 sub을 추출한다.")
+    void extract_sub_in_jwt() {
+        // given
+        final String sub = "subject";
+        final String token = jwtProvider.sign(sub);
+
+        // when
+        final String extract = jwtProvider.extractSubject(token);
+
+        // then
+        assertThat(extract).isEqualTo(sub);
+    }
+}

--- a/backend/src/test/java/site/coduo/config/TestConfig.java
+++ b/backend/src/test/java/site/coduo/config/TestConfig.java
@@ -1,0 +1,34 @@
+package site.coduo.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import site.coduo.fake.FakeGithubApiClient;
+import site.coduo.fake.FakeGithubOAuthClient;
+import site.coduo.fake.FixedNanceProvider;
+import site.coduo.member.client.GithubApiClient;
+import site.coduo.member.client.GithubOAuthClient;
+import site.coduo.member.infrastructure.security.NanceProvider;
+
+@TestConfiguration
+public class TestConfig {
+
+    @Bean
+    @Primary
+    public NanceProvider fakeNanceFactory() {
+        return new FixedNanceProvider();
+    }
+
+    @Bean
+    @Primary
+    public GithubOAuthClient fakeGithubOAuthClient() {
+        return new FakeGithubOAuthClient();
+    }
+
+    @Bean
+    @Primary
+    public GithubApiClient fakeGithubApiClient() {
+        return new FakeGithubApiClient();
+    }
+}

--- a/backend/src/test/java/site/coduo/fake/FakeGithubApiClient.java
+++ b/backend/src/test/java/site/coduo/fake/FakeGithubApiClient.java
@@ -1,0 +1,18 @@
+package site.coduo.fake;
+
+import site.coduo.member.client.GithubApiClient;
+import site.coduo.member.client.dto.GithubUserRequest;
+import site.coduo.member.client.dto.GithubUserResponse;
+
+public class FakeGithubApiClient extends GithubApiClient {
+
+    public static final String ACCESS_TOKEN = "access-token";
+    public static final String LOGIN_ID = "login-id";
+    public static final String USER_ID = "user-id";
+    public static final String PROFILE_IMAGE = "image";
+
+    @Override
+    public GithubUserResponse getUser(final GithubUserRequest request) {
+        return new GithubUserResponse(USER_ID, LOGIN_ID, PROFILE_IMAGE);
+    }
+}

--- a/backend/src/test/java/site/coduo/fake/FakeGithubOAuthClient.java
+++ b/backend/src/test/java/site/coduo/fake/FakeGithubOAuthClient.java
@@ -1,0 +1,28 @@
+package site.coduo.fake;
+
+import site.coduo.member.client.GithubOAuthClient;
+import site.coduo.member.client.dto.TokenRequest;
+import site.coduo.member.client.dto.TokenResponse;
+import site.coduo.member.infrastructure.http.Bearer;
+
+public class FakeGithubOAuthClient extends GithubOAuthClient {
+
+    public static final Bearer ACCESS_TOKEN = new Bearer("access-token");
+    public static final String OAUTH_CLIENT_ID = "test";
+    public static final String OAUTH_REDIRECT_URI = "http://test.test";
+
+    @Override
+    public TokenResponse grant(TokenRequest request) {
+        return new TokenResponse(ACCESS_TOKEN, "", Bearer.SCHEME);
+    }
+
+    @Override
+    public String getOAuthClientId() {
+        return OAUTH_CLIENT_ID;
+    }
+
+    @Override
+    public String getOAuthRedirectUri() {
+        return OAUTH_REDIRECT_URI;
+    }
+}

--- a/backend/src/test/java/site/coduo/fake/FixedNanceProvider.java
+++ b/backend/src/test/java/site/coduo/fake/FixedNanceProvider.java
@@ -1,0 +1,12 @@
+package site.coduo.fake;
+
+import site.coduo.member.infrastructure.security.NanceProvider;
+
+public class FixedNanceProvider implements NanceProvider {
+    public static final String FIXED_VALUE = "random number";
+
+    @Override
+    public String generate() {
+        return FIXED_VALUE;
+    }
+}

--- a/backend/src/test/java/site/coduo/fake/SequentialAccessCodeStrategy.java
+++ b/backend/src/test/java/site/coduo/fake/SequentialAccessCodeStrategy.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import site.coduo.pairroom.domain.accesscode.AccessCodeStrategy;
 
-public class FakeAccessCodeStrategy implements AccessCodeStrategy {
-    
+public class SequentialAccessCodeStrategy implements AccessCodeStrategy {
+
     private static final List<String> SEQUENCE = List.of("1", "2", "3", "4", "5");
 
     private static int INDEX = 0;

--- a/backend/src/test/java/site/coduo/member/domain/MemberTest.java
+++ b/backend/src/test/java/site/coduo/member/domain/MemberTest.java
@@ -1,0 +1,39 @@
+package site.coduo.member.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MemberTest {
+
+    @Test
+    @DisplayName("회원 정보를 수정한다.")
+    void update() {
+        // given
+        final Member origin = Member.builder()
+                .userId("origin")
+                .loginId("origin")
+                .username("origin")
+                .profileImage("origin")
+                .accessToken("origin")
+                .build();
+
+        final Member change = Member.builder()
+                .userId("change")
+                .loginId("change")
+                .username("change")
+                .accessToken("change")
+                .profileImage("change")
+                .build();
+
+        // when
+        origin.update(change);
+
+        // then
+        assertThat(origin)
+                .extracting("userId", "loginId", "username", "accessToken", "profileImage")
+                .contains(change.getUserId(), change.getLoginId(), change.getUsername(), change.getAccessToken(),
+                        change.getProfileImage());
+    }
+}

--- a/backend/src/test/java/site/coduo/member/domain/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/site/coduo/member/domain/repository/MemberRepositoryTest.java
@@ -1,0 +1,48 @@
+package site.coduo.member.domain.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import site.coduo.member.domain.Member;
+
+@SpringBootTest
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @AfterEach
+    void tearDown() {
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("회원을 제공자(idP)의 식별자로 조회한다.")
+    void find_member_by_provider_identifier() {
+        // given
+        final String identifier = "some id";
+
+        final Member member = Member.builder()
+                .loginId("loginId")
+                .userId(identifier)
+                .profileImage("some photo")
+                .accessToken("some accessCode")
+                .username("some username")
+                .build();
+        memberRepository.save(member);
+
+        // when
+        final Optional<Member> find = memberRepository.findByUserId(identifier);
+
+        // then
+        assertThat(find).hasValue(member);
+    }
+
+}

--- a/backend/src/test/java/site/coduo/member/service/AuthServiceTest.java
+++ b/backend/src/test/java/site/coduo/member/service/AuthServiceTest.java
@@ -1,0 +1,91 @@
+package site.coduo.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import site.coduo.config.TestConfig;
+import site.coduo.fake.FakeGithubApiClient;
+import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberRepository;
+import site.coduo.member.infrastructure.security.JwtProvider;
+import site.coduo.member.service.dto.SignInServiceResponse;
+
+@SpringBootTest
+@Import(TestConfig.class)
+class AuthServiceTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @AfterEach
+    void tearDown() {
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("엑세스 토큰으로 회원을 조회한다.")
+    void search_member_by_access_token() {
+        // given
+        final Member member = createMember("username", FakeGithubApiClient.ACCESS_TOKEN, FakeGithubApiClient.USER_ID);
+
+        // when
+        final SignInServiceResponse signInToken = authService.createSignInToken(member.getAccessToken());
+
+        // then
+        assertThatCode(() -> jwtProvider.verify(signInToken.token()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 엑세스 토큰으로 조회화면 빈 토큰을  생성한다.")
+    void throw_exception_when_search_by_does_not_exists_access_token() {
+        // given
+        final String token = "does not exist token";
+
+        // when
+        final SignInServiceResponse signInToken = authService.createSignInToken(token);
+
+        // then
+        assertThat(signInToken.token()).isEmpty();
+    }
+
+    private Member createMember(final String username, final String accessToken, final String userId) {
+        final Member member = Member.builder()
+                .username(username)
+                .accessToken(accessToken)
+                .loginId("")
+                .userId(userId)
+                .profileImage("")
+                .build();
+
+        return memberRepository.save(member);
+    }
+
+    @Test
+    @DisplayName("로그인 토큰을 생성할 때 회원이 엑세스 토큰을 갱신한다.")
+    void renewal_member_access_token_when_create_sign_in_token() {
+        // given
+        final Member member = createMember("username", "origin", FakeGithubApiClient.USER_ID);
+
+        // when
+        authService.createSignInToken("change");
+
+        // then
+        assertThat(memberRepository.findById(member.getId()).orElseThrow())
+                .extracting("accessToken")
+                .isEqualTo("change");
+    }
+}

--- a/backend/src/test/java/site/coduo/member/service/GithubOAuthServiceTest.java
+++ b/backend/src/test/java/site/coduo/member/service/GithubOAuthServiceTest.java
@@ -1,0 +1,53 @@
+package site.coduo.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import site.coduo.config.TestConfig;
+import site.coduo.fake.FakeGithubOAuthClient;
+import site.coduo.fake.FixedNanceProvider;
+import site.coduo.member.client.dto.TokenResponse;
+import site.coduo.member.controller.dto.oauth.GithubAuthQuery;
+
+@SpringBootTest
+@Import(TestConfig.class)
+class GithubOAuthServiceTest {
+
+    @Autowired
+    private GithubOAuthService githubOAuthService;
+
+    @Test
+    @DisplayName("인가 요청을 위한 정보를 생성한다.")
+    void create_info_for_authorization_request_to_third_party() {
+        // given
+        final GithubAuthQuery expect = new GithubAuthQuery(
+                FakeGithubOAuthClient.OAUTH_CLIENT_ID,
+                FakeGithubOAuthClient.OAUTH_REDIRECT_URI,
+                FixedNanceProvider.FIXED_VALUE
+        );
+
+        // when
+        final GithubAuthQuery response = githubOAuthService.createAuthorizationContent();
+
+        // then
+        assertThat(response).isEqualTo(expect);
+    }
+
+    @Test
+    @DisplayName("엑세스 토큰을 발급 받아온다.")
+    void get_access_token() {
+        // given
+        final String code = "code";
+
+        // when
+        final TokenResponse tokenResponse = githubOAuthService.invokeOAuthCallback(code);
+
+        // then
+        assertThat(tokenResponse.accessToken()).isEqualTo(FakeGithubOAuthClient.ACCESS_TOKEN);
+    }
+}

--- a/backend/src/test/java/site/coduo/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/site/coduo/member/service/MemberServiceTest.java
@@ -1,0 +1,43 @@
+package site.coduo.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import site.coduo.config.TestConfig;
+import site.coduo.member.domain.repository.MemberRepository;
+
+@SpringBootTest
+@Import(TestConfig.class)
+class MemberServiceTest {
+
+    @Autowired
+    private MemberService MemberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @AfterEach
+    void tearDown() {
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("회원을 저장한다.")
+    void save_member() {
+        // given
+        final String credential = "access-token";
+        final String username = "username";
+
+        // when
+        MemberService.createMember(username, credential);
+
+        // then
+        assertThat(memberRepository.findAll()).hasSize(1);
+    }
+}

--- a/backend/src/test/java/site/coduo/pairroom/domain/AccessCodeFactoryTest.java
+++ b/backend/src/test/java/site/coduo/pairroom/domain/AccessCodeFactoryTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import site.coduo.fake.FakeAccessCodeStrategy;
+import site.coduo.fake.SequentialAccessCodeStrategy;
 import site.coduo.pairroom.domain.accesscode.AccessCode;
 import site.coduo.pairroom.domain.accesscode.AccessCodeFactory;
 
@@ -17,7 +17,7 @@ class AccessCodeFactoryTest {
     @DisplayName("중복이 없는 엑세스 코드를 생성한다.")
     void generate_unique_access_code() {
         // given
-        final AccessCodeFactory sut = new AccessCodeFactory(new FakeAccessCodeStrategy());
+        final AccessCodeFactory sut = new AccessCodeFactory(new SequentialAccessCodeStrategy());
         final List<AccessCode> accessCodes = List.of(new AccessCode("FAKE_1"),
                 new AccessCode("FAKE_2"),
                 new AccessCode("FAKE_3"),


### PR DESCRIPTION
* feat: github oauth 인증 엔드 포인트 리다이렉트 API 기능 구현

* feat: Github oauth access token 발급 기능 구현

* feat: Github 측과 백채널 통신 기능 구현

* feat: 회원 생성/ 조회 기능 구현

* feat: 회원 생성/ 조회 기능 구현

* feat: jwt 토큰 제공 클래스 기능 구현

* refactor: dto 클래스이름 변경

* feat: oauth 로그인 api 엔드포인트 작성

* refactor: 패키지명 변경

* refactor: 누락된 final 키워드 추가

* feat: 인증/ 인가 예외 핸들링 기능 구현

* refactor: 서비스/컨트롤러 Dto 결합

* feat: baseTimeEntity 상속

* feat: cors localhost, coduo 도메인 접근 허용

* sync

## 연관된 이슈

- closes: (이슈 번호)

## 구현한 기능

## 상세 설명
