### PR TITLE
[BE] SSE 타임아웃이 발생하면 멈추는 문제 해결

### DIFF
--- a/backend/src/main/java/site/coduo/sync/service/SseEventStream.java
+++ b/backend/src/main/java/site/coduo/sync/service/SseEventStream.java
@@ -42,7 +42,8 @@ public class SseEventStream implements EventStream {
             sseEmitter.send(SseEmitter.event()
                     .id(eventId)
                     .name(CONNECT_NAME)
-                    .data(SUCCESS_MESSAGE));
+                    .data(SUCCESS_MESSAGE)
+                    .reconnectTime(1));
         } catch (final IOException e) {
             throw new SseConnectionFailureException("SSE 연결이 실패했습니다.");
         }


### PR DESCRIPTION
## 연관된 이슈

- closes: #705 

## 구현한 기능
- SSE 타임아웃이 발생하면 클라이언트가 ```1ms```안에 재연결 요청을 보내도록 하는 설정 추가

## 상세 설명
기존 로직에서 한명의 사용자가 하나의 SSE 커넥션을 맺어 페어룸 타이머를 사용할시, 타임아웃이 발생하면 재연결하는 과정(2 ~ 3초) 사이 타이머가 커넥션을 찾을 수 없어 타이머를 중지시키는 문제가 있었다.

따라서 타임아웃이 발생하면 타이머의 작업 단위인 1초보다 먼저 재연결을 하도록 하여 이 문제가 발생하지 않도록 조치하였다.