### PR TITLE
[BE] 회원 탈퇴 API 추가

### DIFF
--- a/backend/src/main/java/site/coduo/member/controller/MemberController.java
+++ b/backend/src/main/java/site/coduo/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import static site.coduo.common.config.web.filter.SignInCookieFilter.SIGN_IN_COO
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,11 +20,17 @@ public class MemberController implements MemberControllerDocs {
     private final MemberService memberService;
 
     @GetMapping("/member")
-    public ResponseEntity<MemberReadResponse> getMember(
-            @CookieValue(SIGN_IN_COOKIE_NAME) final String token
-    ) {
+    public ResponseEntity<MemberReadResponse> getMember(@CookieValue(SIGN_IN_COOKIE_NAME) final String token) {
         final MemberReadResponse response = memberService.findMemberNameByCredential(token);
 
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/member")
+    public ResponseEntity<Void> deleteMember(@CookieValue(SIGN_IN_COOKIE_NAME) final String token) {
+        memberService.deleteMember(token);
+
+        return ResponseEntity.noContent()
+                .build();
     }
 }

--- a/backend/src/main/java/site/coduo/member/controller/docs/MemberControllerDocs.java
+++ b/backend/src/main/java/site/coduo/member/controller/docs/MemberControllerDocs.java
@@ -29,4 +29,14 @@ public interface MemberControllerDocs {
                     schema = @Schema(type = "string")
             )
             String token);
+
+    @ApiResponse(responseCode = "204", description = "회원 정보를 삭제한다.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+    ResponseEntity<Void> deleteMember(
+            @Parameter(
+                    in = ParameterIn.COOKIE,
+                    name = "coduo_whoami",
+                    description = "사용자가 인증에 성공하면 서버에서 발급하는 쿠키",
+                    schema = @Schema(type = "string")
+            ) String token);
 }

--- a/backend/src/main/java/site/coduo/member/domain/Member.java
+++ b/backend/src/main/java/site/coduo/member/domain/Member.java
@@ -1,5 +1,6 @@
 package site.coduo.member.domain;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 import jakarta.persistence.Column;
@@ -8,6 +9,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+
+import org.springframework.format.annotation.DateTimeFormat;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -41,14 +44,19 @@ public class Member extends BaseTimeEntity {
     @Column(name = "USER_NAME")
     private String username;
 
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @Column(name = "DELETED_AT")
+    private LocalDateTime deletedAt;
+
     @Builder
     private Member(final String accessToken, final String loginId, final String userId, final String profileImage,
-                   final String username) {
+                   final String username, final LocalDateTime deletedAt) {
         this.accessToken = accessToken;
         this.loginId = loginId;
         this.userId = userId;
         this.profileImage = profileImage;
         this.username = username;
+        this.deletedAt = deletedAt;
     }
 
     public void update(final Member other) {
@@ -57,6 +65,15 @@ public class Member extends BaseTimeEntity {
         this.userId = other.userId;
         this.profileImage = other.profileImage;
         this.username = other.username;
+        this.deletedAt = other.deletedAt;
+    }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
     }
 
     @Override

--- a/backend/src/main/java/site/coduo/member/domain/repository/MemberRepository.java
+++ b/backend/src/main/java/site/coduo/member/domain/repository/MemberRepository.java
@@ -5,10 +5,16 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import site.coduo.member.domain.Member;
+import site.coduo.member.exception.MemberNotFoundException;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByUserId(String userId);
+
+    default Member fetchByUserId(final String userId) {
+        return findByUserId(userId)
+                .orElseThrow(() -> new MemberNotFoundException(String.format("%s는 찾을 수 없는 회원 아이디입니다.", userId)));
+    }
 
     boolean existsByUserId(String userId);
 

--- a/backend/src/main/java/site/coduo/member/domain/repository/MemberRepository.java
+++ b/backend/src/main/java/site/coduo/member/domain/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package site.coduo.member.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,9 +12,20 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByUserId(String userId);
 
+    List<Member> findByDeletedAtIsNull();
+
+    @Override
+    default List<Member> findAll() {
+        return findByDeletedAtIsNull();
+    }
+
     default Member fetchByUserId(final String userId) {
-        return findByUserId(userId)
+        final Member member = findByUserId(userId)
                 .orElseThrow(() -> new MemberNotFoundException(String.format("%s는 찾을 수 없는 회원 아이디입니다.", userId)));
+        if (member.isDeleted()) {
+            throw new MemberNotFoundException(String.format("%s는 삭제된 회원입니다.", userId));
+        }
+        return member;
     }
 
     boolean existsByUserId(String userId);

--- a/backend/src/main/java/site/coduo/member/service/MemberService.java
+++ b/backend/src/main/java/site/coduo/member/service/MemberService.java
@@ -51,6 +51,6 @@ public class MemberService {
         final String userId = jwtProvider.extractSubject(token);
         final Member member = memberRepository.fetchByUserId(userId);
 
-        memberRepository.delete(member);
+        member.delete();
     }
 }

