### PR TITLE
[FE] 페어룸 추가 안내 모달 구현

### DIFF
--- a/frontend/.stylelintrc
+++ b/frontend/.stylelintrc
@@ -59,6 +59,7 @@
           "padding-bottom",
           "padding-left",
           "border",
+          "border-color",
           "border-radius"
         ]
       },

--- a/frontend/src/components/PairRoom/GuideModal/GuideModal.styles.ts
+++ b/frontend/src/components/PairRoom/GuideModal/GuideModal.styles.ts
@@ -1,0 +1,87 @@
+import styled, { css } from 'styled-components';
+
+export const buttonStyles = css`
+  width: 9rem;
+  height: 3.2rem;
+  border-color: ${({ theme }) => theme.color.danger[400]};
+  border-radius: 0.8rem;
+
+  background-color: ${({ theme }) => theme.color.danger[400]};
+  font-size: ${({ theme }) => theme.fontSize.md};
+
+  &:hover {
+    border-color: ${({ theme }) => theme.color.danger[500]};
+
+    background-color: ${({ theme }) => theme.color.danger[500]};
+  }
+
+  &:active {
+    border-color: ${({ theme }) => theme.color.danger[500]};
+
+    background-color: ${({ theme }) => theme.color.danger[500]};
+  }
+`;
+
+export const startButtonStyles = css`
+  width: 18rem;
+`;
+
+export const Layout = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+
+  padding: 1rem 0;
+`;
+
+export const Title = styled.h2`
+  font-size: ${({ theme }) => theme.fontSize.h5};
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
+`;
+
+export const List = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+`;
+
+export const Item = styled.li`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+export const Question = styled.p`
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+
+  font-size: ${({ theme }) => theme.fontSize.base};
+`;
+
+export const Description = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+
+  height: 5.2rem;
+  padding: 1rem 1rem 1rem 1.6rem;
+  border-radius: 1rem;
+
+  background-color: ${({ theme }) => theme.color.danger[100]};
+  font-size: ${({ theme }) => theme.fontSize.md};
+  font-weight: ${({ theme }) => theme.fontWeight.light};
+`;
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.8rem;
+
+  p {
+    color: ${({ theme }) => theme.color.black[60]};
+    font-size: ${({ theme }) => theme.fontSize.sm};
+  }
+`;

--- a/frontend/src/components/PairRoom/GuideModal/GuideModal.tsx
+++ b/frontend/src/components/PairRoom/GuideModal/GuideModal.tsx
@@ -1,0 +1,94 @@
+import { useRef } from 'react';
+
+import { FaCheck } from 'react-icons/fa6';
+
+import { AlarmSound } from '@/assets';
+
+import Button from '@/components/common/Button/Button';
+import { Modal } from '@/components/common/Modal';
+
+import useToastStore from '@/stores/toastStore';
+
+import useCopyClipBoard from '@/hooks/common/useCopyClipboard';
+
+import * as S from './GuideModal.styles';
+
+interface GuideModalProps {
+  isOpen: boolean;
+  close: () => void;
+  accessCode: string;
+}
+
+const GuideModal = ({ isOpen, close, accessCode }: GuideModalProps) => {
+  const alarmAudio = useRef(new Audio(AlarmSound));
+
+  const { addToast } = useToastStore();
+
+  const [, onCopy] = useCopyClipBoard();
+
+  const checkPermission = () => {
+    if (Notification.permission !== 'granted') {
+      addToast({ status: 'ERROR', message: '알림 권한이 허용되지 않았습니다. 설정에서 권한을 허용해 주세요.' });
+      return;
+    }
+
+    addToast({ status: 'SUCCESS', message: '알림 권한이 허용된 상태입니다.' });
+  };
+
+  return (
+    <Modal isOpen={isOpen} close={close} size="70rem">
+      <Modal.CloseButton close={close} />
+      <S.Layout>
+        <S.Title>페어 프로그래밍을 시작하기 전에...</S.Title>
+        <S.List>
+          <S.Item>
+            <S.Question>
+              <FaCheck />
+              브라우저 알림을 허용하셨나요?
+            </S.Question>
+            <S.Description>
+              브라우저 알림을 허용하지 않으면 타이머 종료 시 올바르게 알림을 제공할 수 없어요.
+              <Button css={S.buttonStyles} onClick={checkPermission}>
+                권한 확인
+              </Button>
+            </S.Description>
+          </S.Item>
+          <S.Item>
+            <S.Question>
+              <FaCheck />
+              사용 중인 기기의 소리가 켜져 있나요?
+            </S.Question>
+            <S.Description>
+              사용 중인 기기의 소리가 꺼져 있다면 타이머 종료 시 알람 소리를 들으실 수 없어요.
+              <Button css={S.buttonStyles} onClick={() => alarmAudio.current.play()}>
+                소리 확인
+              </Button>
+            </S.Description>
+          </S.Item>
+          <S.Item>
+            <S.Question>
+              <FaCheck />
+              페어룸 코드를 복사하셨나요?
+            </S.Question>
+            <S.Description>
+              페어에게 페어룸 코드를 전달하여 페어룸에 들어올 수 있도록 해주세요.
+              <Button css={S.buttonStyles} onClick={() => onCopy(accessCode)}>
+                코드 복사
+              </Button>
+            </S.Description>
+          </S.Item>
+        </S.List>
+        <Modal.Footer position="CENTER">
+          <S.ButtonContainer>
+            <p>모두 확인하셨나요?</p>
+            <Button css={S.startButtonStyles} onClick={close}>
+              시작하기
+            </Button>
+          </S.ButtonContainer>
+        </Modal.Footer>
+      </S.Layout>
+    </Modal>
+  );
+};
+
+export default GuideModal;

--- a/frontend/src/components/common/Tooltip/Tooltip.styles.ts
+++ b/frontend/src/components/common/Tooltip/Tooltip.styles.ts
@@ -52,8 +52,9 @@ const directionStyle = (direction: Direction, color: string) => {
           top: 100%;
           left: 50%;
 
-          transform: translateX(-50%);
           border-color: ${color} transparent transparent transparent;
+
+          transform: translateX(-50%);
         }
       `;
     case 'bottom':
