### PR TITLE
fix: 로그 기록시 타임존을 Asia/Seoul 기준으로 로깅하도록 설정 변경

### DIFF
--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -5,9 +5,9 @@
     <property name="LOGS_DIR_ROOT_PATH" value="logs"/>
     <property name="LOGS_BACKUP_DIR_ROOT_PATH" value="logs-backup"/>
     <property name="CONSOLE_LOG_PATTERN"
-              value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+              value="[%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
     <property name="FILE_LOG_PATTERN"
-              value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] [%thread] %-5level [%C.%M:%L] - %msg%n"/>
+              value="[%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul}:%-4relative] [%thread] %-5level [%C.%M:%L] - %msg%n"/>
 
     <springProfile name="prod">
         <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">


### PR DESCRIPTION
## 연관된 이슈

- closes: #774 

## 구현한 기능
- 로깅시 타임존이 Asia/Seoul 기준으로 로깅되도록 설정 변경
