### PR TITLE
[BE] sse connection 끊어질 때 발생하는 에러 로그 삭제

### DIFF
--- a/backend/src/main/java/site/coduo/sync/service/SseEventStream.java
+++ b/backend/src/main/java/site/coduo/sync/service/SseEventStream.java
@@ -60,8 +60,7 @@ public class SseEventStream implements EventStream {
                     .name(name)
                     .data(message)
             );
-        } catch (final IOException e) {
-            log.warn("SSE 통신 중 에러가 발생했습니다.");
+        } catch (final IOException ignored) {
         }
     }
 


### PR DESCRIPTION
## 연관된 이슈

- closes: #761 

## 상세 설명
sse connection이 생성된 페어룸이 띄워진 브라우저를 종료하면 broken pipe 에러가 발생합니다.
그럼 브라우저가 종료될 때마다 에러 로그가 찍히는데, 좋은 정보를 주는 로그라는 생각이 들지 않아 삭제해 주었습니다.