### PR TITLE
[FE] 창을 닫았다 다시 열어도 로그인이 유지되도록 구현 및 버그 해결

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -12,12 +13,27 @@ import PairRoom from '@/pages/PairRoom/PairRoom';
 import PairRoomOnboarding from '@/pages/PairRoomOnboarding/PairRoomOnboarding';
 import SignUp from '@/pages/SignUp/SignUp';
 
+import useUserStatusStore from '@/stores/userStatusStore';
+
+import { getIsUserLoggedIn } from '@/apis/oauth';
+
 import GlobalStyles from './styles/Global.style';
 import { theme } from './styles/theme';
 
 const queryClient = new QueryClient();
 
 const App = () => {
+  const { setUserStatus } = useUserStatusStore();
+
+  useEffect(() => {
+    const checkUserStatus = async () => {
+      const response = await getIsUserLoggedIn();
+      setUserStatus(response.signedIn ? 'SIGNED_IN' : 'SIGNED_OUT');
+    };
+
+    checkUserStatus();
+  }, []);
+
   const router = createBrowserRouter([
     {
       path: '/',

--- a/frontend/src/apis/oauth.ts
+++ b/frontend/src/apis/oauth.ts
@@ -17,7 +17,20 @@ export const getSignInGithub = async (): Promise<SignInGithubResponse> => {
   return await response.json();
 };
 
-export const addSignUpGithub = async (username: string): Promise<void> => {
+export interface IsUserLoggedInResponse {
+  signedIn: boolean;
+}
+
+export const getIsUserLoggedIn = async (): Promise<IsUserLoggedInResponse> => {
+  const response = await fetcher.get({
+    url: `${API_URL}/sign-in/oauth/github`,
+    errorMessage: ERROR_MESSAGES.SIGN_IN,
+  });
+
+  return await response.json();
+};
+
+export const addSignUp = async (username: string): Promise<void> => {
   const response = await fetcher.post({
     url: `${API_URL}/sign-up`,
     body: JSON.stringify({ username }),

--- a/frontend/src/apis/oauth.ts
+++ b/frontend/src/apis/oauth.ts
@@ -23,8 +23,8 @@ export interface IsUserLoggedInResponse {
 
 export const getIsUserLoggedIn = async (): Promise<IsUserLoggedInResponse> => {
   const response = await fetcher.get({
-    url: `${API_URL}/sign-in/oauth/github`,
-    errorMessage: ERROR_MESSAGES.SIGN_IN,
+    url: `${API_URL}/sign-in/check`,
+    errorMessage: ERROR_MESSAGES.CHECK_USER_LOGIN,
   });
 
   return await response.json();

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -7,4 +7,5 @@ export const ERROR_MESSAGES = {
   SIGN_IN: '로그인에 실패했습니다.',
   SIGN_UP: '회원가입에 실패했습니다.',
   SIGN_OUT: '로그아웃에 실패했습니다.',
+  CHECK_USER_LOGIN: '유저 로그인 여부를 확인하지 못했습니다.',
 };

--- a/frontend/src/hooks/member/useSignUpHandler.ts
+++ b/frontend/src/hooks/member/useSignUpHandler.ts
@@ -2,14 +2,14 @@ import { useNavigate } from 'react-router-dom';
 
 import useUserStatusStore from '@/stores/userStatusStore';
 
-import { addSignUpGithub } from '@/apis/oauth';
+import { addSignUp } from '@/apis/oauth';
 
 const useSignUpHandler = () => {
   const { setUserStatus } = useUserStatusStore();
   const navigate = useNavigate();
 
   const handleSignUp = async (username: string) => {
-    await addSignUpGithub(username);
+    await addSignUp(username);
     setUserStatus('SIGNED_IN');
     navigate('/');
   };

--- a/frontend/src/stores/userStatusStore.ts
+++ b/frontend/src/stores/userStatusStore.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand';
 
-type UserStatus = 'SIGNED_IN' | 'SIGNED_OUT' | 'SIGN_UP';
+import { getIsUserLoggedIn } from '@/apis/oauth';
 
-interface UserStatusStore {}
+type UserStatus = 'SIGNED_IN' | 'SIGNED_OUT' | 'SIGN_UP';
 
 interface UserStatusStore {
   userStatus: UserStatus;
@@ -17,5 +17,9 @@ const useUserStatusStore = create<UserStatusStore>((set) => ({
     }));
   },
 }));
+
+getIsUserLoggedIn().then((response) => {
+  useUserStatusStore.getState().setUserStatus(response.signedIn ? 'SIGNED_IN' : 'SIGNED_OUT');
+});
 
 export default useUserStatusStore;

--- a/frontend/src/stores/userStatusStore.ts
+++ b/frontend/src/stores/userStatusStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 
 import { getIsUserLoggedIn } from '@/apis/oauth';
 
-type UserStatus = 'SIGNED_IN' | 'SIGNED_OUT' | 'SIGN_UP';
+type UserStatus = 'SIGNED_IN' | 'SIGNED_OUT';
 
 interface UserStatusStore {
   userStatus: UserStatus;


### PR DESCRIPTION
## 연관된 이슈

- closes: #403 

## 구현한 기능

사용자가 창을 닫았다 다시 열어도 로그인이 유지되도록 하는 기능 구현
사용자가 로그인 후 뒤로가기를 누르면 조건부 렌더링이 제대로 동작하지 않던 문제 해결

## 상세 설명

👍
