### PR TITLE
[BE] 타이머 시간 저장 api 추가

### DIFF
--- a/backend/src/main/java/site/coduo/pairroom/controller/PairRoomController.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/PairRoomController.java
@@ -21,6 +21,7 @@ import site.coduo.pairroom.dto.PairRoomCreateResponse;
 import site.coduo.pairroom.dto.PairRoomDeleteRequest;
 import site.coduo.pairroom.dto.PairRoomReadRequest;
 import site.coduo.pairroom.dto.PairRoomReadResponse;
+import site.coduo.pairroom.dto.TimerDurationCreateRequest;
 import site.coduo.pairroom.service.PairRoomService;
 
 @RequiredArgsConstructor
@@ -35,10 +36,21 @@ public class PairRoomController implements PairRoomDocs {
     public ResponseEntity<PairRoomCreateResponse> createPairRoom(
             @Valid @RequestBody final PairRoomCreateRequest request
     ) {
-        final PairRoomCreateResponse response = new PairRoomCreateResponse(service.save(request));
+        final PairRoomCreateResponse response = new PairRoomCreateResponse(service.savePairNameAndAccessCode(request));
 
         return ResponseEntity.created(URI.create("/"))
                 .body(response);
+    }
+
+    @PostMapping("/pair-room/{accessCode}/info")
+    public ResponseEntity<Void> createTimerDuration(
+            @PathVariable("accessCode") final String accessCode,
+            @RequestBody final TimerDurationCreateRequest request
+    ) {
+        service.saveTimerDuration(accessCode, request);
+
+        return ResponseEntity.created(URI.create("/"))
+                .build();
     }
 
     @GetMapping("/pair-room/{accessCode}")

--- a/backend/src/main/java/site/coduo/pairroom/controller/PairRoomController.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/PairRoomController.java
@@ -30,13 +30,13 @@ import site.coduo.pairroom.service.PairRoomService;
 @CrossOrigin(origins = {"http://localhost:3000", "http://3.35.178.58"})
 public class PairRoomController implements PairRoomDocs {
 
-    private final PairRoomService service;
+    private final PairRoomService pairRoomService;
 
     @PostMapping("/pair-room")
     public ResponseEntity<PairRoomCreateResponse> createPairRoom(
             @Valid @RequestBody final PairRoomCreateRequest request
     ) {
-        final PairRoomCreateResponse response = new PairRoomCreateResponse(service.savePairNameAndAccessCode(request));
+        final PairRoomCreateResponse response = new PairRoomCreateResponse(pairRoomService.savePairNameAndAccessCode(request));
 
         return ResponseEntity.created(URI.create("/"))
                 .body(response);
@@ -47,7 +47,7 @@ public class PairRoomController implements PairRoomDocs {
             @PathVariable("accessCode") final String accessCode,
             @RequestBody final TimerDurationCreateRequest request
     ) {
-        service.saveTimerDuration(accessCode, request);
+        pairRoomService.saveTimerDuration(accessCode, request);
 
         return ResponseEntity.created(URI.create("/"))
                 .build();
@@ -58,7 +58,7 @@ public class PairRoomController implements PairRoomDocs {
             @Valid @PathVariable("accessCode") final PairRoomReadRequest request
     ) {
         final PairRoomReadResponse response = PairRoomReadResponse.from(
-                service.findByAccessCode(request.accessCode()));
+                pairRoomService.findByAccessCode(request.accessCode()));
 
         return ResponseEntity.ok(response);
     }
@@ -67,7 +67,7 @@ public class PairRoomController implements PairRoomDocs {
     public ResponseEntity<Void> deletePairRoom(
             @Valid @PathVariable("accessCode") final PairRoomDeleteRequest request
     ) {
-        service.deletePairRoom(request.accessCode());
+        pairRoomService.deletePairRoom(request.accessCode());
 
         return ResponseEntity.noContent()
                 .build();

--- a/backend/src/main/java/site/coduo/pairroom/controller/docs/PairRoomDocs.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/docs/PairRoomDocs.java
@@ -11,14 +11,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import site.coduo.pairroom.dto.PairRoomCreateRequest;
 import site.coduo.pairroom.dto.PairRoomCreateResponse;
 import site.coduo.pairroom.dto.PairRoomDeleteRequest;
-import site.coduo.pairroom.dto.PairRoomReadRequest;
-import site.coduo.pairroom.dto.PairRoomReadResponse;
 import site.coduo.pairroom.dto.TimerDurationCreateRequest;
-
 
 @Tag(name = "페어룸 API")
 public interface PairRoomDocs {
-
 
     ResponseEntity<PairRoomCreateResponse> createPairRoom(
             @Parameter(description = "페어 프로그래밍에 참여하는 페어 A의 이름, 페어 B의 이름", required = true)

--- a/backend/src/main/java/site/coduo/pairroom/controller/docs/PairRoomDocs.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/docs/PairRoomDocs.java
@@ -2,6 +2,8 @@ package site.coduo.pairroom.controller.docs;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -15,6 +17,7 @@ import site.coduo.pairroom.dto.PairRoomCreateResponse;
 import site.coduo.pairroom.dto.PairRoomDeleteRequest;
 import site.coduo.pairroom.dto.PairRoomReadRequest;
 import site.coduo.pairroom.dto.PairRoomReadResponse;
+import site.coduo.pairroom.dto.TimerDurationCreateRequest;
 
 @Tag(name = "페어룸 API")
 public interface PairRoomDocs {
@@ -36,6 +39,16 @@ public interface PairRoomDocs {
     ResponseEntity<PairRoomCreateResponse> createPairRoom(
             @Parameter(description = "페어 프로그래밍에 참여하는 페어 A의 이름, 페어 B의 이름", required = true)
             PairRoomCreateRequest pairRoomCreateRequest);
+
+    @Operation(summary = "타이머 시간을 저장한다.")
+    @ApiResponse(responseCode = "201", description = "타이머 시간 저장 성공")
+    ResponseEntity<Void> createTimerDuration(
+            @Parameter(description = "페어룸 접근 코드", required = true)
+            @PathVariable("accessCode") final String accessCode,
+
+            @Parameter(description = "타이머 시간 저장 요청 바디", required = true)
+            @RequestBody final TimerDurationCreateRequest request
+    );
 
     @Operation(summary = "페어룸을 삭제한다.")
     @ApiResponse(responseCode = "204", description = "페어룸 삭제 성공")

--- a/backend/src/main/java/site/coduo/pairroom/domain/PairRoom.java
+++ b/backend/src/main/java/site/coduo/pairroom/domain/PairRoom.java
@@ -37,13 +37,6 @@ public class PairRoom extends BaseTimeEntity {
     @Column(name = "TIMER_DURATION", nullable = true)
     private LocalTime timerDuration;
 
-    public PairRoom(final Long id, final Pair pair, final AccessCode accessCode, final LocalTime timerDuration) {
-        this.id = id;
-        this.pair = pair;
-        this.accessCode = accessCode;
-        this.timerDuration = timerDuration;
-    }
-
     public PairRoom(final Pair pair, final AccessCode accessCode) {
         this.pair = pair;
         this.accessCode = accessCode;

--- a/backend/src/main/java/site/coduo/pairroom/domain/PairRoom.java
+++ b/backend/src/main/java/site/coduo/pairroom/domain/PairRoom.java
@@ -1,7 +1,5 @@
 package site.coduo.pairroom.domain;
 
-import java.time.LocalTime;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -35,7 +33,7 @@ public class PairRoom extends BaseTimeEntity {
     private AccessCode accessCode;
 
     @Column(name = "TIMER_DURATION", nullable = true)
-    private LocalTime timerDuration;
+    private Long timerDuration;
 
     public PairRoom(final Pair pair, final AccessCode accessCode) {
         this.pair = pair;

--- a/backend/src/main/java/site/coduo/pairroom/domain/PairRoom.java
+++ b/backend/src/main/java/site/coduo/pairroom/domain/PairRoom.java
@@ -1,5 +1,7 @@
 package site.coduo.pairroom.domain;
 
+import java.time.LocalTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -32,6 +34,16 @@ public class PairRoom extends BaseTimeEntity {
     @Column(name = "ACCESS_CODE", nullable = false)
     private AccessCode accessCode;
 
+    @Column(name = "TIMER_DURATION", nullable = true)
+    private LocalTime timerDuration;
+
+    public PairRoom(final Long id, final Pair pair, final AccessCode accessCode, final LocalTime timerDuration) {
+        this.id = id;
+        this.pair = pair;
+        this.accessCode = accessCode;
+        this.timerDuration = timerDuration;
+    }
+
     public PairRoom(final Pair pair, final AccessCode accessCode) {
         this.pair = pair;
         this.accessCode = accessCode;
@@ -47,6 +59,7 @@ public class PairRoom extends BaseTimeEntity {
                 "id=" + id +
                 ", pair=" + pair +
                 ", accessCode=" + accessCode +
+                ", timerDuration=" + timerDuration +
                 '}';
     }
 }

--- a/backend/src/main/java/site/coduo/pairroom/dto/PairRoomReadResponse.java
+++ b/backend/src/main/java/site/coduo/pairroom/dto/PairRoomReadResponse.java
@@ -1,7 +1,5 @@
 package site.coduo.pairroom.dto;
 
-import java.time.LocalTime;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import site.coduo.pairroom.domain.PairRoom;
 
@@ -10,7 +8,7 @@ public record PairRoomReadResponse(
         @Schema(description = "페어룸 id") long id,
         @Schema(description = "첫 번째 페어의 이름") String firstPair,
         @Schema(description = "두 번째 페어의 이름") String secondPair,
-        @Schema(description = "타이머 시간") LocalTime timerDuration
+        @Schema(description = "타이머 시간") long timerDuration
 ) {
 
     public static PairRoomReadResponse from(final PairRoom pairRoom) {

--- a/backend/src/main/java/site/coduo/pairroom/dto/PairRoomReadResponse.java
+++ b/backend/src/main/java/site/coduo/pairroom/dto/PairRoomReadResponse.java
@@ -1,5 +1,7 @@
 package site.coduo.pairroom.dto;
 
+import java.time.LocalTime;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import site.coduo.pairroom.domain.PairRoom;
 
@@ -7,14 +9,16 @@ import site.coduo.pairroom.domain.PairRoom;
 public record PairRoomReadResponse(
         @Schema(description = "페어룸 id") long id,
         @Schema(description = "첫 번째 페어의 이름") String firstPair,
-        @Schema(description = "두 번째 페어의 이름") String secondPair
+        @Schema(description = "두 번째 페어의 이름") String secondPair,
+        @Schema(description = "타이머 시간") LocalTime timerDuration
 ) {
 
     public static PairRoomReadResponse from(final PairRoom pairRoom) {
         return new PairRoomReadResponse(
                 pairRoom.getId(),
                 pairRoom.getPair().getFirstPair().getValue(),
-                pairRoom.getPair().getSecondPair().getValue()
+                pairRoom.getPair().getSecondPair().getValue(),
+                pairRoom.getTimerDuration()
         );
     }
 }

--- a/backend/src/main/java/site/coduo/pairroom/dto/TimerDurationCreateRequest.java
+++ b/backend/src/main/java/site/coduo/pairroom/dto/TimerDurationCreateRequest.java
@@ -1,0 +1,9 @@
+package site.coduo.pairroom.dto;
+
+import java.time.LocalTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "타이머 시간 저장 요청 바디")
+public record TimerDurationCreateRequest(@Schema(description = "타이머 시간") LocalTime timerDuration) {
+}

--- a/backend/src/main/java/site/coduo/pairroom/dto/TimerDurationCreateRequest.java
+++ b/backend/src/main/java/site/coduo/pairroom/dto/TimerDurationCreateRequest.java
@@ -1,9 +1,7 @@
 package site.coduo.pairroom.dto;
 
-import java.time.LocalTime;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "타이머 시간 저장 요청 바디")
-public record TimerDurationCreateRequest(@Schema(description = "타이머 시간") LocalTime timerDuration) {
+public record TimerDurationCreateRequest(@Schema(description = "타이머 시간") long timerDuration) {
 }

--- a/backend/src/main/java/site/coduo/pairroom/exception/InvalidTimerDurationException.java
+++ b/backend/src/main/java/site/coduo/pairroom/exception/InvalidTimerDurationException.java
@@ -1,0 +1,8 @@
+package site.coduo.pairroom.exception;
+
+public class InvalidTimerDurationException extends PairRoomException {
+
+    public InvalidTimerDurationException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/site/coduo/pairroom/repository/PairRoomRepository.java
+++ b/backend/src/main/java/site/coduo/pairroom/repository/PairRoomRepository.java
@@ -21,7 +21,7 @@ public interface PairRoomRepository extends JpaRepository<PairRoom, Long> {
                 .orElseThrow(() -> new PairRoomNotFoundException("존재하지 않는 페어룸 접근 코드입니다."));
     }
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE PairRoom pr SET pr.timerDuration = :newTimerDuration WHERE pr.id = :id")
     int updateTimerDuration(@Param("id") Long id, @Param("newTimerDuration") LocalTime newTimerDuration);
 }

--- a/backend/src/main/java/site/coduo/pairroom/repository/PairRoomRepository.java
+++ b/backend/src/main/java/site/coduo/pairroom/repository/PairRoomRepository.java
@@ -1,6 +1,5 @@
 package site.coduo.pairroom.repository;
 
-import java.time.LocalTime;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,5 +22,5 @@ public interface PairRoomRepository extends JpaRepository<PairRoom, Long> {
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE PairRoom pr SET pr.timerDuration = :newTimerDuration WHERE pr.id = :id")
-    int updateTimerDuration(@Param("id") Long id, @Param("newTimerDuration") LocalTime newTimerDuration);
+    int updateTimerDuration(@Param("id") long id, @Param("newTimerDuration") long newTimerDuration);
 }

--- a/backend/src/main/java/site/coduo/pairroom/repository/PairRoomRepository.java
+++ b/backend/src/main/java/site/coduo/pairroom/repository/PairRoomRepository.java
@@ -1,8 +1,12 @@
 package site.coduo.pairroom.repository;
 
+import java.time.LocalTime;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import site.coduo.pairroom.domain.PairRoom;
 import site.coduo.pairroom.domain.accesscode.AccessCode;
@@ -16,4 +20,8 @@ public interface PairRoomRepository extends JpaRepository<PairRoom, Long> {
         return findByAccessCode(accessCode)
                 .orElseThrow(() -> new PairRoomNotFoundException("존재하지 않는 페어룸 접근 코드입니다."));
     }
+
+    @Modifying
+    @Query("UPDATE PairRoom pr SET pr.timerDuration = :newTimerDuration WHERE pr.id = :id")
+    int updateTimerDuration(@Param("id") Long id, @Param("newTimerDuration") LocalTime newTimerDuration);
 }

--- a/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
@@ -13,6 +13,8 @@ import site.coduo.pairroom.domain.accesscode.AccessCode;
 import site.coduo.pairroom.domain.accesscode.AccessCodeFactory;
 import site.coduo.pairroom.domain.accesscode.UUIDAccessCodeStrategy;
 import site.coduo.pairroom.dto.PairRoomCreateRequest;
+import site.coduo.pairroom.dto.TimerDurationCreateRequest;
+import site.coduo.pairroom.exception.InvalidTimerDurationException;
 import site.coduo.pairroom.repository.PairRoomRepository;
 
 @RequiredArgsConstructor
@@ -20,10 +22,12 @@ import site.coduo.pairroom.repository.PairRoomRepository;
 @Service
 public class PairRoomService {
 
+    private static final int UPDATED_ROW_COUNT = 1;
+
     private final PairRoomRepository pairRoomRepository;
 
     @Transactional
-    public String save(final PairRoomCreateRequest request) {
+    public String savePairNameAndAccessCode(final PairRoomCreateRequest request) {
         final Pair pair = new Pair(new PairName(request.firstPair()), new PairName(request.secondPair()));
         final List<AccessCode> accessCodes = pairRoomRepository.findAll()
                 .stream()
@@ -36,6 +40,15 @@ public class PairRoomService {
         pairRoomRepository.save(pairRoom);
 
         return pairRoom.getAccessCodeText();
+    }
+
+    @Transactional
+    public void saveTimerDuration(final String accessCode, final TimerDurationCreateRequest request) {
+        final PairRoom pairRoom = pairRoomRepository.fetchByAccessCode(new AccessCode(accessCode));
+
+        if (pairRoomRepository.updateTimerDuration(pairRoom.getId(), request.timerDuration()) != UPDATED_ROW_COUNT) {
+            throw new InvalidTimerDurationException("타이머 시간을 저장하는데 실패했습니다.");
+        }
     }
 
     public PairRoom findByAccessCode(final String accessCode) {

--- a/backend/src/test/java/site/coduo/acceptance/AcceptanceFixture.java
+++ b/backend/src/test/java/site/coduo/acceptance/AcceptanceFixture.java
@@ -1,8 +1,5 @@
 package site.coduo.acceptance;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,9 +23,6 @@ abstract class AcceptanceFixture {
 
     @Autowired
     private OpenGraphRepository openGraphRepository;
-
-    @PersistenceContext
-    private EntityManager entityManager;
 
     @LocalServerPort
     private int port;

--- a/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
@@ -1,6 +1,5 @@
 package site.coduo.acceptance;
 
-import java.time.LocalTime;
 import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
@@ -42,7 +41,7 @@ class PairRoomAcceptanceTest extends AcceptanceFixture {
     void save_timer_duration() {
         // given
         final PairRoomCreateResponse pairRoomUrl = createPairRoom(new PairRoomCreateRequest("레디", "프람"));
-        final Map<String, Object> request = Map.of("timerDuration", LocalTime.of(0, 30));
+        final Map<String, Object> request = Map.of("timerDuration", 600000);
 
         // when & then
         RestAssured

--- a/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
@@ -1,5 +1,8 @@
 package site.coduo.acceptance;
 
+import java.time.LocalTime;
+import java.util.Map;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -32,6 +35,30 @@ class PairRoomAcceptanceTest extends AcceptanceFixture {
                 .log()
                 .all()
                 .statusCode(200);
+    }
+
+    @Test
+    @DisplayName("타이머 시간을 저장한다.")
+    void save_timer_duration() {
+        // given
+        final PairRoomCreateResponse pairRoomUrl = createPairRoom(new PairRoomCreateRequest("레디", "프람"));
+        final Map<String, Object> request = Map.of("timerDuration", LocalTime.of(0, 30));
+
+        // when & then
+        RestAssured
+                .given()
+                .log()
+                .all()
+                .contentType("application/json")
+                .body(request)
+
+                .when()
+                .post("/api/pair-room/" + pairRoomUrl.accessCode() + "/info")
+
+                .then()
+                .log()
+                .all()
+                .statusCode(201);
     }
 
     @Test

--- a/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
@@ -53,7 +53,7 @@ class PairRoomAcceptanceTest extends AcceptanceFixture {
                 .body(request)
 
                 .when()
-                .post("/api/pair-room/" + pairRoomUrl.accessCode() + "/info")
+                .post("/api/pair-room/{accessCode}/info", pairRoomUrl.accessCode())
 
                 .then()
                 .log()

--- a/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
@@ -19,6 +19,7 @@ class PairRoomAcceptanceTest extends AcceptanceFixture {
     void show_pair_room() {
         //given
         final PairRoomCreateResponse pairRoomUrl = createPairRoom(new PairRoomCreateRequest("레디", "프람"));
+        createTimerDuration(pairRoomUrl.accessCode(), 600000);
 
         //when & then
         RestAssured
@@ -114,5 +115,24 @@ class PairRoomAcceptanceTest extends AcceptanceFixture {
                 .then()
                 .extract()
                 .as(PairRoomCreateResponse.class);
+    }
+
+    static void createTimerDuration(final String accessCode, final long timerDuration) {
+        final Map<String, Object> request = Map.of("timerDuration", timerDuration);
+
+        RestAssured
+                .given()
+                .log()
+                .all()
+                .contentType("application/json")
+                .body(request)
+
+                .when()
+                .post("/api/pair-room/{accessCode}/info", accessCode)
+
+                .then()
+                .log()
+                .all()
+                .statusCode(201);
     }
 }

--- a/backend/src/test/java/site/coduo/pairroom/service/PairRoomServiceTest.java
+++ b/backend/src/test/java/site/coduo/pairroom/service/PairRoomServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
-import java.time.LocalTime;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
@@ -46,7 +45,7 @@ class PairRoomServiceTest {
         return Stream.of(
                 dynamicTest("타이머 시간을 저장한다", () -> {
                     // given
-                    final LocalTime expected = LocalTime.of(0, 10);
+                    final long expected = 600000;
 
                     // when
                     pairRoomService.saveTimerDuration(accessCode, new TimerDurationCreateRequest(expected));
@@ -57,7 +56,7 @@ class PairRoomServiceTest {
                 }),
                 dynamicTest("새로운 타이머 시간을 저장한다", () -> {
                     // given
-                    final LocalTime expected = LocalTime.of(0, 7);
+                    final long expected = 420000;
 
                     // when
                     pairRoomService.saveTimerDuration(accessCode, new TimerDurationCreateRequest(expected));
@@ -68,7 +67,7 @@ class PairRoomServiceTest {
                 }),
                 dynamicTest("페어룸을 반환한 후, 새로운 타이머 시간으로 변경되어 있는 것을 확인한다", () -> {
                     // given
-                    final LocalTime expected = LocalTime.of(0, 7);
+                    final long expected = 420000;
 
                     // when
                     pairRoomService.findByAccessCode(accessCode);

--- a/backend/src/test/java/site/coduo/pairroom/service/PairRoomServiceTest.java
+++ b/backend/src/test/java/site/coduo/pairroom/service/PairRoomServiceTest.java
@@ -1,16 +1,24 @@
 package site.coduo.pairroom.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
+import java.time.LocalTime;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import site.coduo.pairroom.dto.PairRoomCreateRequest;
+import site.coduo.pairroom.dto.TimerDurationCreateRequest;
 import site.coduo.pairroom.exception.PairRoomNotFoundException;
 
-@Transactional
 @SpringBootTest
 class PairRoomServiceTest {
 
@@ -18,6 +26,7 @@ class PairRoomServiceTest {
     private PairRoomService pairRoomService;
 
     @Test
+    @Transactional
     @DisplayName("존재하지 않는 페어룸 접근 코드를 찾으면 예외가 발생한다.")
     void throw_exception_when_find_not_exist_access_code() {
         // given
@@ -26,5 +35,48 @@ class PairRoomServiceTest {
         // when & then
         assertThatThrownBy(() -> pairRoomService.findByAccessCode(notSavedAccessCode))
                 .isExactlyInstanceOf(PairRoomNotFoundException.class);
+    }
+
+    @DisplayName("타이머 시간 저장 후, 변경된 타이머 시간을 저장하고, 페어룸 정보를 조회한다.")
+    @TestFactory
+    Stream<DynamicTest> pairRoom_create_timerDuration_save_pairRoom_get() {
+        final PairRoomCreateRequest pairRoomCreateRequest = new PairRoomCreateRequest("잉크", "프람");
+        final String accessCode = pairRoomService.savePairNameAndAccessCode(pairRoomCreateRequest);
+
+        return Stream.of(
+                dynamicTest("타이머 시간을 저장한다", () -> {
+                    // given
+                    final LocalTime expected = LocalTime.of(0, 10);
+
+                    // when
+                    pairRoomService.saveTimerDuration(accessCode, new TimerDurationCreateRequest(expected));
+
+                    // then
+                    assertThat(pairRoomService.findByAccessCode(accessCode).getTimerDuration())
+                            .isEqualTo(expected);
+                }),
+                dynamicTest("새로운 타이머 시간을 저장한다", () -> {
+                    // given
+                    final LocalTime expected = LocalTime.of(0, 7);
+
+                    // when
+                    pairRoomService.saveTimerDuration(accessCode, new TimerDurationCreateRequest(expected));
+
+                    // then
+                    assertThat(pairRoomService.findByAccessCode(accessCode).getTimerDuration())
+                            .isEqualTo(expected);
+                }),
+                dynamicTest("페어룸을 반환한 후, 새로운 타이머 시간으로 변경되어 있는 것을 확인한다", () -> {
+                    // given
+                    final LocalTime expected = LocalTime.of(0, 7);
+
+                    // when
+                    pairRoomService.findByAccessCode(accessCode);
+
+                    // then
+                    assertThat(pairRoomService.findByAccessCode(accessCode).getTimerDuration())
+                            .isEqualTo(expected);
+                })
+        );
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- closes: #355

## 구현한 기능
- 타이머 시간 저장 api

## 상세 설명
### 추가한 기능
- PairRoom 도메인(엔티티)에 타이머 시간 필드 추가
``` java
    @Column(name = "TIMER_DURATION", nullable = true)
    private LocalTime timerDuration;
```
- PairRoom 컨트롤러 클래스에 타이머 시간 저장 api 추가
``` java
    @PostMapping("/pair-room/{accessCode}/info")
    public ResponseEntity<Void> createTimerDuration(
            @PathVariable("accessCode") final String accessCode,
            @RequestBody final TimerDurationCreateRequest request
    ) {
        service.saveTimerDuration(accessCode, request);

        return ResponseEntity.created(URI.create("/"))
                .build();
    }
```
- PairRoomRepository에 타이머 속성만 저장할 수 있도록 jpql을 사용하여 타이머 시간 update
``` java
    @Modifying
    @Query("UPDATE PairRoom pr SET pr.timerDuration = :newTimerDuration WHERE pr.id = :id")
    int updateTimerDuration(@Param("id") Long id, @Param("newTimerDuration") LocalTime newTimerDuration);
```
- 타이머 시간을 update했을 때, 변경된 컬럼이 1개가 아닐 경우(id가 존재하지 않아 아무것도 update되지 않을 경우, 여러개의 컬럼이 update 될 경우 등) `InvalidTimerDurationException` 예외 던짐
``` java
    @Transactional
    public void saveTimerDuration(final String accessCode, final TimerDurationCreateRequest request) {
        final PairRoom pairRoom = pairRoomRepository.fetchByAccessCode(new AccessCode(accessCode));

        if (pairRoomRepository.updateTimerDuration(pairRoom.getId(), request.timerDuration()) != UPDATED_ROW_COUNT) {
            throw new InvalidTimerDurationException("타이머 시간을 저장하는데 실패했습니다.");
        }
    }

```
- PairRoom 조회 api에서 타이머 시간도 반환하도록 response DTO에 페어룸 시간 필드 추가
``` java
@Schema(description = "페어룸 조회 응답 바디")
public record PairRoomReadResponse(
        @Schema(description = "페어룸 id") long id,
        @Schema(description = "첫 번째 페어의 이름") String firstPair,
        @Schema(description = "두 번째 페어의 이름") String secondPair,
        // 추가
        @Schema(description = "타이머 시간") LocalTime timerDuration
) {
```
- `PairRoomDocs`에 추가한 컨트롤러 문서화 추가
``` java
    @Operation(summary = "타이머 시간을 저장한다.")
    @ApiResponse(responseCode = "201", description = "타이머 시간 저장 성공")
    ResponseEntity<Void> createTimerDuration(
            @Parameter(description = "페어룸 접근 코드", required = true)
            @PathVariable("accessCode") final String accessCode,

            @Parameter(description = "타이머 시간 저장 요청 바디", required = true)
            @RequestBody final TimerDurationCreateRequest request
    );
```
- `PairRoomAcceptanceTest`에 페어룸 시간 저장 테스트 추가, `PairRoomServiceTest`에 "타이머 시간 저장 후, 변경된 타이머 시간을 저장하고, 페어룸 정보를 조회한다" 는 내용의 Dynamic Test 추가

### 기존 기능 변경
- `PairRoomService` 의 `save` 메서드명을 `savePairNameAndAccessCode` 로 수정
  - 페어룸 전체를 저장하는 것이 아닌, 페어 이름과 accessCode만 저장하기 때문에 수정
  - 더 좋은 네이밍이 있다면 추천해 주세요!
