### PR TITLE
[FE] 페어룸 투두 리스트 피드백 반영

### DIFF
--- a/frontend/.stylelintrc
+++ b/frontend/.stylelintrc
@@ -81,6 +81,7 @@
           "text-align",
           "text-indent",
           "text-overflow",
+          "text-decoration",
           "vertical-align",
           "white-space",
           "word-break"

--- a/frontend/src/components/PairRoom/ReferenceCard/AddReferenceForm/AddReferenceForm.styles.ts
+++ b/frontend/src/components/PairRoom/ReferenceCard/AddReferenceForm/AddReferenceForm.styles.ts
@@ -1,12 +1,21 @@
 import styled, { css } from 'styled-components';
 
+export const Layout = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+
+  width: 100%;
+  height: 6rem;
+  padding: 0 2rem;
+`;
+
 export const Form = styled.form`
   display: flex;
   align-items: center;
-  gap: 2rem;
+  gap: 0.6rem;
 
-  width: 75%;
-  padding: 0 2rem;
+  width: 80%;
 `;
 
 export const ButtonContainer = styled.div`
@@ -16,32 +25,11 @@ export const ButtonContainer = styled.div`
 
 export const inputStyles = css`
   height: 4rem;
-`;
-export const FooterButton = styled.button`
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-
-  width: 100%;
-  height: 6rem;
-  padding: 2rem;
-  border-radius: 0 0 1.5rem 1.5rem;
-
-  color: ${({ theme }) => theme.color.black[70]};
-  font-size: ${({ theme }) => theme.fontSize.base};
-
-  transition: all 0.2s ease 0s;
-
-  &:hover {
-    background-color: ${({ theme }) => theme.color.black[20]};
-  }
+  border-radius: 0.6rem;
 `;
 
-export const ReferenceFormContainer = styled.div`
-  display: flex;
-  align-items: center;
-
-  width: 100%;
-  height: 6rem;
-  padding-left: 1rem;
+export const buttonStyles = css`
+  width: 4.4rem;
+  height: 4rem;
+  border-radius: 0.6rem;
 `;

--- a/frontend/src/components/PairRoom/ReferenceCard/AddReferenceForm/AddReferenceForm.tsx
+++ b/frontend/src/components/PairRoom/ReferenceCard/AddReferenceForm/AddReferenceForm.tsx
@@ -8,8 +8,6 @@ import Input from '@/components/common/Input/Input';
 
 import useInput from '@/hooks/common/useInput';
 
