### PR TITLE
[FE] 페어룸 내에서도 미션 리포지토리를 확인할 수 있도록 추가

### DIFF
--- a/frontend/src/apis/pairRoom.ts
+++ b/frontend/src/apis/pairRoom.ts
@@ -49,7 +49,7 @@ export const addPairRoom = async ({
 }: AddPairRoomRequest) => {
   const response = await fetcher.post({
     url: `${API_URL}/pair-room`,
-    body: JSON.stringify({ driver, navigator, missionUrl, timerDuration, timerRemainingTime, status: 'IN_PROGRESS' }),
+    body: JSON.stringify({ driver, navigator, missionUrl, timerDuration, timerRemainingTime }),
     errorMessage: '',
   });
 

--- a/frontend/src/apis/pairRoom.ts
+++ b/frontend/src/apis/pairRoom.ts
@@ -34,14 +34,21 @@ export const getPairRoomExists = async (accessCode: string): Promise<{ exists: b
 interface AddPairRoomRequest {
   driver: string;
   navigator: string;
+  missionUrl: string;
   timerDuration: number;
   timerRemainingTime: number;
 }
 
-export const addPairRoom = async ({ driver, navigator, timerDuration, timerRemainingTime }: AddPairRoomRequest) => {
+export const addPairRoom = async ({
+  driver,
+  navigator,
+  missionUrl,
+  timerDuration,
+  timerRemainingTime,
+}: AddPairRoomRequest) => {
   const response = await fetcher.post({
     url: `${API_URL}/pair-room`,
-    body: JSON.stringify({ driver, navigator, timerDuration, timerRemainingTime, status: 'IN_PROGRESS' }),
+    body: JSON.stringify({ driver, navigator, missionUrl, timerDuration, timerRemainingTime, status: 'IN_PROGRESS' }),
     errorMessage: '',
   });
 

--- a/frontend/src/apis/pairRoom.ts
+++ b/frontend/src/apis/pairRoom.ts
@@ -8,8 +8,9 @@ export type PairRoomStatus = 'IN_PROGRESS' | 'COMPLETED';
 
 export interface GetPairRoomResponse {
   id: number;
-  navigator: string;
   driver: string;
+  navigator: string;
+  missionUrl: string;
   status: PairRoomStatus;
 }
 

--- a/frontend/src/components/PairRoom/PairListCard/PairListCard.tsx
+++ b/frontend/src/components/PairRoom/PairListCard/PairListCard.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 // import DeleteButton from '@/components/PairRoom/PairListCard/DeleteButton/DeleteButton';
 import Header from '@/components/PairRoom/PairListCard/Header/Header';
 import PairListSection from '@/components/PairRoom/PairListCard/PairListSection/PairListSection';
+import RepositorySection from '@/components/PairRoom/PairListCard/RepositorySection/RepositorySection';
 import RoomCodeSection from '@/components/PairRoom/PairListCard/RoomCodeSection/RoomCodeSection';
 import { PairRoomCard } from '@/components/PairRoom/PairRoomCard';
 
@@ -11,11 +12,12 @@ import * as S from './PairListCard.styles';
 interface PairListCardProps {
   driver: string;
   navigator: string;
+  missionUrl: string;
   roomCode: string;
   onRoomDelete?: () => void;
 }
 
-const PairListCard = ({ driver, navigator, roomCode }: PairListCardProps) => {
+const PairListCard = ({ driver, navigator, missionUrl, roomCode }: PairListCardProps) => {
   const [isOpen, setIsOpen] = useState(true);
 
   const toggleOpen = () => setIsOpen(!isOpen);
@@ -26,6 +28,7 @@ const PairListCard = ({ driver, navigator, roomCode }: PairListCardProps) => {
         <Header isOpen={isOpen} toggleOpen={toggleOpen} />
         <S.Sidebar>
           <RoomCodeSection isOpen={isOpen} roomCode={roomCode} />
+          {missionUrl !== '' && <RepositorySection isOpen={isOpen} missionUrl={missionUrl} />}
           <PairListSection isOpen={isOpen} driver={driver} navigator={navigator} />
           {/* <DeleteButton isOpen={isOpen} onRoomDelete={onRoomDelete} /> */}
         </S.Sidebar>

--- a/frontend/src/components/PairRoom/PairListCard/RepositorySection/RepositorySection.styles.ts
+++ b/frontend/src/components/PairRoom/PairListCard/RepositorySection/RepositorySection.styles.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+export const Layout = styled.div<{ $isOpen: boolean }>`
+  display: flex;
+  justify-content: ${({ $isOpen }) => ($isOpen ? 'space-between' : 'center')};
+  align-items: center;
+
+  width: 100%;
+  height: 6rem;
+  padding: 2rem;
+
+  background-color: ${({ theme }) => theme.color.black[80]};
+
+  transition: background-color 0.3s ease-out;
+
+  cursor: pointer;
+`;
+
+export const RepositoryWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.2rem;
+`;
+
+export const RepositoryText = styled.span`
+  height: 2rem;
+
+  color: ${({ theme }) => theme.color.black[10]};
+  font-size: ${({ theme }) => theme.fontSize.base};
+`;

--- a/frontend/src/components/PairRoom/PairListCard/RepositorySection/RepositorySection.styles.ts
+++ b/frontend/src/components/PairRoom/PairListCard/RepositorySection/RepositorySection.styles.ts
@@ -24,8 +24,6 @@ export const RepositoryWrapper = styled.div`
 `;
 
 export const RepositoryText = styled.span`
-  height: 2rem;
-
   color: ${({ theme }) => theme.color.black[10]};
-  font-size: ${({ theme }) => theme.fontSize.base};
+  font-size: ${({ theme }) => theme.fontSize.md};
 `;

--- a/frontend/src/components/PairRoom/PairListCard/RepositorySection/RepositorySection.tsx
+++ b/frontend/src/components/PairRoom/PairListCard/RepositorySection/RepositorySection.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom';
+
+import { IoIosArrowForward } from 'react-icons/io';
+
+import { GithubLogoWhite } from '@/assets';
+
+import * as S from './RepositorySection.styles';
+
+interface RepositorySectionProps {
+  isOpen: boolean;
+  missionUrl: string;
+}
+
+const RepositorySection = ({ isOpen, missionUrl }: RepositorySectionProps) => {
+  return (
+    <Link to={missionUrl} target="_blank">
+      <S.Layout $isOpen={isOpen}>
+        <img src={GithubLogoWhite} alt="" />
+        {isOpen && (
+          <S.RepositoryWrapper>
+            <S.RepositoryText>리포지토리로 이동</S.RepositoryText>
+            <IoIosArrowForward size="1.8rem" color="white" />
+          </S.RepositoryWrapper>
+        )}
+      </S.Layout>
+    </Link>
+  );
+};
+
+export default RepositorySection;

--- a/frontend/src/components/PairRoom/PairListCard/RepositorySection/RepositorySection.tsx
+++ b/frontend/src/components/PairRoom/PairListCard/RepositorySection/RepositorySection.tsx
@@ -18,8 +18,8 @@ const RepositorySection = ({ isOpen, missionUrl }: RepositorySectionProps) => {
         <img src={GithubLogoWhite} alt="" />
         {isOpen && (
           <S.RepositoryWrapper>
-            <S.RepositoryText>리포지토리로 이동</S.RepositoryText>
-            <IoIosArrowForward size="1.8rem" color="white" />
+            <S.RepositoryText>미션 리포지토리로 이동</S.RepositoryText>
+            <IoIosArrowForward size="1.6rem" color="white" />
           </S.RepositoryWrapper>
         )}
       </S.Layout>

--- a/frontend/src/components/PairRoomOnboarding/MissionSelectInput/MissionSelectInput.tsx
+++ b/frontend/src/components/PairRoomOnboarding/MissionSelectInput/MissionSelectInput.tsx
@@ -7,10 +7,10 @@ import useGetRepositories from '@/queries/PairRoomOnboarding/useGetRepositories'
 import * as S from './MissionSelectInput.styles';
 
 interface MissionSelectInputProps {
-  onRepositoryName: (repositoryName: string) => void;
+  onSelect: (repositoryName: string) => void;
 }
 
-const MissionSelectInput = ({ onRepositoryName }: MissionSelectInputProps) => {
+const MissionSelectInput = ({ onSelect }: MissionSelectInputProps) => {
   const { repositories, isFetching } = useGetRepositories();
 
   return (
@@ -31,12 +31,7 @@ const MissionSelectInput = ({ onRepositoryName }: MissionSelectInputProps) => {
         ) : (
           repositories.map((repository) => {
             return (
-              <RepositoryButton
-                key={repository.id}
-                id={repository.id}
-                name={repository.name}
-                onSelect={onRepositoryName}
-              />
+              <RepositoryButton key={repository.id} id={repository.id} name={repository.name} onSelect={onSelect} />
             );
           })
         )}

--- a/frontend/src/components/PairRoomOnboarding/MissionSettingSection/MissionSettingSection.tsx
+++ b/frontend/src/components/PairRoomOnboarding/MissionSettingSection/MissionSettingSection.tsx
@@ -4,29 +4,28 @@ import MissionSelectInput from '@/components/PairRoomOnboarding/MissionSelectInp
 
 import useDebounce from '@/hooks/common/useDebounce';
 import useAutoMoveIndex from '@/hooks/PairRoomOnboarding/useAutoMoveIndex';
-import usePairRoomMission from '@/hooks/PairRoomOnboarding/usePairRoomMission';
+import useMissionBranch from '@/hooks/PairRoomOnboarding/useMissionBranch';
 
 import * as S from './MissionSettingSection.styles';
 
 interface MissionSettingSectionProps {
+  repositoryName: string;
+  onRepositoryName: (repositoryName: string) => void;
   onCreateBranch: (repositoryName: string, branchName: string) => void;
 }
 
-const MissionSettingSection = ({ onCreateBranch }: MissionSettingSectionProps) => {
-  const {
-    repositoryName,
-    branchName,
-    isRepositorySelected,
-    isValidBranchName,
-    handleRepositoryName,
-    handleBranchName,
-  } = usePairRoomMission();
+const MissionSettingSection = ({ repositoryName, onRepositoryName, onCreateBranch }: MissionSettingSectionProps) => {
+  const { branchName, isValidBranchName, resetBranchName, handleBranchName } = useMissionBranch();
+  const { moveIndex } = useAutoMoveIndex(0, [repositoryName !== '', useDebounce(isValidBranchName, 500)]);
 
-  const { moveIndex } = useAutoMoveIndex(0, [isRepositorySelected, useDebounce(isValidBranchName, 500)]);
+  const handleSelectMission = (repositoryName: string) => {
+    onRepositoryName(repositoryName);
+    resetBranchName();
+  };
 
   return (
     <S.Layout>
-      <MissionSelectInput onRepositoryName={handleRepositoryName} />
+      <MissionSelectInput onSelect={handleSelectMission} />
       {moveIndex >= 1 && (
         <CreateBranchInput repositoryName={repositoryName} branchName={branchName} onBranchName={handleBranchName} />
       )}

--- a/frontend/src/components/PairRoomOnboarding/PairRoomSettingSection/PairRoomSettingSection.tsx
+++ b/frontend/src/components/PairRoomOnboarding/PairRoomSettingSection/PairRoomSettingSection.tsx
@@ -13,7 +13,11 @@ import { BUTTON_TEXT } from '@/constants/button';
 
 import * as S from './PairRoomSettingSection.styles';
 
-const PairRoomSettingSection = () => {
+interface PairRoomSettingSectionProps {
+  repositoryName: string;
+}
+
+const PairRoomSettingSection = ({ repositoryName }: PairRoomSettingSectionProps) => {
   const {
     firstPairName,
     secondPairName,
@@ -35,7 +39,7 @@ const PairRoomSettingSection = () => {
 
   const { handleAddPairRoom } = useAddPairRoom();
 
-  const handleSuccess = () => handleAddPairRoom(driver, navigator, timerDuration);
+  const handleSuccess = () => handleAddPairRoom(driver, navigator, repositoryName, timerDuration);
 
   return (
     <S.Layout>

--- a/frontend/src/components/PairRoomOnboarding/PairRoomSettingSection/PairRoomSettingSection.tsx
+++ b/frontend/src/components/PairRoomOnboarding/PairRoomSettingSection/PairRoomSettingSection.tsx
@@ -39,7 +39,10 @@ const PairRoomSettingSection = ({ repositoryName }: PairRoomSettingSectionProps)
 
   const { handleAddPairRoom } = useAddPairRoom();
 
-  const handleSuccess = () => handleAddPairRoom(driver, navigator, repositoryName, timerDuration);
+  const handleSuccess = () => {
+    const missionUrl = repositoryName !== '' ? `https://github.com/coduo-missions/${repositoryName}` : '';
+    handleAddPairRoom(driver, navigator, missionUrl, timerDuration);
+  };
 
   return (
     <S.Layout>

--- a/frontend/src/hooks/PairRoomOnboarding/useMissionBranch.ts
+++ b/frontend/src/hooks/PairRoomOnboarding/useMissionBranch.ts
@@ -1,33 +1,21 @@
-import { useState } from 'react';
-
 import { validateBranchName } from '@/validations/validateBranchName';
 
 import useInput from '@/hooks/common/useInput';
 
-const usePairRoomMission = () => {
-  const [repositoryName, setRepositoryName] = useState('');
-
+const useMissionBranch = () => {
   const { value, status, message, handleChange, resetValue } = useInput();
 
-  const isRepositorySelected = repositoryName !== '';
   const isValidBranchName = status === 'DEFAULT' && value !== '' && value.length <= 30;
-
-  const handleRepositoryName = (name: string) => {
-    setRepositoryName(name);
-    resetValue();
-  };
 
   const handleBranchName = (event: React.ChangeEvent<HTMLInputElement>, existingBranches: string[]) =>
     handleChange(event, validateBranchName(event.target.value, existingBranches));
 
   return {
-    repositoryName,
     branchName: { value, status, message },
-    isRepositorySelected,
     isValidBranchName,
-    handleRepositoryName,
+    resetBranchName: resetValue,
     handleBranchName,
   };
 };
 
-export default usePairRoomMission;
+export default useMissionBranch;

--- a/frontend/src/pages/PairRoom/PairRoom.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.tsx
@@ -38,6 +38,7 @@ const PairRoom = () => {
   const {
     driver: latestDriver,
     navigator: latestNavigator,
+    missionUrl,
     duration,
     remainingTime,
     isFetching,
@@ -57,7 +58,13 @@ const PairRoom = () => {
 
   return (
     <S.Layout>
-      <PairListCard driver={driver} navigator={navigator} roomCode={accessCode || ''} onRoomDelete={() => {}} />
+      <PairListCard
+        driver={driver}
+        navigator={navigator}
+        missionUrl={missionUrl}
+        roomCode={accessCode || ''}
+        onRoomDelete={() => {}}
+      />
       <S.Container>
         <PairRoleCard driver={driver} navigator={navigator} />
         <TimerCard

--- a/frontend/src/pages/PairRoomOnboarding/PairRoomOnboarding.tsx
+++ b/frontend/src/pages/PairRoomOnboarding/PairRoomOnboarding.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import MissionSettingSection from '@/components/PairRoomOnboarding/MissionSettingSection/MissionSettingSection';
@@ -12,14 +13,26 @@ const PairRoomOnboarding = () => {
   const searchParams = new URLSearchParams(location.search);
   const mission = searchParams.get('mission');
 
+  const [repositoryName, setRepositoryName] = useState('');
+
   const { handleCreateBranch, isSuccess } = useCreateBranch();
+
+  const handleRepositoryName = (repositoryName: string) => setRepositoryName(repositoryName);
 
   return (
     <S.Layout>
       <S.Container>
         <S.Title>{mission === 'true' ? '미션과 함께 시작하기' : '그냥 시작하기'}</S.Title>
-        {mission === 'true' && !isSuccess && <MissionSettingSection onCreateBranch={handleCreateBranch} />}
-        {((mission === 'true' && isSuccess) || mission === 'false') && <PairRoomSettingSection />}
+        {mission === 'true' && !isSuccess && (
+          <MissionSettingSection
+            repositoryName={repositoryName}
+            onRepositoryName={handleRepositoryName}
+            onCreateBranch={handleCreateBranch}
+          />
+        )}
+        {((mission === 'true' && isSuccess) || mission === 'false') && (
+          <PairRoomSettingSection repositoryName={repositoryName} />
+        )}
       </S.Container>
     </S.Layout>
   );

--- a/frontend/src/queries/Main/useAddPairRoom.ts
+++ b/frontend/src/queries/Main/useAddPairRoom.ts
@@ -17,10 +17,16 @@ const useAddPairRoom = () => {
     onSuccess: (accessCode) => navigate(`/room/${accessCode}`),
   });
 
-  const handleAddPairRoom = async (driver: string, navigator: string, timerDuration: string) => {
+  const handleAddPairRoom = async (
+    driver: string,
+    navigator: string,
+    repositoryName: string,
+    timerDuration: string,
+  ) => {
     return mutate({
       driver,
       navigator,
+      missionUrl: `https://github.com/coduo-missions/${repositoryName}`,
       timerDuration: Number(timerDuration) * 60 * 1000,
       timerRemainingTime: Number(timerDuration) * 60 * 1000,
     });

--- a/frontend/src/queries/Main/useAddPairRoom.ts
+++ b/frontend/src/queries/Main/useAddPairRoom.ts
@@ -17,16 +17,11 @@ const useAddPairRoom = () => {
     onSuccess: (accessCode) => navigate(`/room/${accessCode}`),
   });
 
-  const handleAddPairRoom = async (
-    driver: string,
-    navigator: string,
-    repositoryName: string,
-    timerDuration: string,
-  ) => {
+  const handleAddPairRoom = async (driver: string, navigator: string, missionUrl: string, timerDuration: string) => {
     return mutate({
       driver,
       navigator,
-      missionUrl: `https://github.com/coduo-missions/${repositoryName}`,
+      missionUrl,
       timerDuration: Number(timerDuration) * 60 * 1000,
       timerRemainingTime: Number(timerDuration) * 60 * 1000,
     });

--- a/frontend/src/queries/PairRoom/useGetPairRoom.ts
+++ b/frontend/src/queries/PairRoom/useGetPairRoom.ts
@@ -28,6 +28,7 @@ const useGetPairRoom = (accessCode: string) => {
   return {
     driver: pairRoom?.driver || '',
     navigator: pairRoom?.navigator || '',
+    missionUrl: pairRoom?.missionUrl || '',
     duration: timer?.duration || 0,
     remainingTime: timer?.remainingTime || 0,
     isFetching: (isPairRoomFetching && !isPairRoomReFetching) || isTimerFetching,

--- a/frontend/src/queries/PairRoomOnboarding/useCreateBranch.ts
+++ b/frontend/src/queries/PairRoomOnboarding/useCreateBranch.ts
@@ -9,13 +9,8 @@ const useCreateBranch = () => {
 
   const { mutate, isSuccess } = useMutation({
     mutationFn: createBranch,
-    onSuccess: () => {
-      addToast({ status: 'SUCCESS', message: '브랜치 생성에 성공했습니다.' });
-    },
-    onError: () => {
-      addToast({ status: 'ERROR', message: '브랜치 생성에 실패했습니다.' });
-      //TODO: 추후에 status 분기처리하기
-    },
+    onSuccess: () => addToast({ status: 'SUCCESS', message: '브랜치 생성에 성공했습니다.' }),
+    onError: () => addToast({ status: 'ERROR', message: '브랜치 생성에 실패했습니다.' }),
   });
 
   const handleCreateBranch = async (currentRepository: string, branchName: string) => {


### PR DESCRIPTION
## 연관된 이슈

- closes: #751 

## 구현한 기능
- [x] 페어룸 생성, 페어룸 조회 API 수정
- [x] 페어룸 안에서도 리포지토리 페이지로 이동할 수 있도록 버튼 추가

## 상세 설명
> <img width="266" alt="스크린샷 2024-10-15 오전 11 06 40" src="https://github.com/user-attachments/assets/59e443b1-61e9-4967-a2bc-5521aee4c7d4">

- 페어룸 안에서도 리포지토리 페이지로 이동할 수 있도록 페어 목록 컴포넌트에 버튼을 추가했습니다.
- 조건부 렌더링으로 처리하여 `그냥 시작할래요` 로 페어룸을 만들게 되는 경우 해당 버튼이 보이지 않습니다.