### PR TITLE
[BE] 페어룸 조회 응답 바디의 timerDuration 타입 long에서 Long으로 변경

### DIFF
--- a/backend/src/main/java/site/coduo/pairroom/dto/PairRoomReadResponse.java
+++ b/backend/src/main/java/site/coduo/pairroom/dto/PairRoomReadResponse.java
@@ -8,7 +8,7 @@ public record PairRoomReadResponse(
         @Schema(description = "페어룸 id") long id,
         @Schema(description = "첫 번째 페어의 이름") String firstPair,
         @Schema(description = "두 번째 페어의 이름") String secondPair,
-        @Schema(description = "타이머 시간") long timerDuration
+        @Schema(description = "타이머 시간") Long timerDuration
 ) {
 
     public static PairRoomReadResponse from(final PairRoom pairRoom) {


### PR DESCRIPTION
## 연관된 이슈

- closes: (이슈 번호)

## 구현한 기능

nullable 한 timerDuration의 응답값 타입을 long에서 Long으로 변경

## 상세 설명
