### PR TITLE
[FE] Header가 항상 화면 최상단에 보이도록 수정

### DIFF
--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -50,7 +50,7 @@ export const Logo = styled.img`
 
 export const LinkContainer = styled.div`
   display: flex;
-  justify-content: space-between;
+  justify-content: space-evenly;
   align-items: center;
   gap: 1.4rem;
 `;

--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -2,19 +2,21 @@ import styled from 'styled-components';
 
 export const Layout = styled.div`
   display: flex;
-  position: fixed;
   justify-content: space-between;
   align-items: center;
+
+  position: fixed;
+  z-index: 99;
+
   width: 100%;
   height: 7rem;
   padding: 0 5rem;
 
-  z-index: 99;
-
-  border-bottom: 0.1rem solid ${({ theme }) => theme.color.black[30]};
   background-color: ${({ theme }) => theme.color.black[10]};
   color: ${({ theme }) => theme.color.black[80]};
   font-size: ${({ theme }) => theme.fontSize.base};
+
+  border-bottom: 0.1rem solid ${({ theme }) => theme.color.black[30]};
 
   a {
     display: flex;

--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -2,14 +2,17 @@ import styled from 'styled-components';
 
 export const Layout = styled.div`
   display: flex;
+  position: fixed;
   justify-content: space-between;
   align-items: center;
-
+  width: 100%;
   height: 7rem;
   padding: 0 5rem;
 
-  border-bottom: 0.1rem solid ${({ theme }) => theme.color.black[30]};
+  z-index: 99;
 
+  border-bottom: 0.1rem solid ${({ theme }) => theme.color.black[30]};
+  background-color: ${({ theme }) => theme.color.black[10]};
   color: ${({ theme }) => theme.color.black[80]};
   font-size: ${({ theme }) => theme.fontSize.base};
 

--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -26,7 +26,7 @@ const Header = () => {
       </Link>
       <S.LinkContainer>
         <Link to="/coduo-docs">
-          <S.HowToPairText>코딩해듀오 시작하기</S.HowToPairText>
+          <button>코딩해듀오 시작하기</button>
         </Link>
         <Link to="/coduo-docs">
           <S.HowToPairIcon>

--- a/frontend/src/hooks/common/useHashScroll.ts
+++ b/frontend/src/hooks/common/useHashScroll.ts
@@ -52,7 +52,15 @@ const useHashScroll = () => {
     if (location.hash) {
       const element = document.getElementById(currentHash);
       if (element) {
-        element.scrollIntoView({ behavior: 'smooth' });
+        const headerHeight = 70;
+        const marginTop = 50;
+        const elementPosition = element.getBoundingClientRect().top + window.scrollY;
+        const offsetPosition = elementPosition - headerHeight - marginTop;
+
+        window.scrollTo({
+          top: offsetPosition,
+          behavior: 'smooth',
+        });
       }
     }
   }, [location, currentHash]);

--- a/frontend/src/pages/Layout.styles.ts
+++ b/frontend/src/pages/Layout.styles.ts
@@ -6,3 +6,7 @@ export const Layout = styled.div`
 
   min-width: fit-content;
 `;
+
+export const Main = styled.main`
+  margin-top: 7rem;
+`;

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -9,9 +9,9 @@ const Layout = () => {
   return (
     <S.Layout>
       <Header />
-      <main>
+      <S.Main>
         <Outlet />
-      </main>
+      </S.Main>
       <ToastList />
     </S.Layout>
   );


### PR DESCRIPTION
## 연관된 이슈

- closes: #743 

## 구현한 기능

https://github.com/user-attachments/assets/8386e16f-4097-4e22-8669-b73906fbe651


## 상세 설명
Header가 항상 화면 최상단에 보이도록 수정했습니다.
추가적으로, 로그인 시 헤더 각 버튼의 간격이 달라지던 문제를 해결했습니다.