--- a/backend/src/main/java/site/coduo/member/service/MemberService.java
+++ b/backend/src/main/java/site/coduo/member/service/MemberService.java
@@ -10,7 +10,6 @@ import site.coduo.member.client.dto.GithubUserRequest;
 import site.coduo.member.client.dto.GithubUserResponse;
 import site.coduo.member.domain.Member;
 import site.coduo.member.domain.repository.MemberRepository;
-import site.coduo.member.exception.MemberNotFoundException;
 import site.coduo.member.infrastructure.http.Bearer;
 import site.coduo.member.infrastructure.security.JwtProvider;
 import site.coduo.member.service.dto.member.MemberReadResponse;
@@ -36,23 +35,21 @@ public class MemberService {
 
     public MemberReadResponse findMemberNameByCredential(final String token) {
         final String userId = jwtProvider.extractSubject(token);
-        final Member member = memberRepository.findByUserId(userId)
-                .orElseThrow(() -> new MemberNotFoundException(String.format("%s는 찾을 수 없는 회원 아이디입니다.", userId)));
+        final Member member = memberRepository.fetchByUserId(userId);
 
         return new MemberReadResponse(member.getUsername());
     }
 
     public Member findMemberByCredential(final String token) {
         final String userId = jwtProvider.extractSubject(token);
-        return memberRepository.findByUserId(userId)
-                .orElseThrow(() -> new MemberNotFoundException(String.format("%s는 찾을 수 없는 회원 아이디입니다.", userId)));
+
+        return memberRepository.fetchByUserId(userId);
     }
 
     @Transactional
     public void deleteMember(final String token) {
         final String userId = jwtProvider.extractSubject(token);
-        final Member member = memberRepository.findByUserId(userId)
-                .orElseThrow(() -> new MemberNotFoundException(String.format("%s는 찾을 수 없는 회원 아이디입니다.", userId)));
+        final Member member = memberRepository.fetchByUserId(userId);
 
         memberRepository.delete(member);
     }

--- a/backend/src/main/java/site/coduo/member/service/MemberService.java
+++ b/backend/src/main/java/site/coduo/member/service/MemberService.java
@@ -47,4 +47,13 @@ public class MemberService {
         return memberRepository.findByUserId(userId)
                 .orElseThrow(() -> new MemberNotFoundException(String.format("%s는 찾을 수 없는 회원 아이디입니다.", userId)));
     }
+
+    @Transactional
+    public void deleteMember(final String token) {
+        final String userId = jwtProvider.extractSubject(token);
+        final Member member = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new MemberNotFoundException(String.format("%s는 찾을 수 없는 회원 아이디입니다.", userId)));
+
+        memberRepository.delete(member);
+    }
 }

--- a/backend/src/test/java/site/coduo/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/MemberAcceptanceTest.java
@@ -50,6 +50,33 @@ class MemberAcceptanceTest extends AcceptanceFixture {
                 .body("username", is(member.getUsername()));
     }
 
+    @Test
+    @DisplayName("회원을 삭제한다.")
+    void delete_member() {
+        //given
+        final Member member = Member.builder()
+                .userId("123")
+                .accessToken("access")
+                .loginId("login")
+                .username("username")
+                .profileImage("some image")
+                .build();
+
+        final String loginToken = jwtProvider.sign(member.getUserId());
+        memberRepository.save(member);
+
+        //when && then
+        RestAssured
+                .given()
+                .cookie(SIGN_IN_COOKIE_NAME, loginToken)
+
+                .when()
+                .delete("/api/member")
+
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
     String login(Member member) {
         final String sessionId = GithubAcceptanceTest.createAccessTokenCookie();
 

--- a/backend/src/test/java/site/coduo/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/MemberAcceptanceTest.java
@@ -76,20 +76,4 @@ class MemberAcceptanceTest extends AcceptanceFixture {
                 .then()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
     }
-
-    String login(Member member) {
-        final String sessionId = GithubAcceptanceTest.createAccessTokenCookie();
-
-        memberRepository.save(member);
-
-        return RestAssured
-                .given()
-                .cookie("JSESSIONID", sessionId)
-
-                .when()
-                .get("/api/sign-in/callback")
-
-                .thenReturn()
-                .cookie("coudo_whoami");
-    }
 }

--- a/backend/src/test/java/site/coduo/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/MemberAcceptanceTest.java
@@ -76,4 +76,41 @@ class MemberAcceptanceTest extends AcceptanceFixture {
                 .then()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
     }
+
+    @Test
+    @DisplayName("존재하지 않는 회원을 삭제한다.")
+    void delete_not_member() {
+        //given
+        final Member member = Member.builder()
+                .userId("123")
+                .accessToken("access")
+                .loginId("login")
+                .username("username")
+                .profileImage("some image")
+                .build();
+
+        final String loginToken = jwtProvider.sign(member.getUserId());
+        memberRepository.save(member);
+
+        //when && then
+        RestAssured
+                .given()
+                .cookie(SIGN_IN_COOKIE_NAME, loginToken)
+
+                .when()
+                .delete("/api/member")
+
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        RestAssured
+                .given()
+                .cookie(SIGN_IN_COOKIE_NAME, loginToken)
+
+                .when()
+                .delete("/api/member")
+
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND);
+    }
 }

