### PR TITLE
[FE] 페어룸 존재 여부 확인 API 연동 및 버그 픽스

### DIFF
--- a/frontend/src/apis/pairRoom.ts
+++ b/frontend/src/apis/pairRoom.ts
@@ -22,6 +22,15 @@ export const getPairRoom = async (accessCode: string): Promise<GetPairRoomRespon
   return await response.json();
 };
 
+export const getPairRoomExists = async (accessCode: string): Promise<{ exists: boolean }> => {
+  const response = await fetcher.get({
+    url: `${API_URL}/pair-room/exists?access_code=${accessCode}`,
+    errorMessage: ERROR_MESSAGES.GET_PAIR_ROOM,
+  });
+
+  return await response.json();
+};
+
 interface AddPairRoomRequest {
   driver: string;
   navigator: string;

--- a/frontend/src/components/Main/PairRoomEntryModal/PairRoomEntryModal.tsx
+++ b/frontend/src/components/Main/PairRoomEntryModal/PairRoomEntryModal.tsx
@@ -6,9 +6,9 @@ import { Modal } from '@/components/common/Modal';
 
 import useToastStore from '@/stores/toastStore';
 
-import useInput from '@/hooks/common/useInput';
+import { getPairRoomExists } from '@/apis/pairRoom';
 
-import useGetPairRoom from '@/queries/PairRoom/useGetPairRoom';
+import useInput from '@/hooks/common/useInput';
 
 import { BUTTON_TEXT } from '@/constants/button';
 
@@ -19,23 +19,19 @@ interface PairRoomEntryModal {
 
 const PairRoomEntryModal = ({ isOpen, closeModal }: PairRoomEntryModal) => {
   const navigate = useNavigate();
-  const { addToast } = useToastStore();
 
+  const { addToast } = useToastStore();
   const { value, status, message, handleChange } = useInput();
 
-  const { refetch } = useGetPairRoom(value);
-
   const enterPairRoom = async () => {
-    const { error, isFetching, isSuccess } = await refetch();
+    const { exists } = await getPairRoomExists(value);
 
-    if (error) {
-      addToast({ status: 'ERROR', message: '해당 코드와 일치하는 방이 없습니다 🥹' });
+    if (!exists) {
+      addToast({ status: 'ERROR', message: '해당 코드와 일치하는 방이 없습니다.' });
       return;
     }
 
-    if (!isFetching && isSuccess) {
-      navigate(`/room/${value}`);
-    }
+    navigate(`/room/${value}`);
   };
 
   return (
@@ -55,7 +51,7 @@ const PairRoomEntryModal = ({ isOpen, closeModal }: PairRoomEntryModal) => {
         <Button onClick={closeModal} filled={false}>
           {BUTTON_TEXT.CLOSE}
         </Button>
-        <Button disabled={!value} onClick={() => enterPairRoom()}>
+        <Button disabled={!value} onClick={enterPairRoom}>
           {BUTTON_TEXT.COMPLETE}
         </Button>
       </Modal.Footer>

--- a/frontend/src/components/PairRoom/ReferenceCard/AddReferenceForm/AddReferenceForm.tsx
+++ b/frontend/src/components/PairRoom/ReferenceCard/AddReferenceForm/AddReferenceForm.tsx
@@ -47,7 +47,7 @@ const AddReferenceForm = ({ accessCode, categories, getCategoryNameById, isCateg
           type="submit"
           size="sm"
           rounded={true}
-          disabled={value === '' || status !== 'DEFAULT'}
+          disabled={value.trim() === '' || status !== 'DEFAULT'}
         >
           <LuPlus size="1.6rem" />
         </Button>

--- a/frontend/src/components/PairRoom/ReferenceCard/CategoryManagementModal/CategoryManagementModal.tsx
+++ b/frontend/src/components/PairRoom/ReferenceCard/CategoryManagementModal/CategoryManagementModal.tsx
@@ -82,7 +82,7 @@ const CategoryManagementModal = ({
             type="submit"
             size="sm"
             rounded={true}
-            disabled={value === '' || status !== 'DEFAULT'}
+            disabled={value.trim() === '' || status !== 'DEFAULT'}
           >
             <LuPlus size="1.6rem" />
           </Button>

--- a/frontend/src/components/PairRoom/TodoListCard/TodoListCard.tsx
+++ b/frontend/src/components/PairRoom/TodoListCard/TodoListCard.tsx
@@ -46,7 +46,7 @@ const TodoListCard = ({ isOpen, toggleIsOpen }: TodoListCardProps) => {
                 maxLength={100}
                 placeholder="할 일의 내용을 입력해 주세요."
               />
-              <Button css={S.buttonStyles} type="submit" size="sm" rounded={true} disabled={value === ''}>
+              <Button css={S.buttonStyles} type="submit" size="sm" rounded={true} disabled={value.trim() === ''}>
                 <LuPlus size="1.6rem" />
               </Button>
             </S.Form>

--- a/frontend/src/pages/PairRoom/PairRoom.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.tsx
@@ -9,7 +9,7 @@ import ReferenceCard from '@/components/PairRoom/ReferenceCard/ReferenceCard';
 import TimerCard from '@/components/PairRoom/TimerCard/TimerCard';
 import TodoListCard from '@/components/PairRoom/TodoListCard/TodoListCard';
 
-import { getPairRoom } from '@/apis/pairRoom';
+import { getPairRoomExists } from '@/apis/pairRoom';
 
 import useGetPairRoom from '@/queries/PairRoom/useGetPairRoom';
 import useUpdatePairRoom from '@/queries/PairRoom/useUpdatePairRoom';
@@ -18,18 +18,15 @@ import * as S from './PairRoom.styles';
 
 const PairRoom = () => {
   const navigate = useNavigate();
-
   const { accessCode } = useParams();
 
   useEffect(() => {
     const checkPairRoomExists = async () => {
-      if (!accessCode) return navigate('/404');
+      if (!accessCode) navigate('/error');
 
-      try {
-        await getPairRoom(accessCode);
-      } catch (error) {
-        navigate('/404');
-      }
+      const { exists } = await getPairRoomExists(accessCode || '');
+
+      if (!exists) navigate('/error');
     };
 
     checkPairRoomExists();

--- a/frontend/src/pages/SignUp/SignUp.styles.ts
+++ b/frontend/src/pages/SignUp/SignUp.styles.ts
@@ -1,13 +1,17 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+
+export const buttonStyles = css`
+  font-size: ${({ theme }) => theme.fontSize.md};
+`;
 
 export const Layout = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2rem;
+  gap: 6rem;
 
   height: calc(100vh - 7rem);
-  padding: 20px;
+  padding: 15rem 5rem;
 
   background-color: ${({ theme }) => theme.color.black[20]};
 `;
@@ -15,28 +19,17 @@ export const Layout = styled.div`
 export const LogoIconWithTitle = styled.img`
   width: 30rem;
   max-width: 40rem;
-  margin: 5rem;
+`;
+
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3.6rem;
 `;
 
 export const Title = styled.h1`
-  margin-bottom: 2rem;
-
   color: ${({ theme }) => theme.color.primary[800]};
   font-size: ${({ theme }) => theme.fontSize.h5};
-  font-weight: ${({ theme }) => theme.fontWeight.bold};
-`;
-
-export const InputWrapper = styled.div`
-  width: 100%;
-  max-width: 40rem;
-  margin-bottom: 2rem;
-`;
-
-export const ButtonWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  width: 100%;
-  max-width: 40rem;
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
 `;

--- a/frontend/src/pages/SignUp/SignUp.tsx
+++ b/frontend/src/pages/SignUp/SignUp.tsx
@@ -37,25 +37,29 @@ const SignUp = () => {
     onUsernameChange(event, validateName(event.target.value));
   };
 
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    handleSignUp(username);
+  };
+
   return (
     <S.Layout>
       <S.LogoIconWithTitle src={LogoIconWithTitle} alt="logo_icon_with_title" />
-      <S.Title>첫 방문이시네요! 당신을 어떻게 불러야 할까요?</S.Title>
-      <S.InputWrapper>
+      <S.Form onSubmit={handleSubmit}>
+        <S.Title>첫 방문이시네요! 당신을 어떻게 불러야 할까요?</S.Title>
         <Input
           value={username}
           status={usernameStatus}
           message={usernameMessage}
+          width="50rem"
           title="이름(또는 닉네임)"
           placeholder="이름(또는 닉네임)을 입력해주세요."
           onChange={handleChange}
         />
-      </S.InputWrapper>
-      <S.ButtonWrapper>
-        <Button size="lg" rounded={true} onClick={() => handleSignUp(username)}>
+        <Button css={S.buttonStyles} type="submit" size="lg" disabled={validateName(username).status === 'ERROR'}>
           계정 만들기 🥳
         </Button>
-      </S.ButtonWrapper>
+      </S.Form>
     </S.Layout>
   );
 };


### PR DESCRIPTION
## 연관된 이슈

- closes: #717 

## 구현한 기능
- [x] 페어룸 존재 여부 확인 API `getPairRoomExists` 함수를 연동하여 페어룸에 참가할 때 페어룸 존재 여부에 따라 핸들링하도록 변경했습니다.
- [x] 투두 리스트, 레퍼런스 링크, 레퍼런스 카테고리 입력 시 공백만 입력해도 버튼이 활성화되던 버그를 해결했습니다.
- [x] 계정 만들기 시 유효성 검사에 어긋나도 폼이 제출되는 버그를 해결했습니다.
- [x] 계정 만들기 시 버튼으로 폼을 제출할 수 있도록 변경했습니다.
