### PR TITLE
[BE] 필터에서 발생하는 예외 핸들링

### DIFF
--- a/backend/src/main/java/site/coduo/common/config/FilterConfig.java
+++ b/backend/src/main/java/site/coduo/common/config/FilterConfig.java
@@ -4,8 +4,11 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import lombok.RequiredArgsConstructor;
 import site.coduo.common.config.filter.AccessTokenSessionFilter;
+import site.coduo.common.config.filter.AuthFailHandlerFilter;
 import site.coduo.common.config.filter.SignInCookieFilter;
 import site.coduo.common.config.filter.StateSessionFilter;
 import site.coduo.member.infrastructure.security.JwtProvider;
@@ -14,7 +17,7 @@ import site.coduo.member.infrastructure.security.JwtProvider;
 @Configuration
 public class FilterConfig {
 
-    private final JwtProvider jwtProvider;
+    private final JwtProvider jwtProvider; //TODO 인스턴스 변수 없애고 사옹하는 메서드에서 파라미터로 받자.
 
     @Bean
     public FilterRegistrationBean<StateSessionFilter> stateSessionFilter() {
@@ -40,6 +43,14 @@ public class FilterConfig {
         bean.setFilter(new SignInCookieFilter(jwtProvider));
         bean.addUrlPatterns("/api/sign-out", "/api/sign-in/check", "/api/member");
         bean.setOrder(1);
+        return bean;
+    }
+
+    @Bean
+    public FilterRegistrationBean<AuthFailHandlerFilter> authFailHandlerFilter(final ObjectMapper objectMapper) {
+        final FilterRegistrationBean<AuthFailHandlerFilter> bean = new FilterRegistrationBean<>();
+        bean.setFilter(new AuthFailHandlerFilter(objectMapper));
+        bean.setOrder(0);
         return bean;
     }
 }

--- a/backend/src/main/java/site/coduo/common/config/FilterConfig.java
+++ b/backend/src/main/java/site/coduo/common/config/FilterConfig.java
@@ -17,8 +17,6 @@ import site.coduo.member.infrastructure.security.JwtProvider;
 @Configuration
 public class FilterConfig {
 
-    private final JwtProvider jwtProvider; //TODO 인스턴스 변수 없애고 사옹하는 메서드에서 파라미터로 받자.
-
     @Bean
     public FilterRegistrationBean<StateSessionFilter> stateSessionFilter() {
         final FilterRegistrationBean<StateSessionFilter> bean = new FilterRegistrationBean<>();
@@ -38,7 +36,7 @@ public class FilterConfig {
     }
 
     @Bean
-    public FilterRegistrationBean<SignInCookieFilter> signInCookieFilter() {
+    public FilterRegistrationBean<SignInCookieFilter> signInCookieFilter(final JwtProvider jwtProvider) {
         final FilterRegistrationBean<SignInCookieFilter> bean = new FilterRegistrationBean<>();
         bean.setFilter(new SignInCookieFilter(jwtProvider));
         bean.addUrlPatterns("/api/sign-out", "/api/sign-in/check", "/api/member");

--- a/backend/src/main/java/site/coduo/common/config/filter/AuthFailHandlerFilter.java
+++ b/backend/src/main/java/site/coduo/common/config/filter/AuthFailHandlerFilter.java
@@ -29,7 +29,7 @@ public class AuthFailHandlerFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
         } catch (final AuthenticationException e) {
-            log.info(e.getMessage());
+            log.warn(e.getMessage());
 
             response.setStatus(MemberApiError.AUTHENTICATION_ERROR.getHttpStatus().value());
             response.setContentType("application/json;charset=utf-8");

--- a/backend/src/main/java/site/coduo/common/config/filter/AuthFailHandlerFilter.java
+++ b/backend/src/main/java/site/coduo/common/config/filter/AuthFailHandlerFilter.java
@@ -1,0 +1,41 @@
+package site.coduo.common.config.filter;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import site.coduo.common.controller.response.ApiErrorResponse;
+import site.coduo.member.controller.error.MemberApiError;
+import site.coduo.member.exception.AuthenticationException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class AuthFailHandlerFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response,
+                                    final FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (final AuthenticationException e) {
+            log.info(e.getMessage());
+
+            response.setStatus(MemberApiError.AUTHENTICATION_ERROR.getHttpStatus().value());
+            response.setContentType("application/json;charset=utf-8");
+            response.getWriter()
+                    .write(objectMapper.writeValueAsString(
+                            new ApiErrorResponse(MemberApiError.AUTHENTICATION_ERROR.getMessage())));
+        }
+    }
+}

--- a/backend/src/main/java/site/coduo/common/controller/CommonErrorController.java
+++ b/backend/src/main/java/site/coduo/common/controller/CommonErrorController.java
@@ -1,9 +1,13 @@
 package site.coduo.common.controller;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import lombok.extern.slf4j.Slf4j;
@@ -12,21 +16,27 @@ import site.coduo.common.controller.response.ApiErrorResponse;
 
 @Slf4j
 @RestControllerAdvice
-public class CommonErrorController {
+public class CommonErrorController extends ResponseEntityExceptionHandler {
 
-    @ExceptionHandler(NoResourceFoundException.class)
-    public ResponseEntity<ApiErrorResponse> handleNoResourceFoundException(final NoResourceFoundException e) {
-        log.warn(e.getMessage());
+    @Override
+    protected ResponseEntity<Object> handleNoResourceFoundException(final NoResourceFoundException ex,
+                                                                    final HttpHeaders headers,
+                                                                    final HttpStatusCode status,
+                                                                    final WebRequest request
+    ) {
+        log.warn(ex.getMessage());
 
         return ResponseEntity.status(CommonApiError.DATA_NOT_FOUND_ERROR.getHttpStatus())
                 .body(new ApiErrorResponse(CommonApiError.DATA_NOT_FOUND_ERROR.getMessage()));
     }
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiErrorResponse> handleMethodArgumentNotValidException(
-            final MethodArgumentNotValidException e
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(final MethodArgumentNotValidException ex,
+                                                                  final HttpHeaders headers,
+                                                                  final HttpStatusCode status,
+                                                                  final WebRequest request
     ) {
-        log.warn(e.getMessage());
+        log.warn(ex.getMessage());
 
         return ResponseEntity.status(CommonApiError.INVALID_ARGUMENT_ERROR.getHttpStatus())
                 .body(new ApiErrorResponse(CommonApiError.INVALID_ARGUMENT_ERROR.getMessage()));

--- a/backend/src/main/java/site/coduo/common/controller/CommonExceptionHandler.java
+++ b/backend/src/main/java/site/coduo/common/controller/CommonExceptionHandler.java
@@ -16,7 +16,7 @@ import site.coduo.common.controller.response.ApiErrorResponse;
 
 @Slf4j
 @RestControllerAdvice
-public class CommonErrorController extends ResponseEntityExceptionHandler {
+public class CommonExceptionHandler extends ResponseEntityExceptionHandler {
 
     @Override
     protected ResponseEntity<Object> handleNoResourceFoundException(final NoResourceFoundException ex,

--- a/backend/src/main/java/site/coduo/common/controller/CommonExceptionHandler.java
+++ b/backend/src/main/java/site/coduo/common/controller/CommonExceptionHandler.java
@@ -19,10 +19,11 @@ import site.coduo.common.controller.response.ApiErrorResponse;
 public class CommonExceptionHandler extends ResponseEntityExceptionHandler {
 
     @Override
-    protected ResponseEntity<Object> handleNoResourceFoundException(final NoResourceFoundException ex,
-                                                                    final HttpHeaders headers,
-                                                                    final HttpStatusCode status,
-                                                                    final WebRequest request
+    protected ResponseEntity<Object> handleNoResourceFoundException(
+            final NoResourceFoundException ex,
+            final HttpHeaders headers,
+            final HttpStatusCode status,
+            final WebRequest request
     ) {
         log.warn(ex.getMessage());
 
@@ -31,10 +32,11 @@ public class CommonExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @Override
-    protected ResponseEntity<Object> handleMethodArgumentNotValid(final MethodArgumentNotValidException ex,
-                                                                  final HttpHeaders headers,
-                                                                  final HttpStatusCode status,
-                                                                  final WebRequest request
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            final MethodArgumentNotValidException ex,
+            final HttpHeaders headers,
+            final HttpStatusCode status,
+            final WebRequest request
     ) {
         log.warn(ex.getMessage());
 

--- a/backend/src/main/java/site/coduo/common/controller/CommonExceptionHandler.java
+++ b/backend/src/main/java/site/coduo/common/controller/CommonExceptionHandler.java
@@ -20,12 +20,12 @@ public class CommonExceptionHandler extends ResponseEntityExceptionHandler {
 
     @Override
     protected ResponseEntity<Object> handleNoResourceFoundException(
-            final NoResourceFoundException ex,
+            final NoResourceFoundException e,
             final HttpHeaders headers,
             final HttpStatusCode status,
             final WebRequest request
     ) {
-        log.warn(ex.getMessage());
+        log.warn(e.getMessage());
 
         return ResponseEntity.status(CommonApiError.DATA_NOT_FOUND_ERROR.getHttpStatus())
                 .body(new ApiErrorResponse(CommonApiError.DATA_NOT_FOUND_ERROR.getMessage()));
@@ -33,12 +33,12 @@ public class CommonExceptionHandler extends ResponseEntityExceptionHandler {
 
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(
-            final MethodArgumentNotValidException ex,
+            final MethodArgumentNotValidException e,
             final HttpHeaders headers,
             final HttpStatusCode status,
             final WebRequest request
     ) {
-        log.warn(ex.getMessage());
+        log.warn(e.getMessage());
 
         return ResponseEntity.status(CommonApiError.INVALID_ARGUMENT_ERROR.getHttpStatus())
                 .body(new ApiErrorResponse(CommonApiError.INVALID_ARGUMENT_ERROR.getMessage()));

--- a/backend/src/main/java/site/coduo/member/controller/MemberErrorController.java
+++ b/backend/src/main/java/site/coduo/member/controller/MemberErrorController.java
@@ -18,15 +18,6 @@ import site.coduo.member.exception.AuthorizationException;
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class MemberErrorController {
 
-    @ExceptionHandler(ServletRequestBindingException.class)
-    public ResponseEntity<ApiErrorResponse> handleServletRequestBindingException(
-            final ServletRequestBindingException e) {
-        log.warn(e.getMessage());
-
-        return ResponseEntity.status(MemberApiError.AUTHENTICATION_ERROR.getHttpStatus())
-                .body(new ApiErrorResponse(MemberApiError.AUTHENTICATION_ERROR.getMessage()));
-    }
-
     @ExceptionHandler(AuthenticationException.class)
     public ResponseEntity<ApiErrorResponse> handleAuthenticationException(final AuthenticationException e) {
         log.warn("인증 예외: {}", e.getMessage());

--- a/backend/src/main/java/site/coduo/member/controller/MemberExceptionHandler.java
+++ b/backend/src/main/java/site/coduo/member/controller/MemberExceptionHandler.java
@@ -9,27 +9,18 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import lombok.extern.slf4j.Slf4j;
 import site.coduo.common.controller.response.ApiErrorResponse;
 import site.coduo.member.controller.error.MemberApiError;
-import site.coduo.member.exception.AuthenticationException;
-import site.coduo.member.exception.AuthorizationException;
+import site.coduo.member.exception.MemberNotFoundException;
 
 @Slf4j
 @RestControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class MemberExceptionHandler {
 
-    @ExceptionHandler(AuthenticationException.class)
-    public ResponseEntity<ApiErrorResponse> handleAuthenticationException(final AuthenticationException e) {
-        log.warn("인증 예외: {}", e.getMessage());
+    @ExceptionHandler(MemberNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handlerMemberNotFoundException(final MemberNotFoundException e) {
+        log.warn(e.getMessage());
 
-        return ResponseEntity.status(MemberApiError.AUTHENTICATION_ERROR.getHttpStatus())
-                .body(new ApiErrorResponse(MemberApiError.AUTHENTICATION_ERROR.getMessage()));
-    }
-
-    @ExceptionHandler(AuthorizationException.class)
-    public ResponseEntity<ApiErrorResponse> handleAuthorizationException(final AuthorizationException e) {
-        log.warn("인가 예외: {}", e.getMessage());
-
-        return ResponseEntity.status(MemberApiError.AUTHORIZATION_ERROR.getHttpStatus())
-                .body(new ApiErrorResponse(MemberApiError.AUTHORIZATION_ERROR.getMessage()));
+        return ResponseEntity.status(MemberApiError.MEMBER_NOT_FOUND_ERROR.getHttpStatus())
+                .body(new ApiErrorResponse(MemberApiError.MEMBER_NOT_FOUND_ERROR.getMessage()));
     }
 }

--- a/backend/src/main/java/site/coduo/member/controller/MemberExceptionHandler.java
+++ b/backend/src/main/java/site/coduo/member/controller/MemberExceptionHandler.java
@@ -3,7 +3,6 @@ package site.coduo.member.controller;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -16,7 +15,7 @@ import site.coduo.member.exception.AuthorizationException;
 @Slf4j
 @RestControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
-public class MemberErrorController {
+public class MemberExceptionHandler {
 
     @ExceptionHandler(AuthenticationException.class)
     public ResponseEntity<ApiErrorResponse> handleAuthenticationException(final AuthenticationException e) {

--- a/backend/src/main/java/site/coduo/member/controller/error/MemberApiError.java
+++ b/backend/src/main/java/site/coduo/member/controller/error/MemberApiError.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 public enum MemberApiError {
 
     AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, "인증되지 않은 접근입니다."),
-    AUTHORIZATION_ERROR(HttpStatus.FORBIDDEN, "권한 밖 접근입니다.");
+    MEMBER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/site/coduo/member/controller/error/MemberApiError.java
+++ b/backend/src/main/java/site/coduo/member/controller/error/MemberApiError.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum MemberApiError {
+
     AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, "인증되지 않은 접근입니다."),
     AUTHORIZATION_ERROR(HttpStatus.FORBIDDEN, "권한 밖 접근입니다.");
 

--- a/backend/src/main/java/site/coduo/member/exception/AuthorizationException.java
+++ b/backend/src/main/java/site/coduo/member/exception/AuthorizationException.java
@@ -1,8 +1,0 @@
-package site.coduo.member.exception;
-
-public class AuthorizationException extends MemberException {
-
-    public AuthorizationException(final String message) {
-        super(message);
-    }
-}

--- a/backend/src/main/java/site/coduo/pairroom/controller/PairRoomExceptionHandler.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/PairRoomExceptionHandler.java
@@ -21,7 +21,7 @@ import site.coduo.pairroom.exception.InvalidPairRoomStatusException;
 @Slf4j
 @RestControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
-public class PairRoomErrorController {
+public class PairRoomExceptionHandler {
 
     @ExceptionHandler(DuplicatePairNameException.class)
     public ResponseEntity<ApiErrorResponse> handleDuplicatePairNameException(final DuplicatePairNameException e) {

--- a/backend/src/main/java/site/coduo/pairroomhistory/controller/PairRoomHistoryExceptionHandler.java
+++ b/backend/src/main/java/site/coduo/pairroomhistory/controller/PairRoomHistoryExceptionHandler.java
@@ -16,7 +16,7 @@ import site.coduo.pairroomhistory.exception.PairRoomHistoryNotFoundException;
 @Slf4j
 @RestControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
-public class PairRoomHistoryErrorController {
+public class PairRoomHistoryExceptionHandler {
 
     @ExceptionHandler(PairRoomHistoryNotFoundException.class)
     public ResponseEntity<ApiErrorResponse> handlePairRoomNotFoundException(final PairRoomHistoryNotFoundException e) {

--- a/backend/src/main/java/site/coduo/referencelink/controller/ReferenceLinkExceptionHandler.java
+++ b/backend/src/main/java/site/coduo/referencelink/controller/ReferenceLinkExceptionHandler.java
@@ -15,7 +15,7 @@ import site.coduo.referencelink.exception.ReferenceLinkException;
 @Slf4j
 @RestControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
-public class ReferenceLinkErrorController {
+public class ReferenceLinkExceptionHandler {
 
     @ExceptionHandler(InvalidUrlFormatException.class)
     public ResponseEntity<ApiErrorResponse> handleInvalidUrlFormatException(final InvalidUrlFormatException e) {

--- a/backend/src/main/java/site/coduo/todo/controller/TodoExceptionHandler.java
+++ b/backend/src/main/java/site/coduo/todo/controller/TodoExceptionHandler.java
@@ -14,7 +14,7 @@ import site.coduo.todo.exception.TodoException;
 @Slf4j
 @RestControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
-public class TodoErrorController {
+public class TodoExceptionHandler {
 
     @ExceptionHandler(TodoException.class)
     public ResponseEntity<ApiErrorResponse> handleTodoException(final TodoException e) {

--- a/backend/src/test/java/site/coduo/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/AuthAcceptanceTest.java
@@ -124,6 +124,20 @@ class AuthAcceptanceTest extends AcceptanceFixture {
                 .statusCode(HttpStatus.SC_MOVED_TEMPORARILY);
     }
 
+    @Test
+    @DisplayName("액세스 토큰이 없을 때 예외를 던진다.")
+    void no_access_token() {
+        RestAssured
+                .given().log().all()
+                .contentType(ContentType.JSON)
+
+                .when()
+                .post("/api/sign-up")
+
+                .then().log().all()
+                .statusCode(HttpStatus.SC_UNAUTHORIZED);
+    }
+
     private Member createMember() {
         return Member.builder()
                 .username("test user")


### PR DESCRIPTION
## 연관된 이슈

- closes: #471 

## 구현한 기능

필터에서 발생하는 예외를 처리하였습니다.

## 상세 설명

필터에서 발생하는 예외는 서블릿에서 처리하기 때문에 스프링까지 전파되지 않아 @RestControllerAdvice가 잡아주지 못합니다. 때문에 필터에서 발생하는 예외를 처리하는 필터를 만들어 인증시 발생하는 예외를 처리하였습니다. 