### PR TITLE
[FE] 스크롤 아이콘 리팩터링

### DIFF
--- a/frontend/src/components/Landing/HowToPair/HowToPair.tsx
+++ b/frontend/src/components/Landing/HowToPair/HowToPair.tsx
@@ -1,14 +1,19 @@
 import { Driver, Navigator } from '@/assets';
 
 import { ScrollAnimationContainer } from '@/components/common/Animation/ScrollAnimationContainer';
-import ScrollIcon from '@/components/common/ScrollIcon/ScrollIcon';
+import ScrollIcon, { TargetSection } from '@/components/common/ScrollIcon/ScrollIcon';
 
 import * as S from './HowToPair.styles';
 
 const HowToPair = () => {
+  const targetSections: TargetSection[] = [
+    { id: 'landing', position: 'top' },
+    { id: 'how-to-pair', position: 'bottom' },
+  ];
+
   return (
-    <S.Layout>
-      <ScrollIcon />
+    <S.Layout id="how-to-pair">
+      <ScrollIcon targetSections={targetSections} />
       <ScrollAnimationContainer
         animationDirection="right"
         animationDuration={0.7}

--- a/frontend/src/components/Landing/HowToPair/HowToPair.tsx
+++ b/frontend/src/components/Landing/HowToPair/HowToPair.tsx
@@ -1,19 +1,12 @@
 import { Driver, Navigator } from '@/assets';
 
 import { ScrollAnimationContainer } from '@/components/common/Animation/ScrollAnimationContainer';
-import ScrollIcon, { TargetSection } from '@/components/common/ScrollIcon/ScrollIcon';
 
 import * as S from './HowToPair.styles';
 
 const HowToPair = () => {
-  const targetSections: TargetSection[] = [
-    { id: 'landing', position: 'top' },
-    { id: 'how-to-pair', position: 'bottom' },
-  ];
-
   return (
     <S.Layout id="how-to-pair">
-      <ScrollIcon targetSections={targetSections} />
       <ScrollAnimationContainer
         animationDirection="right"
         animationDuration={0.7}

--- a/frontend/src/components/common/ScrollIcon/ScrollIcon.styles.ts
+++ b/frontend/src/components/common/ScrollIcon/ScrollIcon.styles.ts
@@ -36,6 +36,7 @@ export const Layout = styled.div<{ $isBottom: boolean }>`
 
   position: fixed;
   bottom: 2rem;
+  left: calc(50% - 3rem);
   z-index: 10;
 
   padding: 1.5rem;

--- a/frontend/src/components/common/ScrollIcon/ScrollIcon.tsx
+++ b/frontend/src/components/common/ScrollIcon/ScrollIcon.tsx
@@ -1,28 +1,24 @@
 import useScrollIcon from '@/hooks/common/useScrollIcon';
 
 import * as S from './ScrollIcon.styles';
+
 export interface TargetSection {
   id: string;
   position: 'top' | 'bottom';
 }
-
 interface ScrollIconProps {
-  targetSections: TargetSection[];
-  onClick?: () => void;
+  targetSections?: TargetSection[];
 }
 
-interface ScrollIconProps {
-  targetSections: TargetSection[];
-  onClick?: () => void;
-}
-
-const ScrollIcon = ({ targetSections, onClick }: ScrollIconProps) => {
+const ScrollIcon = ({ targetSections }: ScrollIconProps) => {
   const { currentSection, handleClick } = useScrollIcon({ targetSections });
 
-  const isBottom = currentSection === targetSections[targetSections.length - 1].id;
+  const isBottom =
+    currentSection ===
+    (targetSections && targetSections.length > 0 ? targetSections[targetSections.length - 1].id : 'bottom');
 
   return (
-    <S.Layout onClick={onClick ? onClick : handleClick} $isBottom={isBottom}>
+    <S.Layout onClick={handleClick} $isBottom={isBottom}>
       <S.ScrollIcon size="3rem" $isBottom={isBottom} />
     </S.Layout>
   );

--- a/frontend/src/components/common/ScrollIcon/ScrollIcon.tsx
+++ b/frontend/src/components/common/ScrollIcon/ScrollIcon.tsx
@@ -1,12 +1,28 @@
 import useScrollIcon from '@/hooks/common/useScrollIcon';
 
 import * as S from './ScrollIcon.styles';
+export interface TargetSection {
+  id: string;
+  position: 'top' | 'bottom';
+}
 
-const ScrollIcon = () => {
-  const { isBottom, handleClick } = useScrollIcon();
+interface ScrollIconProps {
+  targetSections: TargetSection[];
+  onClick?: () => void;
+}
+
+interface ScrollIconProps {
+  targetSections: TargetSection[];
+  onClick?: () => void;
+}
+
+const ScrollIcon = ({ targetSections, onClick }: ScrollIconProps) => {
+  const { currentSection, handleClick } = useScrollIcon({ targetSections });
+
+  const isBottom = currentSection === targetSections[targetSections.length - 1].id;
 
   return (
-    <S.Layout onClick={handleClick} $isBottom={isBottom}>
+    <S.Layout onClick={onClick ? onClick : handleClick} $isBottom={isBottom}>
       <S.ScrollIcon size="3rem" $isBottom={isBottom} />
     </S.Layout>
   );

--- a/frontend/src/hooks/common/useScrollIcon.ts
+++ b/frontend/src/hooks/common/useScrollIcon.ts
@@ -1,27 +1,37 @@
 import { useState, useEffect } from 'react';
 
-const useScrollIcon = () => {
-  const [isBottom, setIsBottom] = useState(false);
+import { TargetSection } from '@/components/common/ScrollIcon/ScrollIcon';
+
+interface UseScrollIconProps {
+  targetSections: TargetSection[];
+}
+
+const useScrollIcon = ({ targetSections }: UseScrollIconProps) => {
+  const [currentSection, setCurrentSection] = useState<string>(targetSections[0].id);
 
   const handleScroll = () => {
-    const scrollPosition = window.innerHeight + window.scrollY;
-    const documentHeight = document.documentElement.scrollHeight;
-    const atBottom = scrollPosition >= documentHeight - 80;
-    setIsBottom(atBottom);
+    const scrollPosition = window.scrollY + window.innerHeight / 2;
+
+    for (const section of targetSections) {
+      const element = document.getElementById(section.id);
+      if (element) {
+        const elementTop = element.offsetTop;
+        const elementBottom = elementTop + element.offsetHeight;
+
+        if (scrollPosition >= elementTop && scrollPosition < elementBottom) {
+          setCurrentSection(section.id);
+          break;
+        }
+      }
+    }
   };
 
   const handleClick = () => {
-    if (isBottom) {
-      window.scrollTo({
-        top: 0,
-        behavior: 'smooth',
-      });
-    } else {
-      window.scrollTo({
-        top: document.documentElement.scrollHeight,
-        behavior: 'smooth',
-      });
-    }
+    const currentIndex = targetSections.findIndex((section) => section.id === currentSection);
+    const nextIndex = (currentIndex + 1) % targetSections.length;
+    const nextSection = targetSections[nextIndex];
+
+    document.getElementById(nextSection.id)?.scrollIntoView({ behavior: 'smooth' });
   };
 
   useEffect(() => {
@@ -31,7 +41,7 @@ const useScrollIcon = () => {
     };
   }, []);
 
-  return { isBottom, handleClick };
+  return { currentSection, handleClick };
 };
 
 export default useScrollIcon;

--- a/frontend/src/hooks/common/useScrollIcon.ts
+++ b/frontend/src/hooks/common/useScrollIcon.ts
@@ -46,13 +46,17 @@ const useScrollIcon = ({ targetSections }: UseScrollIconProps) => {
     const nextIndex = (currentIndex + 1) % sections.length;
     const nextSection = sections[nextIndex];
 
-    if (nextSection.id === 'top') {
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-    } else if (nextSection.id === 'bottom') {
-      window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
-    } else {
-      document.getElementById(nextSection.id)?.scrollIntoView({ behavior: 'smooth' });
+    switch (nextSection.id) {
+      case 'top':
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+        break;
+      case 'bottom':
+        window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
+        break;
+      default:
+        document.getElementById(nextSection.id)?.scrollIntoView({ behavior: 'smooth' });
     }
+
     setCurrentSection(nextSection.id);
   };
 

--- a/frontend/src/hooks/common/useScrollIcon.ts
+++ b/frontend/src/hooks/common/useScrollIcon.ts
@@ -3,16 +3,31 @@ import { useState, useEffect } from 'react';
 import { TargetSection } from '@/components/common/ScrollIcon/ScrollIcon';
 
 interface UseScrollIconProps {
-  targetSections: TargetSection[];
+  targetSections?: TargetSection[];
 }
 
 const useScrollIcon = ({ targetSections }: UseScrollIconProps) => {
-  const [currentSection, setCurrentSection] = useState<string>(targetSections[0].id);
+  const defaultSections: TargetSection[] = [
+    { id: 'top', position: 'top' },
+    { id: 'bottom', position: 'bottom' },
+  ];
+
+  const sections = targetSections && targetSections.length > 0 ? targetSections : defaultSections;
+
+  const [currentSection, setCurrentSection] = useState<string>(sections[0].id);
 
   const handleScroll = () => {
     const scrollPosition = window.scrollY + window.innerHeight / 2;
+    if (!targetSections && window.scrollY < 50) {
+      setCurrentSection('top');
+      return;
+    }
+    if (!targetSections && window.innerHeight + window.scrollY >= document.body.scrollHeight - 50) {
+      setCurrentSection('bottom');
+      return;
+    }
 
-    for (const section of targetSections) {
+    for (const section of sections) {
       const element = document.getElementById(section.id);
       if (element) {
         const elementTop = element.offsetTop;
@@ -27,11 +42,18 @@ const useScrollIcon = ({ targetSections }: UseScrollIconProps) => {
   };
 
   const handleClick = () => {
-    const currentIndex = targetSections.findIndex((section) => section.id === currentSection);
-    const nextIndex = (currentIndex + 1) % targetSections.length;
-    const nextSection = targetSections[nextIndex];
+    const currentIndex = sections.findIndex((section) => section.id === currentSection);
+    const nextIndex = (currentIndex + 1) % sections.length;
+    const nextSection = sections[nextIndex];
 
-    document.getElementById(nextSection.id)?.scrollIntoView({ behavior: 'smooth' });
+    if (nextSection.id === 'top') {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    } else if (nextSection.id === 'bottom') {
+      window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
+    } else {
+      document.getElementById(nextSection.id)?.scrollIntoView({ behavior: 'smooth' });
+    }
+    setCurrentSection(nextSection.id);
   };
 
   useEffect(() => {

--- a/frontend/src/hooks/common/useScrollIcon.ts
+++ b/frontend/src/hooks/common/useScrollIcon.ts
@@ -27,18 +27,20 @@ const useScrollIcon = ({ targetSections }: UseScrollIconProps) => {
       return;
     }
 
-    for (const section of sections) {
-      const element = document.getElementById(section.id);
-      if (element) {
-        const elementTop = element.offsetTop;
-        const elementBottom = elementTop + element.offsetHeight;
+    const isInView = (element: HTMLElement, scrollPosition: number) => {
+      const elementTop = element.offsetTop;
+      const elementBottom = elementTop + element.offsetHeight;
+      return scrollPosition >= elementTop && scrollPosition < elementBottom;
+    };
 
-        if (scrollPosition >= elementTop && scrollPosition < elementBottom) {
-          setCurrentSection(section.id);
-          break;
-        }
+    sections.some((section) => {
+      const element = document.getElementById(section.id);
+      if (element && isInView(element, scrollPosition)) {
+        setCurrentSection(section.id);
+        return true;
       }
-    }
+      return false;
+    });
   };
 
   const handleClick = () => {

--- a/frontend/src/pages/Landing/Landing.tsx
+++ b/frontend/src/pages/Landing/Landing.tsx
@@ -7,6 +7,7 @@ import * as S from '@/pages/Landing/Landing.styles';
 
 import { ScrollAnimationContainer } from '@/components/common/Animation/ScrollAnimationContainer';
 import Button from '@/components/common/Button/Button';
+import ScrollIcon, { TargetSection } from '@/components/common/ScrollIcon/ScrollIcon';
 import HowToPair from '@/components/Landing/HowToPair/HowToPair';
 
 import useUserStore from '@/stores/userStore';
@@ -17,7 +18,10 @@ import useSignInHandler from '@/hooks/member/useSignInHandler';
 
 const Landing = () => {
   const navigate = useNavigate();
-
+  const targetSections: TargetSection[] = [
+    { id: 'landing', position: 'top' },
+    { id: 'how-to-pair', position: 'bottom' },
+  ];
   useTitleTime();
   usePreventBackNavigation();
 
@@ -30,6 +34,7 @@ const Landing = () => {
 
   return (
     <>
+      <ScrollIcon targetSections={targetSections} />
       <S.Layout id="landing">
         <ScrollAnimationContainer animationDirection="right">
           <S.SubTitle>당신의 첫 번째 페어 프로그래밍,</S.SubTitle>

--- a/frontend/src/pages/Landing/Landing.tsx
+++ b/frontend/src/pages/Landing/Landing.tsx
@@ -30,7 +30,7 @@ const Landing = () => {
 
   return (
     <>
-      <S.Layout>
+      <S.Layout id="landing">
         <ScrollAnimationContainer animationDirection="right">
           <S.SubTitle>당신의 첫 번째 페어 프로그래밍,</S.SubTitle>
         </ScrollAnimationContainer>


### PR DESCRIPTION
## 연관된 이슈

- closes: #635 

## 구현한 기능

스크롤 아이콘 리팩터링

## 상세 설명

```
export interface TargetSection {
  id: string;
  position: 'top' | 'bottom';
}
```

스크롤 아이콘 재사용 가능하게 변경
targetSections 값을 넣으면 targetSections안에 id값을 찾아 top과 bottom을 정하고 그 위치를 기준으로 동작
targetSections 값이 없으면 자동으로 페이지의 맨 위와 맨 아래를 기준으로 동작