-import { BUTTON_TEXT } from '@/constants/button';
-
 import * as S from './AddReferenceForm.styles';
 
 interface ReferenceFormProps {
@@ -18,7 +16,6 @@ interface ReferenceFormProps {
 }
 const AddReferenceForm = ({ categories, handleAddReferenceLink }: ReferenceFormProps) => {
   const { value, status, message, handleChange, resetValue } = useInput();
-  const [isFooterOpen, setIsFooterOpen] = useState(false);
   const [currentCategory, setCurrentCategory] = useState<string | null>(null);
 
   const handleSubmit = (event: React.FormEvent) => {
@@ -35,16 +32,16 @@ const AddReferenceForm = ({ categories, handleAddReferenceLink }: ReferenceFormP
 
   const newCategories = [...categories, '카테고리 없음'];
 
-  return isFooterOpen ? (
-    <S.ReferenceFormContainer>
+  return (
+    <S.Layout>
       <Dropdown
-        height=""
         width="17rem"
+        height="4rem"
+        direction="upper"
+        placeholder="카테고리를 선택해주세요."
         options={newCategories}
         selectedOption={currentCategory || '카테고리 없음'}
-        placeholder="카테고리를 선택해주세요."
         onSelect={(option) => handleCategory(option)}
-        direction="upper"
       />
       <S.Form onSubmit={handleSubmit}>
         <Input
@@ -55,21 +52,17 @@ const AddReferenceForm = ({ categories, handleAddReferenceLink }: ReferenceFormP
           message={message}
           onChange={handleChange}
         />
-        <S.ButtonContainer>
-          <Button type="button" size="sm" filled={false} rounded={true} onClick={() => setIsFooterOpen(false)}>
-            {BUTTON_TEXT.CANCEL}
-          </Button>
-          <Button type="submit" size="sm" rounded={true} disabled={value === '' || status !== 'DEFAULT'}>
-            {BUTTON_TEXT.CONFIRM}
-          </Button>
-        </S.ButtonContainer>
+        <Button
+          css={S.buttonStyles}
+          type="submit"
+          size="sm"
+          rounded={true}
+          disabled={value === '' || status !== 'DEFAULT'}
+        >
+          <LuPlus size="1.6rem" />
+        </Button>
       </S.Form>
-    </S.ReferenceFormContainer>
-  ) : (
-    <S.FooterButton onClick={() => setIsFooterOpen(true)}>
-      <LuPlus />
-      링크 추가하기
-    </S.FooterButton>
+    </S.Layout>
   );
 };
 

--- a/frontend/src/components/PairRoom/ReferenceCard/CategoryFilter/CategoryFilter.tsx
+++ b/frontend/src/components/PairRoom/ReferenceCard/CategoryFilter/CategoryFilter.tsx
@@ -1,27 +1,24 @@
-import Category from '@/components/PairRoom/ReferenceCard/CategoryFilter/CategoryBox';
+import CategoryBox from '@/components/PairRoom/ReferenceCard/CategoryFilter/CategoryBox';
+import { Category } from '@/components/PairRoom/ReferenceCard/ReferenceCard.type';
 
 import * as S from './CategoryFilter.styles';
 
-interface CategoryRecord {
-  value: string;
-  id: string;
-}
 interface CategoryFilterProps {
-  categories: CategoryRecord[];
+  categories: Category[];
   selectedCategory: string;
   handleSelectCategory: (category: string) => void;
 }
 
 const CategoryFilter = ({ categories, selectedCategory, handleSelectCategory }: CategoryFilterProps) => {
-  const isChecked = (category: string) => category === selectedCategory;
   const newCategories = [...categories, { id: 0, value: '전체' }];
+
   return (
     <S.Categories>
       {newCategories.map((category) => (
-        <Category
+        <CategoryBox
           key={category.id}
           category={category.value}
-          isChecked={isChecked(category.value)}
+          isChecked={category.value === selectedCategory}
           handleSelectCategory={handleSelectCategory}
         />
       ))}

--- a/frontend/src/components/PairRoom/ReferenceCard/CategoryModal/CategoryModal.styles.ts
+++ b/frontend/src/components/PairRoom/ReferenceCard/CategoryModal/CategoryModal.styles.ts
@@ -1,0 +1,40 @@
+import styled, { css } from 'styled-components';
+
+export const inputStyles = css`
+  width: 100%;
+  border: none;
+
+  font-size: ${({ theme }) => theme.fontSize.md};
+`;
+
+export const CategoryBox = styled.div`
+  display: flex;
+  gap: 1rem;
+`;
+
+export const CategoryModalHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+
+  color: ${({ theme }) => theme.color.black[80]};
+  font-size: ${({ theme }) => theme.fontSize.lg};
+`;
+
+export const AddNewCategoryBox = styled.form`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1rem;
+
+  width: 100%;
+  height: 7rem;
+  padding-top: 2rem;
+  border-top: 1px solid ${({ theme }) => theme.color.black[40]};
+`;
+
+export const AddNewCategoryInputBox = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;

--- a/frontend/src/components/PairRoom/ReferenceCard/CategoryModal/CategoryModal.tsx
+++ b/frontend/src/components/PairRoom/ReferenceCard/CategoryModal/CategoryModal.tsx
@@ -1,0 +1,88 @@
+import { FaFilter } from 'react-icons/fa';
+
+import { validateCategory } from '@/validations/validateCategory';
+
+import Button from '@/components/common/Button/Button';
+import Input from '@/components/common/Input/Input';
+import { Message } from '@/components/common/Input/Input.styles';
+import { Modal } from '@/components/common/Modal';
+import CategoryFilter from '@/components/PairRoom/ReferenceCard/CategoryFilter/CategoryFilter';
+import { Category } from '@/components/PairRoom/ReferenceCard/ReferenceCard.type';
+
+import useInput from '@/hooks/common/useInput';
+
+import useAddCategory from '@/queries/PairRoom/category/useAddCategory';
+
+import * as S from './CategoryModal.styles';
+
+interface CategoryModalProps {
+  accessCode: string;
+  isOpen: boolean;
+  closeModal: () => void;
+  categories: Category[];
+  isCategoryExist: (category: string) => boolean;
+  selectedCategory: string;
+  handleSelectCategory: (category: string) => void;
+}
+
+const CategoryModal = ({
+  accessCode,
+  isOpen,
+  closeModal,
+  categories,
+  isCategoryExist,
+  selectedCategory,
+  handleSelectCategory,
+}: CategoryModalProps) => {
+  const { value, handleChange, resetValue, message, status } = useInput('');
+
+  const { addCategory } = useAddCategory();
+
+  const closeCategoryModal = () => {
+    resetValue();
+    closeModal();
+  };
+
+  return (
+    <Modal isOpen={isOpen} close={closeCategoryModal} size="45rem">
+      <Modal.Header>
+        <S.CategoryModalHeader>
+          <FaFilter />
+          <p>카테고리 선택</p>
+        </S.CategoryModalHeader>
+      </Modal.Header>
+      <Modal.CloseButton close={closeCategoryModal} />
+      <Modal.Body>
+        <CategoryFilter
+          categories={categories}
+          selectedCategory={selectedCategory}
+          handleSelectCategory={handleSelectCategory}
+        />
+      </Modal.Body>
+      <S.AddNewCategoryBox
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (status === 'ERROR') return;
+          addCategory({ category: value, accessCode });
+          resetValue();
+        }}
+      >
+        <S.AddNewCategoryInputBox>
+          <Input
+            value={value}
+            placeholder="새로운 카테고리를 입력해주세요."
+            onChange={(event) => handleChange(event, validateCategory(event.target.value, isCategoryExist))}
+            status={status}
+            $css={S.inputStyles}
+          />
+          <Button size="sm" disabled={status === 'ERROR' || value === ''}>
+            추가
+          </Button>
+        </S.AddNewCategoryInputBox>
+        <Message $status={status}>{message}</Message>
+      </S.AddNewCategoryBox>
+    </Modal>
+  );
+};
+
+export default CategoryModal;

--- a/frontend/src/components/PairRoom/ReferenceCard/Header/Header.styles.ts
+++ b/frontend/src/components/PairRoom/ReferenceCard/Header/Header.styles.ts
@@ -1,0 +1,27 @@
+import styled, { css } from 'styled-components';
+
+export const buttonStyles = css`
+  width: fit-content;
+  min-width: 6rem;
+  padding: 0 1rem;
+`;
+
+export const Layout = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  width: 100%;
+  height: 6rem;
+  padding: 2rem;
+
+  font-size: ${({ theme }) => theme.fontSize.lg};
+
+  cursor: pointer;
+`;
+
+export const Container = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+`;

--- a/frontend/src/components/PairRoom/ReferenceCard/Header/Header.tsx
+++ b/frontend/src/components/PairRoom/ReferenceCard/Header/Header.tsx
@@ -24,25 +24,23 @@ const Header = ({ isOpen, selectedCategory, toggleIsOpen, onButtonClick }: React
           <IoIosArrowDown size={theme.fontSize.h6} color={theme.color.primary[600]} />
         )}
         <p>링크</p>
-      </S.Container>
-      <S.Container>
         <ToolTipQuestionBox
           message="페어 프로그래밍을 진행하면서 도움이 되었던 레퍼런스 링크를 저장해 보세요."
           color={theme.color.black[50]}
-          boxDirection="left"
+          boxDirection="right"
         />
-        <Button
-          css={S.buttonStyles}
-          size="sm"
-          rounded={true}
-          onClick={(event: React.MouseEvent<HTMLElement, MouseEvent>) => {
-            event.stopPropagation();
-            onButtonClick();
-          }}
-        >
-          {selectedCategory}
-        </Button>
       </S.Container>
+      <Button
+        css={S.buttonStyles}
+        size="sm"
+        rounded={true}
+        onClick={(event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+          event.stopPropagation();
+          onButtonClick();
+        }}
+      >
+        {selectedCategory}
+      </Button>
     </S.Layout>
   );
 };

--- a/frontend/src/components/PairRoom/ReferenceCard/Header/Header.tsx
+++ b/frontend/src/components/PairRoom/ReferenceCard/Header/Header.tsx
@@ -1,0 +1,50 @@
+import { IoIosLink, IoIosArrowDown } from 'react-icons/io';
+
+import Button from '@/components/common/Button/Button';
+import ToolTipQuestionBox from '@/components/common/ToolTipQuestionBox/ToolTipQuestionBox';
+
+import { theme } from '@/styles/theme';
+
+import * as S from './Header.styles';
+
+interface HeaderProps {
+  isOpen: boolean;
+  selectedCategory: string;
+  toggleIsOpen: () => void;
+  onButtonClick: () => void;
+}
+
+const Header = ({ isOpen, selectedCategory, toggleIsOpen, onButtonClick }: React.PropsWithChildren<HeaderProps>) => {
+  return (
+    <S.Layout onClick={toggleIsOpen}>
+      <S.Container>
+        {isOpen ? (
+          <IoIosLink size={theme.fontSize.h6} color={theme.color.primary[600]} />
+        ) : (
+          <IoIosArrowDown size={theme.fontSize.h6} color={theme.color.primary[600]} />
+        )}
+        <p>링크</p>
+      </S.Container>
+      <S.Container>
+        <ToolTipQuestionBox
+          message="페어 프로그래밍을 진행하면서 도움이 되었던 레퍼런스 링크를 저장해 보세요."
+          color={theme.color.black[50]}
+          boxDirection="left"
+        />
+        <Button
+          css={S.buttonStyles}
+          size="sm"
+          rounded={true}
+          onClick={(event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+            event.stopPropagation();
+            onButtonClick();
+          }}
+        >
+          {selectedCategory}
+        </Button>
+      </S.Container>
+    </S.Layout>
+  );
+};
+
+export default Header;

--- a/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.styles.ts
+++ b/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.styles.ts
@@ -12,10 +12,9 @@ export const Body = styled.div<{ $isOpen: boolean }>`
 
   height: ${({ $isOpen }) => ($isOpen ? 'calc(100vh - 25rem)' : '0')};
 
-  transition: all 0.3s;
+  transition: height 0.3s;
 
-  /* min-height: 42rem; */
-  border-top: 1px solid ${({ theme }) => theme.color.black[30]};
+  border-top: ${({ $isOpen, theme }) => $isOpen && `1px solid ${theme.color.black[30]}`};
 `;
 
 export const Footer = styled.div`
@@ -25,41 +24,7 @@ export const Footer = styled.div`
   gap: 1rem;
 
   width: 100%;
-
-  /* height: 12rem; */
   min-height: 6rem;
 
   border-top: 1px solid ${({ theme }) => theme.color.black[30]};
-`;
-
-export const CategoryBox = styled.div`
-  display: flex;
-  gap: 1rem;
-`;
-
-export const CategoryModalHeader = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-
-  color: ${({ theme }) => theme.color.black[80]};
-  font-size: ${({ theme }) => theme.fontSize.lg};
-`;
-
-export const AddNewCategoryBox = styled.form`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 1rem;
-
-  width: 100%;
-  height: 7rem;
-  padding-top: 2rem;
-  border-top: 1px solid ${({ theme }) => theme.color.black[40]};
-`;
-
-export const AddNewCategoryInputBox = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
 `;

--- a/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.tsx
+++ b/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.tsx
@@ -1,28 +1,15 @@
 import { useState } from 'react';
 
-import { FaFilter } from 'react-icons/fa';
-import { IoIosLink } from 'react-icons/io';
-import { css } from 'styled-components';
-
-import Button from '@/components/common/Button/Button';
-import Input from '@/components/common/Input/Input';
-import { Message } from '@/components/common/Input/Input.styles';
-import { InputStatus } from '@/components/common/Input/Input.type';
-import { Modal } from '@/components/common/Modal';
-import ToolTipQuestionBox from '@/components/common/ToolTipQuestionBox/ToolTipQuestionBox';
 import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
 import AddReferenceForm from '@/components/PairRoom/ReferenceCard/AddReferenceForm/AddReferenceForm';
-import CategoryFilter from '@/components/PairRoom/ReferenceCard/CategoryFilter/CategoryFilter';
+import CategoryModal from '@/components/PairRoom/ReferenceCard/CategoryModal/CategoryModal';
+import Header from '@/components/PairRoom/ReferenceCard/Header/Header';
 import ReferenceList from '@/components/PairRoom/ReferenceCard/ReferenceList/ReferenceList';
 
-import useInput from '@/hooks/common/useInput';
 import useModal from '@/hooks/common/useModal';
 
-import useAddCategory from '@/queries/PairRoom/category/useAddCategory';
 import useGetCategories from '@/queries/PairRoom/category/useGetCategories';
 import useReferenceLinks from '@/queries/PairRoom/useReferenceLinks';
-
-import { theme } from '@/styles/theme';
 
 import * as S from './ReferenceCard.styles';
 
@@ -33,141 +20,26 @@ interface ReferenceCardProps {
 }
 
 const ReferenceCard = ({ accessCode, isOpen, toggleIsOpen }: ReferenceCardProps) => {
-  const { categories, categoryRecord, isCategoryExist } = useGetCategories(accessCode);
-
   const [selectedCategory, setSelectedCategory] = useState('전체');
-  const handleSelectCategory = (category: string) => {
-    setSelectedCategory(category);
-  };
 
+  const { isModalOpen, openModal, closeModal } = useModal();
+
+  const { categories, categoryRecord, isCategoryExist } = useGetCategories(accessCode);
   const { referenceLinks, handleAddReferenceLink, handleDeleteReferenceLink } = useReferenceLinks(
     accessCode,
     selectedCategory,
   );
 
-  const { isModalOpen, openModal, closeModal } = useModal();
-  const { value, handleChange, resetValue, message, status } = useInput('');
-  const { addCategory } = useAddCategory();
-
-  const validateCategoryName = (category: string): { status: InputStatus; message: string } => {
-    if (category.length > 8)
-      return {
-        status: 'ERROR',
-        message: '8자 이하로 입력해주세요',
-      };
-    if (isCategoryExist(category))
-      return {
-        status: 'ERROR',
-        message: '중복된 카테고리 입니다.',
-      };
-    return {
-      status: 'DEFAULT',
-      message: '',
-    };
-  };
-  const closeCategoryModal = () => {
-    closeModal();
-    resetValue();
-  };
   return (
     <>
-      <Modal isOpen={isModalOpen} close={closeCategoryModal} size="45rem">
-        <Modal.Header>
-          <S.CategoryModalHeader>
-            <FaFilter />
-            <p>카테고리 선택</p>
-          </S.CategoryModalHeader>
-        </Modal.Header>
-        <Modal.CloseButton close={closeCategoryModal} />
-        <Modal.Body>
-          <CategoryFilter
-            categories={categoryRecord}
-            selectedCategory={selectedCategory}
-            handleSelectCategory={handleSelectCategory}
-          />
-        </Modal.Body>
-
-        <S.AddNewCategoryBox
-          onSubmit={(event) => {
-            event.preventDefault();
-            if (status === 'ERROR') return;
-            addCategory({ category: value, accessCode });
-            resetValue();
-          }}
-        >
-          <S.AddNewCategoryInputBox>
-            <Input
-              value={value}
-              placeholder="새로운 카테고리를 입력해주세요."
-              onChange={(event) => handleChange(event, validateCategoryName(event.target.value))}
-              status={status}
-              $css={css`
-                width: 100%;
-                border: none;
-
-                font-size: ${({ theme }) => theme.fontSize.md};
-              `}
-            />
-            <Button size="sm" disabled={status === 'ERROR' || value === ''}>
-              추가
-            </Button>
-          </S.AddNewCategoryInputBox>
-
-          <Message $status={status}>{message}</Message>
-        </S.AddNewCategoryBox>
-      </Modal>
       <S.Layout>
         <PairRoomCard>
-          <PairRoomCard.Header
-            icon={<IoIosLink color={theme.color.primary[500]} />}
-            title="링크"
-            secondIcon={
-              <ToolTipQuestionBox
-                boxDirection={isOpen ? 'bottom' : 'top'}
-                message="페어프로그래밍 도중 도움이 되었던 레퍼런스 링크들을 저장해보세요 ☺️"
-              />
-            }
+          <Header
             isOpen={isOpen}
+            selectedCategory={selectedCategory}
             toggleIsOpen={toggleIsOpen}
-          >
-            <S.CategoryBox>
-              {selectedCategory && (
-                <Button
-                  onClick={(event: React.MouseEvent<HTMLElement, MouseEvent>) => {
-                    event.stopPropagation();
-                  }}
-                  rounded={true}
-                  size="sm"
-                  css={css`
-                    width: fit-content;
-                    min-width: 6rem;
-                    padding: 0 1rem;
-                  `}
-                >
-                  {selectedCategory}
-                </Button>
-              )}
-              <Button
-                onClick={(event: React.MouseEvent<HTMLElement, MouseEvent>) => {
-                  event.stopPropagation();
-                  openModal();
-                }}
-                filled={false}
-                rounded={true}
-                size="sm"
-                css={css`
-                  display: flex;
-                  gap: 0.5rem;
-
-                  width: fit-content;
-                  padding: 0 1rem;
-                `}
-              >
-                <FaFilter />
-                카테고리 관리
-              </Button>
-            </S.CategoryBox>
-          </PairRoomCard.Header>
+            onButtonClick={openModal}
+          />
           <S.Body $isOpen={isOpen}>
             <ReferenceList referenceLinks={referenceLinks} onDeleteReferenceLink={handleDeleteReferenceLink} />
             <S.Footer>
@@ -176,6 +48,15 @@ const ReferenceCard = ({ accessCode, isOpen, toggleIsOpen }: ReferenceCardProps)
           </S.Body>
         </PairRoomCard>
       </S.Layout>
+      <CategoryModal
+        accessCode={accessCode}
+        isOpen={isModalOpen}
+        closeModal={closeModal}
+        categories={categoryRecord}
+        isCategoryExist={isCategoryExist}
+        selectedCategory={selectedCategory}
+        handleSelectCategory={(category: string) => setSelectedCategory(category)}
+      />
     </>
   );
 };

--- a/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.tsx
+++ b/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.tsx
@@ -9,7 +9,7 @@ import Input from '@/components/common/Input/Input';
 import { Message } from '@/components/common/Input/Input.styles';
 import { InputStatus } from '@/components/common/Input/Input.type';
 import { Modal } from '@/components/common/Modal';
-import ToolTipQuestionBox from '@/components/common/Tooltip/ToolTipQuestionBox';
+import ToolTipQuestionBox from '@/components/common/ToolTipQuestionBox/ToolTipQuestionBox';
 import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
 import AddReferenceForm from '@/components/PairRoom/ReferenceCard/AddReferenceForm/AddReferenceForm';
 import CategoryFilter from '@/components/PairRoom/ReferenceCard/CategoryFilter/CategoryFilter';
@@ -123,7 +123,7 @@ const ReferenceCard = ({ accessCode, isOpen, toggleIsOpen }: ReferenceCardProps)
             title="링크"
             secondIcon={
               <ToolTipQuestionBox
-                direction={isOpen ? 'bottom' : 'top'}
+                boxDirection={isOpen ? 'bottom' : 'top'}
                 message="페어프로그래밍 도중 도움이 되었던 레퍼런스 링크들을 저장해보세요 ☺️"
               />
             }

--- a/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.type.ts
+++ b/frontend/src/components/PairRoom/ReferenceCard/ReferenceCard.type.ts
@@ -1,0 +1,4 @@
+export interface Category {
+  id: string;
+  value: string;
+}

--- a/frontend/src/components/PairRoom/TimerCard/TimerCard.tsx
+++ b/frontend/src/components/PairRoom/TimerCard/TimerCard.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useEffect } from 'react';
 
 import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
 import TimerEditPanel from '@/components/PairRoom/TimerCard/TimerEditPanel/TimerEditPanel';
@@ -17,33 +17,27 @@ interface TimerCardProps {
   onUpdateTimeLeft: (remainingTime: number) => void;
 }
 
-const TimerCard = ({ defaultTime, defaultTimeleft, onTimerStop }: TimerCardProps) => {
+const TimerCard = ({ defaultTime, defaultTimeleft, onTimerStop, onUpdateTimeLeft }: TimerCardProps) => {
   const { timeLeft, isActive, handleStart, handlePause } = useTimer(defaultTime, defaultTimeleft, onTimerStop);
 
   const timeLeftRef = useRef(timeLeft);
   timeLeftRef.current = timeLeft;
 
-  // useEffect(() => {
-  //   const handleBeforeMove = (event: BeforeUnloadEvent) => {
-  //     onUpdateTimeLeft(timeLeftRef.current);
-  //     handlePause();
-  //     event.preventDefault();
-  //   };
+  useEffect(() => {
+    const handleBeforeMove = (event: BeforeUnloadEvent) => {
+      onUpdateTimeLeft(timeLeftRef.current);
+      handlePause();
+      event.preventDefault();
+    };
 
-  //   window.addEventListener('beforeunload', handleBeforeMove);
-  //   window.addEventListener('popstate', handleBeforeMove);
+    window.addEventListener('beforeunload', handleBeforeMove);
+    window.addEventListener('popstate', handleBeforeMove);
 
-  //   return () => {
-  //     window.removeEventListener('beforeunload', handleBeforeMove);
-  //     window.removeEventListener('popstate', handleBeforeMove);
-  //   };
-  // }, []);
-
-  // useBeforeUnload((event) => {
-  //   onUpdateTimeLeft(timeLeftRef.current);
-  //   handlePause();
-  //   event.preventDefault();
-  // });
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeMove);
+      window.removeEventListener('popstate', handleBeforeMove);
+    };
+  }, []);
 
   const { minutes, seconds } = formatTime(timeLeft);
   useTitleTime(minutes, seconds);

--- a/frontend/src/components/PairRoom/TimerCard/TimerCard.tsx
+++ b/frontend/src/components/PairRoom/TimerCard/TimerCard.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { useRef } from 'react';
 
 import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
 import TimerEditPanel from '@/components/PairRoom/TimerCard/TimerEditPanel/TimerEditPanel';
@@ -17,27 +17,27 @@ interface TimerCardProps {
   onUpdateTimeLeft: (remainingTime: number) => void;
 }
 
-const TimerCard = ({ defaultTime, defaultTimeleft, onTimerStop, onUpdateTimeLeft }: TimerCardProps) => {
+const TimerCard = ({ defaultTime, defaultTimeleft, onTimerStop }: TimerCardProps) => {
   const { timeLeft, isActive, handleStart, handlePause } = useTimer(defaultTime, defaultTimeleft, onTimerStop);
 
   const timeLeftRef = useRef(timeLeft);
   timeLeftRef.current = timeLeft;
 
-  useEffect(() => {
-    const handleBeforeMove = (event: BeforeUnloadEvent) => {
-      onUpdateTimeLeft(timeLeftRef.current);
-      handlePause();
-      event.preventDefault();
-    };
+  // useEffect(() => {
+  //   const handleBeforeMove = (event: BeforeUnloadEvent) => {
+  //     onUpdateTimeLeft(timeLeftRef.current);
+  //     handlePause();
+  //     event.preventDefault();
+  //   };
 
-    window.addEventListener('beforeunload', handleBeforeMove);
-    window.addEventListener('popstate', handleBeforeMove);
+  //   window.addEventListener('beforeunload', handleBeforeMove);
+  //   window.addEventListener('popstate', handleBeforeMove);
 
-    return () => {
-      window.removeEventListener('beforeunload', handleBeforeMove);
-      window.removeEventListener('popstate', handleBeforeMove);
-    };
-  }, []);
+  //   return () => {
+  //     window.removeEventListener('beforeunload', handleBeforeMove);
+  //     window.removeEventListener('popstate', handleBeforeMove);
+  //   };
+  // }, []);
 
   // useBeforeUnload((event) => {
   //   onUpdateTimeLeft(timeLeftRef.current);

--- a/frontend/src/components/PairRoom/TodoListCard/Header/Header.styles.ts
+++ b/frontend/src/components/PairRoom/TodoListCard/Header/Header.styles.ts
@@ -2,8 +2,8 @@ import styled from 'styled-components';
 
 export const Layout = styled.div`
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  gap: 0.8rem;
 
   width: 100%;
   height: 6rem;
@@ -12,10 +12,4 @@ export const Layout = styled.div`
   font-size: ${({ theme }) => theme.fontSize.lg};
 
   cursor: pointer;
-`;
-
-export const TitleContainer = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
 `;

--- a/frontend/src/components/PairRoom/TodoListCard/Header/Header.styles.ts
+++ b/frontend/src/components/PairRoom/TodoListCard/Header/Header.styles.ts
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+export const Layout = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  width: 100%;
+  height: 6rem;
+  padding: 2rem;
+
+  font-size: ${({ theme }) => theme.fontSize.lg};
+
+  cursor: pointer;
+`;
+
+export const TitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+`;

--- a/frontend/src/components/PairRoom/TodoListCard/Header/Header.tsx
+++ b/frontend/src/components/PairRoom/TodoListCard/Header/Header.tsx
@@ -14,18 +14,16 @@ interface HeaderProps {
 const Header = ({ isOpen, toggleIsOpen }: React.PropsWithChildren<HeaderProps>) => {
   return (
     <S.Layout onClick={toggleIsOpen}>
-      <S.TitleContainer>
-        {isOpen ? (
-          <IoIosCheckbox size={theme.fontSize.h6} color={theme.color.primary[600]} />
-        ) : (
-          <IoIosArrowDown size={theme.fontSize.h6} color={theme.color.primary[600]} />
-        )}
-        <p>투두 리스트</p>
-      </S.TitleContainer>
+      {isOpen ? (
+        <IoIosCheckbox size={theme.fontSize.h6} color={theme.color.primary[600]} />
+      ) : (
+        <IoIosArrowDown size={theme.fontSize.h6} color={theme.color.primary[600]} />
+      )}
+      <p>투두 리스트</p>
       <ToolTipQuestionBox
         message="페어 프로그래밍을 위해 필요한 할 일 목록을 작성해 보세요. 할 일을 더욱 효율적으로 관리할 수 있습니다."
         color={theme.color.black[50]}
-        boxDirection="left"
+        boxDirection="right"
       />
     </S.Layout>
   );

--- a/frontend/src/components/PairRoom/TodoListCard/Header/Header.tsx
+++ b/frontend/src/components/PairRoom/TodoListCard/Header/Header.tsx
@@ -1,0 +1,34 @@
+import { IoIosCheckbox, IoIosArrowDown } from 'react-icons/io';
+
+import ToolTipQuestionBox from '@/components/common/ToolTipQuestionBox/ToolTipQuestionBox';
+
+import { theme } from '@/styles/theme';
+
+import * as S from './Header.styles';
+
+interface HeaderProps {
+  isOpen: boolean;
+  toggleIsOpen: () => void;
+}
+
+const Header = ({ isOpen, toggleIsOpen }: React.PropsWithChildren<HeaderProps>) => {
+  return (
+    <S.Layout onClick={toggleIsOpen}>
+      <S.TitleContainer>
+        {isOpen ? (
+          <IoIosCheckbox size={theme.fontSize.h6} color={theme.color.primary[600]} />
+        ) : (
+          <IoIosArrowDown size={theme.fontSize.h6} color={theme.color.primary[600]} />
+        )}
+        <p>투두 리스트</p>
+      </S.TitleContainer>
+      <ToolTipQuestionBox
+        message="페어 프로그래밍을 위해 필요한 할 일 목록을 작성해 보세요. 할 일을 더욱 효율적으로 관리할 수 있습니다."
+        color={theme.color.black[50]}
+        boxDirection="left"
+      />
+    </S.Layout>
+  );
+};
+
+export default Header;

--- a/frontend/src/components/PairRoom/TodoListCard/TodoItem/TodoItem.styles.ts
+++ b/frontend/src/components/PairRoom/TodoListCard/TodoItem/TodoItem.styles.ts
@@ -5,6 +5,7 @@ export const Layout = styled.div<{ $isChecked: boolean; $isIconHovered: boolean;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 1.2rem;
 
   padding: 1.6rem;
   border-radius: 1rem;
@@ -36,6 +37,7 @@ export const TodoContainer = styled.div<{ $isChecked: boolean }>`
 
   p {
     text-decoration: ${({ $isChecked }) => $isChecked && 'line-through'};
+    word-break: break-all;
 
     transition: text-decoration 0.2s ease;
   }

--- a/frontend/src/components/PairRoom/TodoListCard/TodoItem/TodoItem.styles.ts
+++ b/frontend/src/components/PairRoom/TodoListCard/TodoItem/TodoItem.styles.ts
@@ -1,4 +1,4 @@
-import { AiFillDelete } from 'react-icons/ai';
+import { AiFillDelete, AiFillCopy } from 'react-icons/ai';
 import styled from 'styled-components';
 
 export const Layout = styled.div<{ $isChecked: boolean; $isIconHovered: boolean; $isDraggedOver: boolean }>`
@@ -38,6 +38,25 @@ export const TodoContainer = styled.div<{ $isChecked: boolean }>`
     text-decoration: ${({ $isChecked }) => $isChecked && 'line-through'};
 
     transition: text-decoration 0.2s ease;
+  }
+`;
+
+export const IconContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+`;
+
+export const CopyIcon = styled(AiFillCopy)<{ $isChecked: boolean }>`
+  width: 1.7rem;
+  height: 1.7rem;
+
+  color: ${({ $isChecked, theme }) => ($isChecked ? theme.color.black[50] : theme.color.secondary[500])};
+
+  transition: color 0.2s ease;
+
+  &:hover {
+    color: ${({ $isChecked, theme }) => ($isChecked ? theme.color.black[60] : theme.color.secondary[600])};
   }
 `;
 

--- a/frontend/src/components/PairRoom/TodoListCard/TodoItem/TodoItem.styles.ts
+++ b/frontend/src/components/PairRoom/TodoListCard/TodoItem/TodoItem.styles.ts
@@ -20,7 +20,7 @@ export const Layout = styled.div<{ $isChecked: boolean; $isIconHovered: boolean;
         : theme.color.secondary[100]};
   font-size: ${({ theme }) => theme.fontSize.md};
 
-  transition: background 0.2s ease;
+  transition: background 0.1s ease;
 
   cursor: pointer;
 
@@ -39,7 +39,7 @@ export const TodoContainer = styled.div<{ $isChecked: boolean }>`
     text-decoration: ${({ $isChecked }) => $isChecked && 'line-through'};
     word-break: break-all;
 
-    transition: text-decoration 0.2s ease;
+    transition: text-decoration 0.1s ease;
   }
 `;
 
@@ -55,7 +55,7 @@ export const CopyIcon = styled(AiFillCopy)<{ $isChecked: boolean }>`
 
   color: ${({ $isChecked, theme }) => ($isChecked ? theme.color.black[50] : theme.color.secondary[500])};
 
-  transition: color 0.2s ease;
+  transition: color 0.1s ease;
 
   &:hover {
     color: ${({ $isChecked, theme }) => ($isChecked ? theme.color.black[60] : theme.color.secondary[600])};
@@ -68,7 +68,7 @@ export const DeleteIcon = styled(AiFillDelete)<{ $isChecked: boolean }>`
 
   color: ${({ $isChecked, theme }) => ($isChecked ? theme.color.black[50] : theme.color.secondary[500])};
 
-  transition: color 0.2s ease;
+  transition: color 0.1s ease;
 
   &:hover {
     color: ${({ $isChecked, theme }) => ($isChecked ? theme.color.black[60] : theme.color.secondary[600])};

--- a/frontend/src/components/PairRoom/TodoListCard/TodoItem/TodoItem.styles.ts
+++ b/frontend/src/components/PairRoom/TodoListCard/TodoItem/TodoItem.styles.ts
@@ -1,7 +1,7 @@
 import { AiFillDelete } from 'react-icons/ai';
 import styled from 'styled-components';
 
-export const Layout = styled.div<{ $isDraggedOver: boolean }>`
+export const Layout = styled.div<{ $isChecked: boolean; $isIconHovered: boolean; $isDraggedOver: boolean }>`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -9,8 +9,14 @@ export const Layout = styled.div<{ $isDraggedOver: boolean }>`
   padding: 1.6rem;
   border-radius: 1rem;
 
-  background: ${({ $isDraggedOver, theme }) =>
-    $isDraggedOver ? theme.color.secondary[200] : theme.color.secondary[100]};
+  background: ${({ $isChecked, $isDraggedOver, theme }) =>
+    $isChecked
+      ? $isDraggedOver
+        ? theme.color.black[40]
+        : theme.color.black[30]
+      : $isDraggedOver
+        ? theme.color.secondary[200]
+        : theme.color.secondary[100]};
   font-size: ${({ theme }) => theme.fontSize.md};
 
   transition: background 0.2s ease;
@@ -18,25 +24,32 @@ export const Layout = styled.div<{ $isDraggedOver: boolean }>`
   cursor: pointer;
 
   &:hover {
-    background: ${({ theme }) => theme.color.secondary[150]};
+    background: ${({ $isChecked, $isIconHovered, theme }) =>
+      !$isIconHovered && ($isChecked ? theme.color.black[40] : theme.color.secondary[150])};
   }
 `;
 
-export const TodoContainer = styled.div`
+export const TodoContainer = styled.div<{ $isChecked: boolean }>`
   display: flex;
   align-items: center;
   gap: 1.2rem;
+
+  p {
+    text-decoration: ${({ $isChecked }) => $isChecked && 'line-through'};
+
+    transition: text-decoration 0.2s ease;
+  }
 `;
 
-export const DeleteIcon = styled(AiFillDelete)`
+export const DeleteIcon = styled(AiFillDelete)<{ $isChecked: boolean }>`
   width: ${({ theme }) => theme.fontSize.lg};
   height: ${({ theme }) => theme.fontSize.lg};
 
-  color: ${({ theme }) => theme.color.secondary[500]};
+  color: ${({ $isChecked, theme }) => ($isChecked ? theme.color.black[50] : theme.color.secondary[500])};
 
   transition: color 0.2s ease;
 
   &:hover {
-    color: ${({ theme }) => theme.color.secondary[600]};
+    color: ${({ $isChecked, theme }) => ($isChecked ? theme.color.black[60] : theme.color.secondary[600])};
   }
 `;

--- a/frontend/src/components/PairRoom/TodoListCard/TodoItem/TodoItem.tsx
+++ b/frontend/src/components/PairRoom/TodoListCard/TodoItem/TodoItem.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import CheckBox from '@/components/common/CheckBox/CheckBox';
@@ -19,12 +20,16 @@ interface TodoItemProps {
 const TodoItem = ({ todo, isDraggedOver, onDragStart, onDragEnter, onDrop }: TodoItemProps) => {
   const { accessCode } = useParams();
 
+  const [isIconHovered, setIsIconHovered] = useState(false);
+
   const { handleUpdateChecked, handleDeleteTodo } = useTodos(accessCode || '');
 
   const { id, isChecked, content } = todo;
 
   return (
     <S.Layout
+      $isChecked={isChecked}
+      $isIconHovered={isIconHovered}
       $isDraggedOver={isDraggedOver}
       draggable
       onDragStart={() => onDragStart(id)}
@@ -32,11 +37,16 @@ const TodoItem = ({ todo, isDraggedOver, onDragStart, onDragEnter, onDrop }: Tod
       onDragOver={(event) => event.preventDefault()}
       onDragEnd={onDrop}
     >
-      <S.TodoContainer>
+      <S.TodoContainer $isChecked={isChecked}>
         <CheckBox isChecked={isChecked} onClick={() => handleUpdateChecked(id)} />
         <p>{content}</p>
       </S.TodoContainer>
-      <S.DeleteIcon onClick={() => handleDeleteTodo(id)} />
+      <S.DeleteIcon
+        $isChecked={isChecked}
+        onMouseEnter={() => setIsIconHovered(true)}
+        onMouseLeave={() => setIsIconHovered(false)}
+        onClick={() => handleDeleteTodo(id)}
+      />
     </S.Layout>
   );
 };

--- a/frontend/src/components/PairRoom/TodoListCard/TodoItem/TodoItem.tsx
+++ b/frontend/src/components/PairRoom/TodoListCard/TodoItem/TodoItem.tsx
@@ -5,6 +5,8 @@ import CheckBox from '@/components/common/CheckBox/CheckBox';
 
 import { Todo } from '@/apis/todo';
 
+import useCopyClipBoard from '@/hooks/common/useCopyClipboard';
+
 import useTodos from '@/queries/PairRoom/useTodos';
 
 import * as S from './TodoItem.styles';
@@ -21,6 +23,7 @@ const TodoItem = ({ todo, isDraggedOver, onDragStart, onDragEnter, onDrop }: Tod
   const { accessCode } = useParams();
 
   const [isIconHovered, setIsIconHovered] = useState(false);
+  const [, onCopy] = useCopyClipBoard();
 
   const { handleUpdateChecked, handleDeleteTodo } = useTodos(accessCode || '');
 
@@ -41,12 +44,20 @@ const TodoItem = ({ todo, isDraggedOver, onDragStart, onDragEnter, onDrop }: Tod
         <CheckBox isChecked={isChecked} onClick={() => handleUpdateChecked(id)} />
         <p>{content}</p>
       </S.TodoContainer>
-      <S.DeleteIcon
-        $isChecked={isChecked}
-        onMouseEnter={() => setIsIconHovered(true)}
-        onMouseLeave={() => setIsIconHovered(false)}
-        onClick={() => handleDeleteTodo(id)}
-      />
+      <S.IconContainer>
+        <S.CopyIcon
+          $isChecked={isChecked}
+          onMouseEnter={() => setIsIconHovered(true)}
+          onMouseLeave={() => setIsIconHovered(false)}
+          onClick={() => onCopy(content)}
+        />
+        <S.DeleteIcon
+          $isChecked={isChecked}
+          onMouseEnter={() => setIsIconHovered(true)}
+          onMouseLeave={() => setIsIconHovered(false)}
+          onClick={() => handleDeleteTodo(id)}
+        />
+      </S.IconContainer>
     </S.Layout>
   );
 };

--- a/frontend/src/components/PairRoom/TodoListCard/TodoList/TodoList.styles.ts
+++ b/frontend/src/components/PairRoom/TodoListCard/TodoList/TodoList.styles.ts
@@ -4,10 +4,23 @@ export const Layout = styled.div`
   display: flex;
   flex-grow: 1;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.5rem;
   overflow-y: auto;
 
   padding: 2rem;
+`;
+
+export const TodoListContainer = styled.div`
+  display: flex;
+  flex-grow: 1;
+  flex-direction: column;
+  gap: 1rem;
+  overflow-y: auto;
+`;
+
+export const CountText = styled.p`
+  color: ${({ theme }) => theme.color.black[70]};
+  font-size: ${({ theme }) => theme.fontSize.sm};
 `;
 
 export const EmptyText = styled.p`

--- a/frontend/src/components/PairRoom/TodoListCard/TodoList/TodoList.tsx
+++ b/frontend/src/components/PairRoom/TodoListCard/TodoList/TodoList.tsx
@@ -17,16 +17,21 @@ const TodoList = () => {
   return (
     <S.Layout>
       {todos.length > 0 ? (
-        todos.map((todo) => (
-          <TodoItem
-            key={todo.id}
-            todo={todo}
-            isDraggedOver={dragOverItem?.id === todo.id}
-            onDragStart={handleDragStart}
-            onDragEnter={handleDragEnter}
-            onDrop={handleDrop}
-          />
-        ))
+        <>
+          <S.CountText>총 {todos.length}개</S.CountText>
+          <S.TodoListContainer>
+            {todos.map((todo) => (
+              <TodoItem
+                key={todo.id}
+                todo={todo}
+                isDraggedOver={dragOverItem?.id === todo.id}
+                onDragStart={handleDragStart}
+                onDragEnter={handleDragEnter}
+                onDrop={handleDrop}
+              />
+            ))}
+          </S.TodoListContainer>
+        </>
       ) : (
         <S.EmptyText>저장된 투두 리스트가 없습니다.</S.EmptyText>
       )}

--- a/frontend/src/components/PairRoom/TodoListCard/TodoListCard.styles.ts
+++ b/frontend/src/components/PairRoom/TodoListCard/TodoListCard.styles.ts
@@ -15,13 +15,9 @@ export const Body = styled.div<{ $isOpen: boolean }>`
 
   height: ${({ $isOpen }) => ($isOpen ? 'calc(100vh - 25rem)' : '0')};
 
-  transition: all 0.3s;
+  transition: height 0.3s;
 
-  /* height: calc(100vh - 25rem); */
-
-  /* min-height: 42rem; */
-
-  border-top: 1px solid ${({ theme }) => theme.color.black[30]};
+  border-top: ${({ $isOpen, theme }) => $isOpen && `1px solid ${theme.color.black[30]}`};
 `;
 
 export const Footer = styled.div`

--- a/frontend/src/components/PairRoom/TodoListCard/TodoListCard.styles.ts
+++ b/frontend/src/components/PairRoom/TodoListCard/TodoListCard.styles.ts
@@ -2,6 +2,13 @@ import styled, { css } from 'styled-components';
 
 export const inputStyles = css`
   height: 4rem;
+  border-radius: 0.6rem;
+`;
+
+export const buttonStyles = css`
+  width: 4.4rem;
+  height: 4rem;
+  border-radius: 0.6rem;
 `;
 
 export const Layout = styled.div`
@@ -36,16 +43,10 @@ export const Footer = styled.div`
 export const Form = styled.form`
   display: flex;
   align-items: center;
-  gap: 4rem;
+  gap: 0.6rem;
 
   width: 100%;
   padding: 0 2rem;
-`;
-
-export const ButtonContainer = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 1em;
 `;
 
 export const FooterButton = styled.button`

--- a/frontend/src/components/PairRoom/TodoListCard/TodoListCard.tsx
+++ b/frontend/src/components/PairRoom/TodoListCard/TodoListCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { LuPlus } from 'react-icons/lu';
@@ -9,6 +9,7 @@ import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
 import Header from '@/components/PairRoom/TodoListCard/Header/Header';
 import TodoList from '@/components/PairRoom/TodoListCard/TodoList/TodoList';
 
+import useClickOutside from '@/hooks/common/useClickOutside';
 import useInput from '@/hooks/common/useInput';
 
 import useTodos from '@/queries/PairRoom/useTodos';
@@ -22,20 +23,18 @@ interface TodoListCardProps {
 
 const TodoListCard = ({ isOpen, toggleIsOpen }: TodoListCardProps) => {
   const { accessCode } = useParams();
-
   const [isFooterOpen, setIsFooterOpen] = useState(false);
+  const footerRef = useRef<HTMLDivElement>(null);
 
-  const { handleAddTodos } = useTodos(accessCode || '');
+  useClickOutside(footerRef, () => setIsFooterOpen(false));
 
   const { value, handleChange, resetValue } = useInput();
+  const { handleAddTodos } = useTodos(accessCode || '');
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-
     handleAddTodos(value);
-
     resetValue();
-    setIsFooterOpen(false);
   };
 
   return (
@@ -44,7 +43,7 @@ const TodoListCard = ({ isOpen, toggleIsOpen }: TodoListCardProps) => {
         <Header isOpen={isOpen} toggleIsOpen={toggleIsOpen} />
         <S.Body $isOpen={isOpen}>
           <TodoList />
-          <S.Footer>
+          <S.Footer ref={footerRef}>
             {isFooterOpen ? (
               <S.Form onSubmit={handleSubmit}>
                 <Input $css={S.inputStyles} value={value} onChange={handleChange} maxLength={100} />

--- a/frontend/src/components/PairRoom/TodoListCard/TodoListCard.tsx
+++ b/frontend/src/components/PairRoom/TodoListCard/TodoListCard.tsx
@@ -1,20 +1,17 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 
-import { IoIosCheckbox } from 'react-icons/io';
 import { LuPlus } from 'react-icons/lu';
 
 import Button from '@/components/common/Button/Button';
 import Input from '@/components/common/Input/Input';
-import ToolTipQuestionBox from '@/components/common/Tooltip/ToolTipQuestionBox';
 import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
+import Header from '@/components/PairRoom/TodoListCard/Header/Header';
 import TodoList from '@/components/PairRoom/TodoListCard/TodoList/TodoList';
 
 import useInput from '@/hooks/common/useInput';
 
 import useTodos from '@/queries/PairRoom/useTodos';
-
-import { theme } from '@/styles/theme';
 
 import * as S from './TodoListCard.styles';
 
@@ -44,15 +41,7 @@ const TodoListCard = ({ isOpen, toggleIsOpen }: TodoListCardProps) => {
   return (
     <S.Layout>
       <PairRoomCard>
-        <PairRoomCard.Header
-          icon={<IoIosCheckbox color={theme.color.primary[500]} />}
-          title="투두 리스트"
-          secondIcon={
-            <ToolTipQuestionBox message="미션에 대한 todo 를 작성해보세요. 작성한 투두는 markdown 으로 복사가 가능합니다. " />
-          }
-          isOpen={isOpen}
-          toggleIsOpen={toggleIsOpen}
-        />
+        <Header isOpen={isOpen} toggleIsOpen={toggleIsOpen} />
         <S.Body $isOpen={isOpen}>
           <TodoList />
           <S.Footer>
@@ -60,13 +49,7 @@ const TodoListCard = ({ isOpen, toggleIsOpen }: TodoListCardProps) => {
               <S.Form onSubmit={handleSubmit}>
                 <Input $css={S.inputStyles} value={value} onChange={handleChange} />
                 <S.ButtonContainer>
-                  <Button
-                    type="button"
-                    size="sm"
-                    filled={false}
-                    rounded={true}
-                    onClick={() => setIsFooterOpen(false)}
-                  >
+                  <Button type="button" size="sm" filled={false} rounded={true} onClick={() => setIsFooterOpen(false)}>
                     취소
                   </Button>
                   <Button type="submit" size="sm" rounded={true} disabled={value === ''}>

--- a/frontend/src/components/PairRoom/TodoListCard/TodoListCard.tsx
+++ b/frontend/src/components/PairRoom/TodoListCard/TodoListCard.tsx
@@ -47,7 +47,7 @@ const TodoListCard = ({ isOpen, toggleIsOpen }: TodoListCardProps) => {
           <S.Footer>
             {isFooterOpen ? (
               <S.Form onSubmit={handleSubmit}>
-                <Input $css={S.inputStyles} value={value} onChange={handleChange} />
+                <Input $css={S.inputStyles} value={value} onChange={handleChange} maxLength={100} />
                 <S.ButtonContainer>
                   <Button type="button" size="sm" filled={false} rounded={true} onClick={() => setIsFooterOpen(false)}>
                     취소

--- a/frontend/src/components/PairRoom/TodoListCard/TodoListCard.tsx
+++ b/frontend/src/components/PairRoom/TodoListCard/TodoListCard.tsx
@@ -1,4 +1,3 @@
-import { useState, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { LuPlus } from 'react-icons/lu';
@@ -9,7 +8,6 @@ import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
 import Header from '@/components/PairRoom/TodoListCard/Header/Header';
 import TodoList from '@/components/PairRoom/TodoListCard/TodoList/TodoList';
 
-import useClickOutside from '@/hooks/common/useClickOutside';
 import useInput from '@/hooks/common/useInput';
 
 import useTodos from '@/queries/PairRoom/useTodos';
@@ -23,10 +21,6 @@ interface TodoListCardProps {
 
 const TodoListCard = ({ isOpen, toggleIsOpen }: TodoListCardProps) => {
   const { accessCode } = useParams();
-  const [isFooterOpen, setIsFooterOpen] = useState(false);
-  const footerRef = useRef<HTMLDivElement>(null);
-
-  useClickOutside(footerRef, () => setIsFooterOpen(false));
 
   const { value, handleChange, resetValue } = useInput();
   const { handleAddTodos } = useTodos(accessCode || '');
@@ -43,25 +37,19 @@ const TodoListCard = ({ isOpen, toggleIsOpen }: TodoListCardProps) => {
         <Header isOpen={isOpen} toggleIsOpen={toggleIsOpen} />
         <S.Body $isOpen={isOpen}>
           <TodoList />
-          <S.Footer ref={footerRef}>
-            {isFooterOpen ? (
-              <S.Form onSubmit={handleSubmit}>
-                <Input $css={S.inputStyles} value={value} onChange={handleChange} maxLength={100} />
-                <S.ButtonContainer>
-                  <Button type="button" size="sm" filled={false} rounded={true} onClick={() => setIsFooterOpen(false)}>
-                    취소
-                  </Button>
-                  <Button type="submit" size="sm" rounded={true} disabled={value === ''}>
-                    확인
-                  </Button>
-                </S.ButtonContainer>
-              </S.Form>
-            ) : (
-              <S.FooterButton onClick={() => setIsFooterOpen(true)}>
-                <LuPlus />
-                투두 추가하기
-              </S.FooterButton>
-            )}
+          <S.Footer>
+            <S.Form onSubmit={handleSubmit}>
+              <Input
+                $css={S.inputStyles}
+                value={value}
+                onChange={handleChange}
+                maxLength={100}
+                placeholder="할 일의 내용을 입력해 주세요."
+              />
+              <Button css={S.buttonStyles} type="submit" size="sm" rounded={true} disabled={value === ''}>
+                <LuPlus size="1.6rem" />
+              </Button>
+            </S.Form>
           </S.Footer>
         </S.Body>
       </PairRoomCard>

--- a/frontend/src/components/common/CheckBox/CheckBox.styles.ts
+++ b/frontend/src/components/common/CheckBox/CheckBox.styles.ts
@@ -17,16 +17,14 @@ export const CheckMark = styled.div<{ $isChecked: boolean }>`
 
   width: 2rem;
   height: 2rem;
-  border: 1px solid ${({ theme }) => theme.color.secondary[500]};
+  border: 1px solid ${({ $isChecked, theme }) => ($isChecked ? theme.color.black[60] : theme.color.secondary[500])};
   border-radius: 4px;
 
-  background-color: ${({ theme, $isChecked }) =>
-    $isChecked ? theme.color.secondary[500] : theme.color.secondary[200]};
+  background-color: ${({ $isChecked, theme }) => ($isChecked ? theme.color.black[50] : theme.color.secondary[200])};
 
   transition: all 0.2s ease 0s;
 
   &:hover {
-    background-color: ${({ theme, $isChecked }) =>
-      $isChecked ? theme.color.secondary[600] : theme.color.secondary[300]};
+    background-color: ${({ theme, $isChecked }) => ($isChecked ? theme.color.black[60] : theme.color.secondary[300])};
   }
 `;

--- a/frontend/src/components/common/CheckBox/CheckBox.styles.ts
+++ b/frontend/src/components/common/CheckBox/CheckBox.styles.ts
@@ -22,7 +22,7 @@ export const CheckMark = styled.div<{ $isChecked: boolean }>`
 
   background-color: ${({ $isChecked, theme }) => ($isChecked ? theme.color.black[50] : theme.color.secondary[200])};
 
-  transition: all 0.2s ease 0s;
+  transition: all 0.1s ease 0s;
 
   &:hover {
     background-color: ${({ theme, $isChecked }) => ($isChecked ? theme.color.black[60] : theme.color.secondary[300])};

--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -8,7 +8,7 @@ export const Layout = styled.div`
   height: 7rem;
   padding: 0 5rem;
 
-  border-bottom: 0.3rem solid ${({ theme }) => theme.color.black[30]};
+  border-bottom: 0.1rem solid ${({ theme }) => theme.color.black[30]};
 
   a,
   p {

--- a/frontend/src/components/common/ToolTipQuestionBox/ToolTipQuestionBox.styles.ts
+++ b/frontend/src/components/common/ToolTipQuestionBox/ToolTipQuestionBox.styles.ts
@@ -1,0 +1,16 @@
+import { AiFillQuestionCircle } from 'react-icons/ai';
+import styled from 'styled-components';
+
+export const QuestionIcon = styled(AiFillQuestionCircle)<{ $color: string }>`
+  width: 2rem;
+  height: 2rem;
+
+  color: ${({ $color }) => $color};
+
+  cursor: help;
+
+  &:hover {
+    transform: scale(1.1);
+    transition: all 0.1s ease-out;
+  }
+`;

--- a/frontend/src/components/common/ToolTipQuestionBox/ToolTipQuestionBox.tsx
+++ b/frontend/src/components/common/ToolTipQuestionBox/ToolTipQuestionBox.tsx
@@ -3,21 +3,23 @@ import { Direction } from '@/components/common/Tooltip/Tooltip.type';
 
 import { theme } from '@/styles/theme';
 
-import * as S from './Tooltip.styles';
+import * as S from './ToolTipQuestionBox.styles';
 
 interface ToolTipQuestionBoxProps {
   message: string;
-  direction?: Direction;
   color?: string;
+  boxColor?: string;
+  boxDirection?: Direction;
 }
 
 const ToolTipQuestionBox = ({
-  direction = 'bottom',
   color = theme.color.primary[800],
+  boxColor = theme.color.primary[800],
+  boxDirection = 'bottom',
   ...props
 }: ToolTipQuestionBoxProps) => {
   return (
-    <Tooltip direction={direction} color={color} {...props}>
+    <Tooltip direction={boxDirection} color={boxColor} {...props}>
       <S.QuestionIcon $color={color} />
     </Tooltip>
   );

--- a/frontend/src/components/common/Tooltip/Tooltip.styles.ts
+++ b/frontend/src/components/common/Tooltip/Tooltip.styles.ts
@@ -1,4 +1,3 @@
-import { AiFillQuestionCircle } from 'react-icons/ai';
 import styled, { css, keyframes } from 'styled-components';
 
 import { Direction } from '@/components/common/Tooltip/Tooltip.type';
@@ -13,6 +12,9 @@ const fadeIn = keyframes`
 `;
 
 export const Box = styled.div`
+  display: flex;
+  align-items: center;
+
   position: relative;
   top: 0.1rem;
 
@@ -31,34 +33,75 @@ const arrowStyle = css`
   content: '';
 
   position: absolute;
-  left: 50%;
-
-  transform: translateX(-50%);
   border-width: 0.8rem;
   border-style: solid;
   filter: drop-shadow(0 0.2rem 0.2rem rgb(0 0 0 / 30%));
 `;
 
-const directionStyle = ($direction: Direction, $color: string) => {
-  switch ($direction) {
+const directionStyle = (direction: Direction, color: string) => {
+  switch (direction) {
     case 'top':
       return css`
         bottom: 3.5rem;
+        left: 50%;
+
+        transform: translateX(-50%);
 
         &::before {
           ${arrowStyle}
           top: 100%;
-          border-color: ${$color} transparent transparent transparent;
+          left: 50%;
+
+          transform: translateX(-50%);
+          border-color: ${color} transparent transparent transparent;
         }
       `;
     case 'bottom':
       return css`
         top: 3.5rem;
+        left: 50%;
+
+        transform: translateX(-50%);
 
         &::before {
           ${arrowStyle}
           bottom: 100%;
-          border-color: transparent transparent ${$color};
+          left: 50%;
+
+          transform: translateX(-50%);
+          border-color: transparent transparent ${color} transparent;
+        }
+      `;
+    case 'left':
+      return css`
+        top: 50%;
+        right: 3.5rem;
+
+        transform: translateY(-50%);
+
+        &::before {
+          ${arrowStyle}
+          top: 50%;
+          left: 100%;
+
+          transform: translateY(-50%);
+          border-color: transparent transparent transparent ${color};
+        }
+      `;
+    case 'right':
+      return css`
+        top: 50%;
+        left: 3.5rem;
+
+        transform: translateY(-50%);
+
+        &::before {
+          ${arrowStyle}
+          top: 50%;
+          right: 100%;
+
+          transform: translateY(-50%);
+          border-color: transparent ${color} transparent transparent;
         }
       `;
   }
@@ -68,7 +111,6 @@ export const Content = styled.div<{ $color: string; $direction: Direction }>`
   display: none;
 
   position: absolute;
-  left: 50%;
   z-index: 100;
 
   width: fit-content;
@@ -85,27 +127,8 @@ export const Content = styled.div<{ $color: string; $direction: Direction }>`
   word-break: keep-all;
 
   animation: ${fadeIn} 0.3s ease-in-out forwards;
-  transform: translate(-50%);
-
-  content: attr(aria-label);
-
-  text-transform: none;
 
   cursor: help;
 
   ${({ $color, $direction }) => directionStyle($direction, $color)};
-`;
-
-export const QuestionIcon = styled(AiFillQuestionCircle)<{ $color: string }>`
-  width: 2rem;
-  height: 2rem;
-
-  color: ${({ $color }) => $color};
-
-  cursor: help;
-
-  &:hover {
-    transform: scale(1.1);
-    transition: all 0.1s ease-out;
-  }
 `;

--- a/frontend/src/components/common/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/common/Tooltip/Tooltip.tsx
@@ -1,5 +1,3 @@
-import { ReactNode } from 'react';
-
 import { Direction } from '@/components/common/Tooltip/Tooltip.type';
 
 import { theme } from '@/styles/theme';
@@ -8,12 +6,16 @@ import * as S from './Tooltip.styles';
 
 interface ToolTipProps {
   message: string;
-  children?: ReactNode;
   direction?: Direction;
   color?: string;
 }
 
-const Tooltip = ({ children, message, direction = 'bottom', color = theme.color.primary[800] }: ToolTipProps) => {
+const Tooltip = ({
+  message,
+  direction = 'bottom',
+  color = theme.color.primary[800],
+  children,
+}: React.PropsWithChildren<ToolTipProps>) => {
   return (
     <S.Box>
       {children}

--- a/frontend/src/pages/PairRoom/PairRoom.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.tsx
@@ -37,7 +37,6 @@ const PairRoom = () => {
   }, [latestDriver, latestNavigator]);
 
   const [isCardOpen, setIsCardOpen] = useState(false);
-  const toggleIsCardOpen = () => setIsCardOpen((prev) => !prev);
 
   const handleSwap = () => {
     handleAddPairRoomHistory(navigator, driver, timerDuration, timerDuration);
@@ -67,8 +66,8 @@ const PairRoom = () => {
         />
       </S.Container>
       <S.Container>
-        <TodoListCard isOpen={!isCardOpen} toggleIsOpen={toggleIsCardOpen} />
-        <ReferenceCard accessCode={accessCode || ''} isOpen={isCardOpen} toggleIsOpen={toggleIsCardOpen} />
+        <TodoListCard isOpen={!isCardOpen} toggleIsOpen={() => setIsCardOpen(false)} />
+        <ReferenceCard accessCode={accessCode || ''} isOpen={isCardOpen} toggleIsOpen={() => setIsCardOpen(true)} />
       </S.Container>
     </S.Layout>
   );

--- a/frontend/src/queries/PairRoom/category/useGetCategories.ts
+++ b/frontend/src/queries/PairRoom/category/useGetCategories.ts
@@ -13,16 +13,15 @@ const useGetCategories = (accessCode: string) => {
 
   const categories = data ? data.map((prop) => prop.value) : [];
 
-  const isCategoryExist = (categoryName: string) =>
-    categories.filter((category) => categoryName === category).length > 0;
+  const isCategoryExist = (category: string) => categories.includes(category);
 
   return {
-    isCategoryExist,
     categories,
     categoryRecord: data || [],
     isSuccess,
     isError,
     isFetching,
+    isCategoryExist,
   };
 };
 

--- a/frontend/src/validations/validateCategory.ts
+++ b/frontend/src/validations/validateCategory.ts
@@ -1,0 +1,8 @@
+import { InputStatus } from '@/components/common/Input/Input.type';
+
+export const validateCategory = (category: string, isCategoryExist: (category: string) => boolean) => {
+  if (category.length > 8) return { status: 'ERROR' as InputStatus, message: '8자 이하로 입력해주세요' };
+  if (isCategoryExist(category)) return { status: 'ERROR' as InputStatus, message: '중복된 카테고리 입니다.' };
+
+  return { status: 'DEFAULT' as InputStatus, message: '' };
+};


### PR DESCRIPTION
## 연관된 이슈

- closes: #498 

## 구현한 기능
- [x] 투두 아이템 입력창 글자 제한 추가
- [x] 투두 아이템 총 개수 표시 추가
- [x] 투두 아이템을 체크했을 때 취소선이 생기도록 추가
- [x] 투두 아이템을 여러 개 작성하기 편하도록 커서 이동 추가

## 상세 설명
- 투두 아이템 입력창에 100자 글자 제한을 추가했습니다.
- 투두 아이템을 체크했을 때 취소선이 생기도록 추가하고, 체크된 투두 아이템을 더 잘 드러내기 위해 배경색을 변경했습니다.
- 투두 리스트를 여러 개 작성하기 편하도록 `투두 추가하기` 버튼을 누르면 바깥 영역을 클릭하거나 `취소` 버튼을 클릭하지 않는 한 입력창에 포커스가 남아 있도록 변경했습니다.
- Tooltip 컴포넌트를 개선했습니다.
- 페어룸 내 세부적인 UI 깨짐 현상을 개선했습니다.