### PR TITLE
[BE] 타이머 무한 스케줄링 에러 해결

### DIFF
--- a/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
@@ -43,9 +43,6 @@ public class PairRoomService {
     @Transactional
     public String savePairRoom(final PairRoomCreateRequest request, @Nullable final String token) {
         final PairRoom pairRoom = createPairRoom(request);
-        final PairRoomEntity entity = PairRoomEntity.from(pairRoom);
-        log.info("Pair ROom entity : {}", entity);
-
         final PairRoomEntity pairRoomEntity = pairRoomRepository.save(PairRoomEntity.from(pairRoom));
 
         final Timer timer = new Timer(pairRoom.getAccessCode(), request.timerDuration(), request.timerRemainingTime());
@@ -67,7 +64,6 @@ public class PairRoomService {
 
     private AccessCode generateAccessCode() {
         final String generatedAccessCode = uuidAccessCodeGenerator.generate();
-        log.info("ACCESS CODE : {}", generatedAccessCode);
         if (pairRoomRepository.existsByAccessCode(generatedAccessCode)) {
             return generateAccessCode();
         }

--- a/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
@@ -85,7 +85,7 @@ public class PairRoomService {
 
     public PairRoomReadResponse findPairRoomAndTimer(final String accessCode) {
         final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCode);
-        final TimerEntity timerEntity = timerRepository.fetchTimerByPairRoomId(pairRoomEntity.getId());
+        final TimerEntity timerEntity = timerRepository.fetchTimerByPairRoomEntity(pairRoomEntity);
         return PairRoomReadResponse.of(pairRoomEntity.toDomain(), timerEntity.toDomain());
     }
 

--- a/backend/src/main/java/site/coduo/referencelink/service/ReferenceLinkService.java
+++ b/backend/src/main/java/site/coduo/referencelink/service/ReferenceLinkService.java
@@ -72,7 +72,6 @@ public class ReferenceLinkService {
 
         final List<ReferenceLinkEntity> referenceLinkEntities = referenceLinkRepository.findByPairRoomEntity(pairRoom);
 
-        log.info("[Reference Link] 4. referenceLinkRepository.findAll() 반환 데이터 필터링 시작!!");
         return referenceLinkEntities.stream()
                 .map(this::makeReferenceLinkResponse)
                 .toList();

--- a/backend/src/main/java/site/coduo/sync/service/SchedulerService.java
+++ b/backend/src/main/java/site/coduo/sync/service/SchedulerService.java
@@ -68,8 +68,10 @@ public class SchedulerService {
     }
 
     public void pause(final String key) {
-        sseService.broadcast(key, "timer", "pause");
-        schedulerRegistry.release(key);
+        if (schedulerRegistry.isActive(key)) {
+            sseService.broadcast(key, "timer", "pause");
+            schedulerRegistry.release(key);
+        }
     }
 
     private void stop(final String key, final Timer timer) {

--- a/backend/src/main/java/site/coduo/sync/service/SchedulerService.java
+++ b/backend/src/main/java/site/coduo/sync/service/SchedulerService.java
@@ -53,13 +53,11 @@ public class SchedulerService {
 
     private void runTimer(final String key, final Timer timer) {
         if (timer.isTimeUp()) {
-            stop(key);
-            final Timer initalTimer = new Timer(timer.getAccessCode(), timer.getDuration(), timer.getDuration());
-            timestampRegistry.register(key, initalTimer);
+            stop(key, timer);
             return;
         }
         if (sseService.hasNoConnections(key) && schedulerRegistry.has(key)) {
-            stop(key);
+            pause(key);
             return;
         }
         timer.decreaseRemainingTime(DELAY_SECOND.toMillis());
@@ -71,8 +69,10 @@ public class SchedulerService {
         schedulerRegistry.release(key);
     }
 
-    public void stop(final String key) {
+    private void stop(final String key, final Timer timer) {
         sseService.broadcast(key, "timer", "stop");
         schedulerRegistry.release(key);
+        final Timer initalTimer = new Timer(timer.getAccessCode(), timer.getDuration(), timer.getDuration());
+        timestampRegistry.register(key, initalTimer);
     }
 }

--- a/backend/src/main/java/site/coduo/sync/service/SchedulerService.java
+++ b/backend/src/main/java/site/coduo/sync/service/SchedulerService.java
@@ -29,6 +29,9 @@ public class SchedulerService {
     private final SseService sseService;
 
     public void start(final String key) {
+        if (schedulerRegistry.isActive(key)) {
+            return;
+        }
         sseService.broadcast(key, "timer", "start");
         if (isInitial(key)) {
             final Timer timer = timerRepository.fetchTimerByAccessCode(key)
@@ -52,7 +55,7 @@ public class SchedulerService {
     }
 
     private void runTimer(final String key, final Timer timer) {
-        if (timer.isTimeUp()) {
+        if (timer.isTimeUp() && schedulerRegistry.has(key)) {
             stop(key, timer);
             return;
         }

--- a/backend/src/main/java/site/coduo/timer/repository/TimerRepository.java
+++ b/backend/src/main/java/site/coduo/timer/repository/TimerRepository.java
@@ -4,16 +4,17 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import site.coduo.pairroom.repository.PairRoomEntity;
 import site.coduo.timer.exception.TimerNotFoundException;
 
 public interface TimerRepository extends JpaRepository<TimerEntity, Long> {
 
-    default TimerEntity fetchTimerByPairRoomId(final long pairRoomId) {
-        return findByPairRoomEntityId(pairRoomId)
+    default TimerEntity fetchTimerByPairRoomEntity(final PairRoomEntity pairRoomEntity) {
+        return findByPairRoomEntity(pairRoomEntity)
                 .orElseThrow(() -> new TimerNotFoundException("해당 페어룸의 타이머가 존재하지 않습니다."));
     }
 
-    Optional<TimerEntity> findByPairRoomEntityId(long pairRoomId);
+    Optional<TimerEntity> findByPairRoomEntity(PairRoomEntity pairRoomEntity);
 
     default TimerEntity fetchTimerByAccessCode(final String accessCode) {
         return findByPairRoomEntityAccessCode(accessCode)

--- a/backend/src/main/java/site/coduo/timer/service/TimerService.java
+++ b/backend/src/main/java/site/coduo/timer/service/TimerService.java
@@ -24,7 +24,7 @@ public class TimerService {
 
     public TimerReadResponse readTimer(final String accessCode) {
         final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCode);
-        final TimerEntity timerEntity = timerRepository.fetchTimerByPairRoomId(pairRoomEntity.getId());
+        final TimerEntity timerEntity = timerRepository.fetchTimerByPairRoomEntity(pairRoomEntity);
         return TimerReadResponse.of(timerEntity.getId(), timerEntity.toDomain());
     }
 
@@ -41,7 +41,7 @@ public class TimerService {
     @Transactional
     public void updateTimer(final String accessCode, final TimerUpdateRequest updateRequest) {
         final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCode);
-        final TimerEntity timerEntity = timerRepository.fetchTimerByPairRoomId(pairRoomEntity.getId());
+        final TimerEntity timerEntity = timerRepository.fetchTimerByPairRoomEntity(pairRoomEntity);
         final Timer newTimer = new Timer(
                 new AccessCode(pairRoomEntity.getAccessCode()),
                 updateRequest.duration(),

--- a/backend/src/test/java/site/coduo/timer/repository/TimerRepositoryTest.java
+++ b/backend/src/test/java/site/coduo/timer/repository/TimerRepositoryTest.java
@@ -51,7 +51,7 @@ class TimerRepositoryTest {
 
         // when
         final TimerEntity actual = timerRepository
-                .fetchTimerByPairRoomId(entity.getId());
+                .fetchTimerByPairRoomEntity(entity);
 
         // then
         assertThat(actual)


### PR DESCRIPTION
## 연관된 이슈

- closes: #685 

## 문제 상황
![image](https://github.com/user-attachments/assets/a2483875-796a-481e-a334-5e6e79ea2242)
![image](https://github.com/user-attachments/assets/a81a2f04-3fd2-4ade-8fab-28393b1dcf7f)
- 브라우저 탭을 커넥션 제한 개수 이상 띄우면(http/1.1 기준 커넥션 제한 6개) 동기화가 되지 않는 페어룸이 생긴다. 동기화 되지 않는 페어룸의 타이머를 동작시키면 정상적인 타이머 실행 속도가 빨라진다. 타이머 남은 시간이 0이 되면 "키에 해당하는 스케줄러 결과가 존재하지 않습니다" 라는 에러 메세지가 반복되어 실행된다. 
## 상세 설명
- 타이머가 실행 중이면 start 메서드를 실행하지 않도록 수정
- 타이머가 중단된 상태이면 pause 메서드를 실행하지 않도록 수정