--- a/backend/src/test/java/site/coduo/acceptance/ReferenceAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/ReferenceAcceptanceTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.transaction.annotation.Transactional;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -18,8 +17,8 @@ import site.coduo.pairroom.service.dto.PairRoomCreateRequest;
 import site.coduo.pairroom.service.dto.PairRoomCreateResponse;
 import site.coduo.referencelink.service.dto.CategoryCreateRequest;
 import site.coduo.referencelink.service.dto.CategoryCreateResponse;
+import site.coduo.referencelink.service.dto.ReferenceLinkResponse;
 
-@Transactional
 class ReferenceAcceptanceTest extends AcceptanceFixture {
 
     @Test
@@ -101,18 +100,22 @@ class ReferenceAcceptanceTest extends AcceptanceFixture {
                 .body("[0].image", is(""));
     }
 
-    void createReferenceLink(final String url, String accessCodeText, String categoryName) {
+    ReferenceLinkResponse createReferenceLink(final String url, String accessCodeText, String categoryName) {
         final CategoryCreateResponse response = CategoryAcceptanceTest.createCategory(
                 accessCodeText, new CategoryCreateRequest(categoryName));
         final Map<String, Object> request = Map.of("url", url, "categoryId", response.id());
 
-        RestAssured
+        return RestAssured
                 .given()
                 .contentType(ContentType.JSON)
                 .body(request)
 
                 .when()
-                .post("/api/" + accessCodeText + "/reference-link");
+                .post("/api/" + accessCodeText + "/reference-link")
+
+                .then()
+                .extract()
+                .as(ReferenceLinkResponse.class);
     }
 
     @Test
@@ -122,7 +125,8 @@ class ReferenceAcceptanceTest extends AcceptanceFixture {
         final PairRoomCreateResponse pairRoom =
                 createPairRoom(new PairRoomCreateRequest("레모네", "프람", 1000L, 1000L, "IN_PROGRESS"));
 
-        createReferenceLink("http://www.delete.com", pairRoom.accessCode(), "카테고리 이름");
+        final ReferenceLinkResponse response = createReferenceLink("http://www.delete.com", pairRoom.accessCode(),
+                "카테고리 이름");
 
         // when & then
         RestAssured
@@ -131,7 +135,7 @@ class ReferenceAcceptanceTest extends AcceptanceFixture {
 
                 .when()
                 .log().all()
-                .delete("/api/" + pairRoom.accessCode() + "/reference-link/1")
+                .delete("/api/" + pairRoom.accessCode() + "/reference-link/" + response.id())
 
                 .then()
                 .assertThat()

--- a/backend/src/test/java/site/coduo/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/site/coduo/member/service/MemberServiceTest.java
@@ -2,6 +2,8 @@ package site.coduo.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -88,5 +90,29 @@ class MemberServiceTest {
 
         // then
         assertThat(findMember.getUsername()).isEqualTo(member.getUsername());
+    }
+
+    @Test
+    @DisplayName("회원을 삭제한다.")
+    void delete_member() {
+        // given
+        final Member member = Member.builder()
+                .userId("userid")
+                .accessToken("access")
+                .loginId("login")
+                .username("username")
+                .profileImage("some image")
+                .build();
+        final String token = jwtProvider.sign(member.getUserId());
+
+        memberRepository.save(member);
+        final List<Member> beforeDelete = memberRepository.findAll();
+
+        // when
+        memberService.deleteMember(token);
+
+        //then
+        final List<Member> afterDelete = memberRepository.findAll();
+        assertThat(afterDelete).hasSize(beforeDelete.size() - 1);
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- closes: #748 

## 구현한 기능

회원 탈퇴 API를 추가하였습니다.

## 상세 설명

물리 삭제와 논리 삭제를 고민하다가 논리 삭제로 하기로 정했습니다. 


이유1. 회원을 탈퇴하면 그 회원이 만든 페어룸과 투두, 링크들도 같이 삭제해야 합니다. 각 테이블이 연관관계를 가지고 있기 때문에 member 테이블에서 삭제하기 전에 지우려는 회원 아이디로 만든 페어룸부터 그 페어룸에서 만들어진 투두, 링크들을 삭제 해줘야 하는데, 그렇게 된다면 같이 페어 프로그래밍 했던 아직 탈퇴하지 않은 회원에게도 삭제되어 버려 볼 수 없게 됩니다

이유2. 삭제 쿼리보다 변경 쿼리가 속도가 더 빠릅니다. 