@@ -68,8 +69,9 @@ const directionStyle = (direction: Direction, color: string) => {
           bottom: 100%;
           left: 50%;
 
-          transform: translateX(-50%);
           border-color: transparent transparent ${color} transparent;
+
+          transform: translateX(-50%);
         }
       `;
     case 'left':
@@ -84,8 +86,9 @@ const directionStyle = (direction: Direction, color: string) => {
           top: 50%;
           left: 100%;
 
-          transform: translateY(-50%);
           border-color: transparent transparent transparent ${color};
+
+          transform: translateY(-50%);
         }
       `;
     case 'right':
@@ -100,8 +103,9 @@ const directionStyle = (direction: Direction, color: string) => {
           top: 50%;
           right: 100%;
 
-          transform: translateY(-50%);
           border-color: transparent ${color} transparent transparent;
+
+          transform: translateY(-50%);
         }
       `;
   }

--- a/frontend/src/pages/PairRoom/PairRoom.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import Loading from '@/pages/Loading/Loading';
 
+import GuideModal from '@/components/PairRoom/GuideModal/GuideModal';
 import PairListCard from '@/components/PairRoom/PairListCard/PairListCard';
 import PairRoleCard from '@/components/PairRoom/PairRoleCard/PairRoleCard';
 import ReferenceCard from '@/components/PairRoom/ReferenceCard/ReferenceCard';
@@ -10,6 +11,8 @@ import TimerCard from '@/components/PairRoom/TimerCard/TimerCard';
 import TodoListCard from '@/components/PairRoom/TodoListCard/TodoListCard';
 
 import { getPairRoomExists } from '@/apis/pairRoom';
+
+import useModal from '@/hooks/common/useModal';
 
 import useGetPairRoom from '@/queries/PairRoom/useGetPairRoom';
 import useUpdatePairRoom from '@/queries/PairRoom/useUpdatePairRoom';
@@ -51,6 +54,8 @@ const PairRoom = () => {
 
   const [isCardOpen, setIsCardOpen] = useState(false);
 
+  const { isModalOpen, closeModal } = useModal(true);
+
   if (isFetching) {
     return <Loading />;
   }
@@ -71,6 +76,7 @@ const PairRoom = () => {
         <TodoListCard isOpen={!isCardOpen} toggleIsOpen={() => setIsCardOpen(false)} />
         <ReferenceCard accessCode={accessCode || ''} isOpen={isCardOpen} toggleIsOpen={() => setIsCardOpen(true)} />
       </S.Container>
+      <GuideModal isOpen={isModalOpen} close={closeModal} accessCode={accessCode || ''} />
     </S.Layout>
   );
 };


### PR DESCRIPTION
## 연관된 이슈

- closes: #755 

## 구현한 기능
- [x] 페어룸에 진입했을 때 추가 안내를 제공하여 사용자로 하여금 인지할 수 있는 기회를 제공한다.

## 상세 설명
> <img width="849" alt="스크린샷 2024-10-11 오후 5 28 26" src="https://github.com/user-attachments/assets/ebcd8dfd-7a86-4d89-b343-786677b368b4">

- 위와 같은 디자인으로 페어룸 진입 시 추가 안내 모달을 1회 표시합니다.
- `권한 확인` 버튼을 클릭하면 토스트 메시지를 통해 브라우저 알림 권한이 허용되었는지 표시합니다.
- `소리 확인` 버튼을 클릭하면 타이머 종료 시 재생하는 알림음을 재생하여 소리가 켜졌는지 확인할 수 있도록 합니다.
- `코드 복사` 버튼을 클릭하면 클립보드에 페어룸 코드를 복사합니다.