### PR TITLE
[BE] 타이머 비활성화 기능 구현

### DIFF
--- a/backend/src/main/java/site/coduo/member/controller/MemberExceptionHandler.java
+++ b/backend/src/main/java/site/coduo/member/controller/MemberExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import lombok.extern.slf4j.Slf4j;
 import site.coduo.common.controller.response.ApiErrorResponse;
 import site.coduo.member.controller.error.MemberApiError;
+import site.coduo.member.exception.AuthorizationException;
 import site.coduo.member.exception.ExternalApiCallException;
 import site.coduo.member.exception.MemberNotFoundException;
 
@@ -23,6 +24,14 @@ public class MemberExceptionHandler {
 
         return ResponseEntity.status(MemberApiError.MEMBER_NOT_FOUND_ERROR.getHttpStatus())
                 .body(new ApiErrorResponse(MemberApiError.MEMBER_NOT_FOUND_ERROR.getMessage()));
+    }
+
+    @ExceptionHandler(AuthorizationException.class)
+    public ResponseEntity<ApiErrorResponse> handlerAuthorizationException(final AuthorizationException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(MemberApiError.AUTHORIZATION_ERROR.getHttpStatus())
+                .body(new ApiErrorResponse(MemberApiError.AUTHENTICATION_ERROR.getMessage()));
     }
 
     @ExceptionHandler(ExternalApiCallException.class)

--- a/backend/src/main/java/site/coduo/member/controller/error/MemberApiError.java
+++ b/backend/src/main/java/site/coduo/member/controller/error/MemberApiError.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 public enum MemberApiError {
 
     AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, "인증되지 않은 접근입니다."),
+    AUTHORIZATION_ERROR(HttpStatus.FORBIDDEN, "권한 외 접근입니다."),
     MEMBER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
     API_CALL_FAILURE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "외부 API와 상호작용 중 실패했습니다.");
 

--- a/backend/src/main/java/site/coduo/member/exception/AuthorizationException.java
+++ b/backend/src/main/java/site/coduo/member/exception/AuthorizationException.java
@@ -1,0 +1,8 @@
+package site.coduo.member.exception;
+
+public class AuthorizationException extends MemberException {
+
+    public AuthorizationException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/site/coduo/pairroom/domain/PairRoom.java
+++ b/backend/src/main/java/site/coduo/pairroom/domain/PairRoom.java
@@ -31,6 +31,10 @@ public class PairRoom {
         return missionUrl.getValue();
     }
 
+    public boolean isSameAccessCode(final AccessCode code) {
+        return accessCode.equals(code);
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {

--- a/backend/src/main/java/site/coduo/pairroom/domain/PairRoom.java
+++ b/backend/src/main/java/site/coduo/pairroom/domain/PairRoom.java
@@ -31,6 +31,10 @@ public class PairRoom {
         return missionUrl.getValue();
     }
 
+    public boolean isDeleted() {
+        return status == PairRoomStatus.DELETED;
+    }
+
     public boolean isSameAccessCode(final AccessCode code) {
         return accessCode.equals(code);
     }

--- a/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
@@ -10,7 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import site.coduo.member.domain.Member;
-import site.coduo.member.infrastructure.security.JwtProvider;
 import site.coduo.member.service.MemberService;
 import site.coduo.pairroom.domain.MissionUrl;
 import site.coduo.pairroom.domain.Pair;
@@ -20,6 +19,7 @@ import site.coduo.pairroom.domain.PairRoomStatus;
 import site.coduo.pairroom.domain.accesscode.AccessCode;
 import site.coduo.pairroom.domain.accesscode.UUIDAccessCodeGenerator;
 import site.coduo.pairroom.exception.DeletePairRoomException;
+import site.coduo.pairroom.exception.InvalidAccessCodeException;
 import site.coduo.pairroom.repository.PairRoomEntity;
 import site.coduo.pairroom.repository.PairRoomMemberEntity;
 import site.coduo.pairroom.repository.PairRoomMemberRepository;
@@ -41,7 +41,6 @@ public class PairRoomService {
     private final TimerRepository timerRepository;
     private final PairRoomMemberRepository pairRoomMemberRepository;
     private final MemberService memberService;
-    private final JwtProvider jwtProvider;
     private final UUIDAccessCodeGenerator uuidAccessCodeGenerator;
 
     @Transactional
@@ -137,5 +136,12 @@ public class PairRoomService {
                 .filter(pairRoomEntity -> !pairRoomEntity.isDelete())
                 .map(PairRoomEntity::toDomain)
                 .anyMatch(pairRoom -> pairRoom.isSameAccessCode(new AccessCode(accessCode)));
+    }
+
+    public void validateNotDeleted(final String accessCode) {
+        final PairRoom pairRoom = pairRoomRepository.fetchByAccessCode(accessCode).toDomain();
+        if (pairRoom.isDeleted()) {
+            throw new InvalidAccessCodeException("이미 삭제되어 접근이 불가능한 엑세스 코드입니다.");
+        }
     }
 }

--- a/backend/src/main/java/site/coduo/sync/controller/SseExceptionHandler.java
+++ b/backend/src/main/java/site/coduo/sync/controller/SseExceptionHandler.java
@@ -33,8 +33,8 @@ public class SseExceptionHandler {
     public ResponseEntity<ApiErrorResponse> handleNotFoundScheduledFutureException(
             final NotFoundScheduledFutureException e) {
         log.warn(e.getMessage());
-        return ResponseEntity.status(SseApiError.TIMER_STOP_FAILED.getHttpStatus())
-                .body(new ApiErrorResponse(SseApiError.TIMER_STOP_FAILED.getMessage()));
+        return ResponseEntity.status(SseApiError.SCHEDULER_NOT_FOUND.getHttpStatus())
+                .body(new ApiErrorResponse(SseApiError.SCHEDULER_NOT_FOUND.getMessage()));
     }
 
     @ExceptionHandler(NotFoundSseConnectionException.class)

--- a/backend/src/main/java/site/coduo/sync/controller/error/SseApiError.java
+++ b/backend/src/main/java/site/coduo/sync/controller/error/SseApiError.java
@@ -12,6 +12,7 @@ public enum SseApiError {
     SYNC_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "동기화에 실패하였습니다."),
     TIMER_START_FAILED(HttpStatus.BAD_REQUEST, "타이머 실행에 실패하였습니다."),
     TIMER_STOP_FAILED(HttpStatus.BAD_REQUEST, "타이머 중지에 실패하였습니다."),
+    SCHEDULER_NOT_FOUND(HttpStatus.NOT_FOUND, "스케줄러를 찾을 수 없습니다."),
     CONNECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SSE 연결에 실패했습니다."),
     CONNECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 페어룸의 SSE 연결을 찾을 수 없습니다."),
     CONNECTION_DUPLICATED(HttpStatus.BAD_REQUEST, "해당 페어룸에 이미 연결된 SSE 연결이 존재합니다.");

--- a/backend/src/main/java/site/coduo/sync/service/EventStreamsRegistry.java
+++ b/backend/src/main/java/site/coduo/sync/service/EventStreamsRegistry.java
@@ -45,6 +45,6 @@ public class EventStreamsRegistry {
         if (registry.containsKey(key)) {
             return registry.get(key).isEmpty();
         }
-        throw new NotFoundSseConnectionException("SSE 커넥션을 찾을 수 없습니다.");
+        return true;
     }
 }

--- a/backend/src/main/java/site/coduo/sync/service/SchedulerRegistry.java
+++ b/backend/src/main/java/site/coduo/sync/service/SchedulerRegistry.java
@@ -30,6 +30,15 @@ public class SchedulerRegistry {
         registry.remove(key);
     }
 
+    public void clear(final String key) {
+        if (!registry.containsKey(key)) {
+            return;
+        }
+        registry.get(key)
+                .cancel(false);
+        registry.remove(key);
+    }
+
     public boolean has(final String key) {
         return registry.containsKey(key);
     }

--- a/backend/src/main/java/site/coduo/sync/service/SchedulerService.java
+++ b/backend/src/main/java/site/coduo/sync/service/SchedulerService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import site.coduo.member.exception.AuthorizationException;
-import site.coduo.pairroom.repository.PairRoomMemberRepository;
 import site.coduo.pairroom.service.PairRoomService;
 import site.coduo.timer.domain.Timer;
 import site.coduo.timer.repository.TimerRepository;
@@ -23,7 +22,6 @@ import site.coduo.timer.service.TimestampRegistry;
 @Component
 public class SchedulerService {
     public static final Duration DELAY_SECOND = Duration.of(1, ChronoUnit.SECONDS);
-    private final PairRoomMemberRepository pairRoomMemberRepository;
     private final ThreadPoolTaskScheduler taskScheduler;
     private final SchedulerRegistry schedulerRegistry;
     private final TimestampRegistry timestampRegistry;
@@ -32,6 +30,7 @@ public class SchedulerService {
     private final PairRoomService pairRoomService;
 
     public void start(final String key) {
+        pairRoomService.validateNotDeleted(key);
         if (schedulerRegistry.isActive(key)) {
             return;
         }

--- a/backend/src/main/java/site/coduo/sync/service/SchedulerService.java
+++ b/backend/src/main/java/site/coduo/sync/service/SchedulerService.java
@@ -11,6 +11,9 @@ import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import site.coduo.member.exception.AuthorizationException;
+import site.coduo.pairroom.repository.PairRoomMemberRepository;
+import site.coduo.pairroom.service.PairRoomService;
 import site.coduo.timer.domain.Timer;
 import site.coduo.timer.repository.TimerRepository;
 import site.coduo.timer.service.TimestampRegistry;
@@ -19,23 +22,21 @@ import site.coduo.timer.service.TimestampRegistry;
 @RequiredArgsConstructor
 @Component
 public class SchedulerService {
-
     public static final Duration DELAY_SECOND = Duration.of(1, ChronoUnit.SECONDS);
-
+    private final PairRoomMemberRepository pairRoomMemberRepository;
     private final ThreadPoolTaskScheduler taskScheduler;
     private final SchedulerRegistry schedulerRegistry;
     private final TimestampRegistry timestampRegistry;
     private final TimerRepository timerRepository;
     private final SseService sseService;
+    private final PairRoomService pairRoomService;
 
     public void start(final String key) {
         if (schedulerRegistry.isActive(key)) {
             return;
         }
-        sseService.broadcast(key, "timer", "start");
         if (isInitial(key)) {
-            final Timer timer = timerRepository.fetchTimerByAccessCode(key)
-                    .toDomain();
+            final Timer timer = timerRepository.fetchTimerByAccessCode(key).toDomain();
             scheduling(key, timer);
             timestampRegistry.register(key, timer);
             return;
@@ -49,6 +50,7 @@ public class SchedulerService {
     }
 
     private void scheduling(final String key, final Timer timer) {
+        sseService.broadcast(key, "timer", "start");
         final Trigger trigger = new PeriodicTrigger(DELAY_SECOND);
         final ScheduledFuture<?> schedule = taskScheduler.schedule(() -> runTimer(key, timer), trigger);
         schedulerRegistry.register(key, schedule);
@@ -79,5 +81,15 @@ public class SchedulerService {
         schedulerRegistry.release(key);
         final Timer initalTimer = new Timer(timer.getAccessCode(), timer.getDuration(), timer.getDuration());
         timestampRegistry.register(key, initalTimer);
+    }
+
+    public void detach(final String key, final String accessToken) {
+        if (!pairRoomService.isParticipant(accessToken, key)) {
+            throw new AuthorizationException("인증되지 않은 타이머 비활성화 접근입니다.");
+        }
+        sseService.broadcast(key, "timer", "disconnect");
+        schedulerRegistry.clear(key);
+        sseService.disconnectAll(key);
+        timestampRegistry.clear(key);
     }
 }

--- a/backend/src/main/java/site/coduo/timer/controller/TimerController.java
+++ b/backend/src/main/java/site/coduo/timer/controller/TimerController.java
@@ -1,8 +1,11 @@
 package site.coduo.timer.controller;
 
+import static site.coduo.common.config.web.filter.SignInCookieFilter.SIGN_IN_COOKIE_NAME;
+
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -61,5 +64,16 @@ public class TimerController implements TimerDocs {
         final TimerReadResponse response = timerService.readTimer(accessCode);
 
         return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{accessCode}/timer/disable")
+    public ResponseEntity<Void> disableTimer(
+            @PathVariable("accessCode") final String accessCode,
+            @CookieValue(name = SIGN_IN_COOKIE_NAME) final String signInToken
+    ) {
+        schedulerService.detach(accessCode, signInToken);
+
+        return ResponseEntity.ok()
+                .build();
     }
 }

--- a/backend/src/main/java/site/coduo/timer/controller/docs/TimerDocs.java
+++ b/backend/src/main/java/site/coduo/timer/controller/docs/TimerDocs.java
@@ -41,4 +41,12 @@ public interface TimerDocs {
     ResponseEntity<TimerReadResponse> getTimer(
             String accessCode
     );
+
+    @Operation(summary = "타이머 기능(시작/종료/변경)을 비활성화(SSE disconnect, 스케줄러 삭제, 시간 정보 삭제) 한다.")
+    @ApiResponse(responseCode = "200", description = "페어룸 히스토리 조회 성공/ SSE - event: timer, data: disconnect")
+    @ApiResponse(responseCode = "4xx", description = "페어룸 히스토리 생성 실패")
+    ResponseEntity<Void> disableTimer(
+            String accessCode,
+            String signInToken
+    );
 }

--- a/backend/src/main/java/site/coduo/timer/service/TimestampRegistry.java
+++ b/backend/src/main/java/site/coduo/timer/service/TimestampRegistry.java
@@ -26,6 +26,13 @@ public class TimestampRegistry {
         registry.remove(key);
     }
 
+    public void clear(final String key) {
+        if (!registry.containsKey(key)) {
+            return;
+        }
+        registry.remove(key);
+    }
+
     public boolean has(final String key) {
         return registry.containsKey(key);
     }

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -12,7 +12,6 @@ spring:
         username: ${DB_USERNAME}
         password: ${DB_PASSWORD}
 
-
   jpa:
     database: mysql
     hibernate:

--- a/backend/src/test/java/site/coduo/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/AuthAcceptanceTest.java
@@ -27,6 +27,16 @@ class AuthAcceptanceTest extends AcceptanceFixture {
     @Autowired
     private JwtProvider jwtProvider;
 
+    static Member createMember() {
+        return Member.builder()
+                .username("test user")
+                .userId(FakeGithubApiClient.USER_ID)
+                .loginId(FakeGithubApiClient.LOGIN_ID)
+                .accessToken(FakeGithubOAuthClient.ACCESS_TOKEN.getCredential())
+                .profileImage(FakeGithubApiClient.PROFILE_IMAGE)
+                .build();
+    }
+
     @Test
     @DisplayName("로그인 검증 & 로그인 토큰을 발급한다.")
     void verify_login_and_publish_login_token() {
@@ -138,16 +148,6 @@ class AuthAcceptanceTest extends AcceptanceFixture {
 
                 .then().log().all()
                 .statusCode(HttpStatus.SC_UNAUTHORIZED);
-    }
-
-    private Member createMember() {
-        return Member.builder()
-                .username("test user")
-                .userId(FakeGithubApiClient.USER_ID)
-                .loginId(FakeGithubApiClient.LOGIN_ID)
-                .accessToken(FakeGithubOAuthClient.ACCESS_TOKEN.getCredential())
-                .profileImage(FakeGithubApiClient.PROFILE_IMAGE)
-                .build();
     }
 
 }

--- a/backend/src/test/java/site/coduo/acceptance/GithubAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/GithubAcceptanceTest.java
@@ -1,7 +1,7 @@
 package site.coduo.acceptance;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 
 import static site.coduo.common.config.web.filter.AccessTokenCookieFilter.TEMPORARY_ACCESS_TOKEN_COOKIE_NAME;
 
@@ -53,7 +53,7 @@ class GithubAcceptanceTest extends AcceptanceFixture {
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
                 .body("endpoint",
-                        is("https://www.github.com/login/oauth/authorize?client_id=test&state=randomNumber&redirect_uri=http://test.test"));
+                        startsWith("https://www.github.com/login/oauth/authorize?client_id="));
     }
 
     @Test

--- a/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
@@ -32,6 +32,22 @@ class PairRoomAcceptanceTest extends AcceptanceFixture {
                 .as(PairRoomCreateResponse.class);
     }
 
+    static PairRoomCreateResponse createPairRoom(final PairRoomCreateRequest request, final String loginCookie) {
+        return RestAssured
+                .given()
+                .cookie("coduo_whoami", loginCookie)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+
+                .when()
+                .post("/api/pair-room")
+
+                .then()
+                .extract()
+                .as(PairRoomCreateResponse.class);
+    }
+
     @Test
     @DisplayName("페어룸 요청 시 정보를 반환한다.")
     void show_pair_room() {

--- a/backend/src/test/java/site/coduo/acceptance/SseAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/SseAcceptanceTest.java
@@ -12,6 +12,7 @@ import site.coduo.pairroom.service.dto.PairRoomCreateRequest;
 class SseAcceptanceTest extends AcceptanceFixture {
 
     static void createConnect(final String accessCode) {
+
         RestAssured
                 .given()
 

--- a/backend/src/test/java/site/coduo/acceptance/TimerAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/TimerAcceptanceTest.java
@@ -4,9 +4,15 @@ import static site.coduo.acceptance.SseAcceptanceTest.createConnect;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 
 import io.restassured.RestAssured;
+import site.coduo.fake.FakeGithubApiClient;
+import site.coduo.fake.FakeGithubOAuthClient;
+import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberRepository;
+import site.coduo.member.infrastructure.security.JwtProvider;
 import site.coduo.pairroom.domain.PairRoomStatus;
 import site.coduo.pairroom.service.dto.PairRoomCreateRequest;
 import site.coduo.pairroom.service.dto.PairRoomCreateResponse;
@@ -14,9 +20,33 @@ import site.coduo.timer.service.dto.TimerUpdateRequest;
 
 class TimerAcceptanceTest extends AcceptanceFixture {
 
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
     static String createPairRoom(final PairRoomCreateRequest pairRoom) {
         final PairRoomCreateResponse response = RestAssured
                 .given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .body(pairRoom)
+
+                .when()
+                .post("/api/pair-room")
+
+                .then()
+                .extract()
+                .as(PairRoomCreateResponse.class);
+
+        return response.accessCode();
+    }
+
+    static String createPairRoom(final PairRoomCreateRequest pairRoom, final String token) {
+        final PairRoomCreateResponse response = RestAssured
+                .given()
+                .cookie("coduo_whoami", token)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .body(pairRoom)
@@ -132,5 +162,87 @@ class TimerAcceptanceTest extends AcceptanceFixture {
 
                 .then()
                 .statusCode(204);
+    }
+
+    @Test
+    @DisplayName("타이머 비활성화 요칭 시,로그인 쿠키가 없으면 400을 반환한다.")
+    void return_400_status_code_without_login_cookie() {
+        // given
+        final PairRoomCreateRequest pairRoom = new PairRoomCreateRequest("fram", "lemone", 10000L,
+                10000L, "https://missionUrl.xxx", PairRoomStatus.IN_PROGRESS.name());
+        final String userId = "userId";
+        final String token = jwtProvider.sign(userId);
+        saveMember(userId);
+        final String accessCode = createPairRoom(pairRoom, token);
+
+        // when & then
+        RestAssured
+                .given()
+                .when()
+                .pathParam("accessCode", accessCode)
+                .patch("/api/{accessCode}/timer/disable")
+
+                .then().log().all()
+                .statusCode(400);
+    }
+
+    @Test
+    @DisplayName("타이머 기능을 비활성화는 SSE커넥션이 있는 상태에서만 가능하다.")
+    void disable_pair_room_timer() {
+        // given
+        final PairRoomCreateRequest pairRoom = new PairRoomCreateRequest("fram", "lemone", 10000L,
+                10000L, "https://missionUrl.xxx", PairRoomStatus.IN_PROGRESS.name());
+        final String userId = "userId";
+        final String token = jwtProvider.sign(userId);
+        saveMember(userId);
+        final String accessCode = createPairRoom(pairRoom, token);
+        createConnect(accessCode);
+        TimerAcceptanceTest.timerStart(accessCode);
+
+        // when & then
+        RestAssured
+                .given()
+                .cookie("coduo_whoami", token)
+                .when()
+                .pathParam("accessCode", accessCode)
+                .patch("/api/{accessCode}/timer/disable")
+
+                .then().log().all()
+                .statusCode(200);
+    }
+
+    private void saveMember(final String userId) {
+        final Member member = Member.builder()
+                .username("test user")
+                .userId(userId)
+                .loginId(FakeGithubApiClient.LOGIN_ID)
+                .accessToken(FakeGithubOAuthClient.ACCESS_TOKEN.getCredential())
+                .profileImage(FakeGithubApiClient.PROFILE_IMAGE)
+                .build();
+
+        memberRepository.save(member);
+    }
+
+    @Test
+    @DisplayName("자신의 방이 아닌 방에 타이머를 비활성 요칭 시,  403 상태코드를 반환한다.")
+    void return_403_status_code_when_timer_disable_request_to_does_not_exist_pair_room() {
+        // given
+        final PairRoomCreateRequest pairRoom = new PairRoomCreateRequest("fram", "lemone", 10000L,
+                10000L, "https://missionUrl.xxx", PairRoomStatus.IN_PROGRESS.name());
+        final String userId = "userId";
+        final String token = jwtProvider.sign(userId);
+        saveMember(userId);
+
+        // when & then
+        RestAssured
+                .given()
+                .cookie("coduo_whoami", token)
+
+                .when()
+                .pathParam("accessCode", "does not exist")
+                .patch("/api/{accessCode}/timer/disable")
+
+                .then().log().all()
+                .statusCode(403);
     }
 }

--- a/backend/src/test/java/site/coduo/pairroom/service/PairRoomServiceTest.java
+++ b/backend/src/test/java/site/coduo/pairroom/service/PairRoomServiceTest.java
@@ -26,6 +26,8 @@ import site.coduo.pairroom.domain.accesscode.AccessCode;
 import site.coduo.pairroom.exception.DeletePairRoomException;
 import site.coduo.pairroom.exception.PairRoomNotFoundException;
 import site.coduo.pairroom.repository.PairRoomEntity;
+import site.coduo.pairroom.repository.PairRoomMemberEntity;
+import site.coduo.pairroom.repository.PairRoomMemberRepository;
 import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.pairroom.service.dto.PairRoomCreateRequest;
 import site.coduo.pairroom.service.dto.PairRoomMemberResponse;
@@ -40,14 +42,22 @@ class PairRoomServiceTest {
 
     @Autowired
     private PairRoomService pairRoomService;
+
     @Autowired
     private JwtProvider jwtProvider;
+
     @Autowired
     private MemberRepository memberRepository;
+
     @Autowired
     private TimerRepository timerRepository;
+
     @Autowired
     private PairRoomRepository pairRoomRepository;
+
+    @Autowired
+    private PairRoomMemberRepository pairRoomMemberRepository;
+
 
     @Test
     @DisplayName("페어룸을 생성한다.")
@@ -263,13 +273,9 @@ class PairRoomServiceTest {
     @DisplayName("페어룸이 존재하는지 확인한다.")
     void exists_pair_room() {
         //given
-        final AccessCode accessCode = new AccessCode("123456");
-        final PairRoomEntity pairRoomEntity = PairRoomEntity.from(
-                new PairRoom(PairRoomStatus.IN_PROGRESS,
-                        new Pair(new PairName("레디"), new PairName("레모네")),
-                        new MissionUrl("https://missionUrl.xxx"),
-                        accessCode
-                ));
+        final String code = "123456";
+        final AccessCode accessCode = new AccessCode(code);
+        final PairRoomEntity pairRoomEntity = createPairRoom(code);
         pairRoomRepository.save(pairRoomEntity);
 
         //when & then
@@ -279,4 +285,52 @@ class PairRoomServiceTest {
 
         );
     }
+
+    @Test
+    @DisplayName("특정 멤버가 해당 엑세스코드의 방 참가자인지 판별한다. - 참")
+    void check_is_consistent_of_specific_access_code_pair_room_true_case() {
+        // given
+        final String accessCode = "123456";
+        final PairRoomEntity pairRoomEntity = createPairRoom(accessCode);
+        pairRoomRepository.save(pairRoomEntity);
+        final String memberId = "memberId";
+        final Member member = createMember(memberId);
+        pairRoomMemberRepository.save(new PairRoomMemberEntity(pairRoomEntity, member));
+        final String token = jwtProvider.sign(memberId);
+
+        // when
+        final boolean participant = pairRoomService.isParticipant(token, accessCode);
+
+        // then
+        assertThat(participant).isTrue();
+    }
+
+    private PairRoomEntity createPairRoom(final String code) {
+        final AccessCode accessCode = new AccessCode(code);
+        return PairRoomEntity.from(
+                new PairRoom(PairRoomStatus.IN_PROGRESS,
+                        new Pair(new PairName("레디"), new PairName("레모네")),
+                        new MissionUrl("https://missionUrl.xxx"),
+                        accessCode
+                ));
+    }
+
+    @Test
+    @DisplayName("특정 멤버가 해당 엑세스코드의 방 참가자인지 판별한다. - 거짓")
+    void check_is_consistent_of_specific_access_code_pair_room_false_case() {
+        // given
+        final String accessCode = "123456";
+        final PairRoomEntity pairRoomEntity = createPairRoom(accessCode);
+        pairRoomRepository.save(pairRoomEntity);
+        final String memberId = "memberId";
+        createMember(memberId);
+        final String token = jwtProvider.sign(memberId);
+
+        // when
+        final boolean participant = pairRoomService.isParticipant(token, accessCode);
+
+        // then
+        assertThat(participant).isFalse();
+    }
+
 }

--- a/backend/src/test/java/site/coduo/sync/service/EventStreamsRegistryTest.java
+++ b/backend/src/test/java/site/coduo/sync/service/EventStreamsRegistryTest.java
@@ -72,9 +72,11 @@ class EventStreamsRegistryTest {
         final EventStreamsRegistry eventStreamsRegistry = new EventStreamsRegistry();
         final String key = "tes";
 
-        // when & then
-        assertThatThrownBy(() -> eventStreamsRegistry.hasNoStreams(key))
-                .isInstanceOf(NotFoundSseConnectionException.class);
+        // when
+        final boolean actual = eventStreamsRegistry.hasNoStreams(key);
+
+        // then
+        assertThat(actual).isTrue();
     }
 
     @Test

--- a/backend/src/test/java/site/coduo/sync/service/SchedulerServiceTest.java
+++ b/backend/src/test/java/site/coduo/sync/service/SchedulerServiceTest.java
@@ -17,6 +17,11 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 import site.coduo.fake.FakeScheduledFuture;
 import site.coduo.member.exception.AuthorizationException;
+import site.coduo.pairroom.domain.MissionUrl;
+import site.coduo.pairroom.domain.Pair;
+import site.coduo.pairroom.domain.PairName;
+import site.coduo.pairroom.domain.PairRoom;
+import site.coduo.pairroom.domain.PairRoomStatus;
 import site.coduo.pairroom.domain.accesscode.AccessCode;
 import site.coduo.pairroom.repository.PairRoomEntity;
 import site.coduo.pairroom.service.PairRoomService;
@@ -187,5 +192,15 @@ class SchedulerServiceTest {
         // when & then
         assertThatThrownBy(() -> schedulerService.detach(key, "accessToken"))
                 .isInstanceOf(AuthorizationException.class);
+    }
+
+    private PairRoomEntity createPairRoom(final String code, final PairRoomStatus pairRoomStatus) {
+        final AccessCode accessCode = new AccessCode(code);
+        return PairRoomEntity.from(
+                new PairRoom(pairRoomStatus,
+                        new Pair(new PairName("레디"), new PairName("레모네")),
+                        new MissionUrl("https://missionUrl.xxx"),
+                        accessCode
+                ));
     }
 }

--- a/backend/src/test/java/site/coduo/sync/service/SchedulerServiceTest.java
+++ b/backend/src/test/java/site/coduo/sync/service/SchedulerServiceTest.java
@@ -1,33 +1,32 @@
 package site.coduo.sync.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
+import site.coduo.fake.FakeScheduledFuture;
+import site.coduo.member.exception.AuthorizationException;
 import site.coduo.pairroom.domain.accesscode.AccessCode;
 import site.coduo.pairroom.repository.PairRoomEntity;
+import site.coduo.pairroom.service.PairRoomService;
 import site.coduo.timer.domain.Timer;
 import site.coduo.timer.repository.TimerEntity;
 import site.coduo.timer.repository.TimerRepository;
 import site.coduo.timer.service.TimestampRegistry;
 
-@Disabled
 @SpringBootTest
 class SchedulerServiceTest {
-
-    @Autowired
-    private ThreadPoolTaskScheduler taskScheduler;
 
     @Autowired
     private SchedulerRegistry schedulerRegistry;
@@ -35,25 +34,20 @@ class SchedulerServiceTest {
     @Autowired
     private TimestampRegistry timestampRegistry;
 
+    @Autowired
+    private EventStreamsRegistry eventStreamsRegistry;
+
+    @Autowired
     private TimerRepository timerRepository;
-    private SseService sseService;
+
+    @Autowired
     private SchedulerService schedulerService;
 
-    @BeforeEach
-    void setUp() {
-        timerRepository = mock(TimerRepository.class);
-        sseService = mock(SseService.class);
-
-        schedulerService = new SchedulerService(
-                taskScheduler,
-                schedulerRegistry,
-                timestampRegistry,
-                timerRepository,
-                sseService
-        );
-    }
+    @MockBean
+    private PairRoomService pairRoomService;
 
     @Test
+    @Disabled
     @DisplayName("타이머를 2초 실행한다.")
     void start_timer_3_seconds() {
         // given
@@ -78,6 +72,7 @@ class SchedulerServiceTest {
     }
 
     @Test
+    @Disabled
     @DisplayName("타이머 실행시 남은 시간이 0이 되면 스케줄링이 종료되고 타임스탬프가 삭제된다.")
     void start_timer_unit_zero() {
         // given
@@ -100,6 +95,7 @@ class SchedulerServiceTest {
     }
 
     @Test
+    @Disabled
     @DisplayName("실행중인 타이머를 중지한다.")
     void stop_timer() {
         // given
@@ -119,5 +115,77 @@ class SchedulerServiceTest {
                     schedulerService.pause(key);
                     assertThat(schedulerRegistry.has(key)).isFalse();
                 });
+    }
+
+    @Test
+    @DisplayName("타임스탬프 정보를 registry에서 삭제한다.")
+    void remove_timestamp_in_timestamp_registry() {
+        // given
+        final String key = "some-access-code";
+        final String userId = "fram";
+        eventStreamsRegistry.register(key);
+        schedulerRegistry.register(key, new FakeScheduledFuture());
+        timestampRegistry.register(key, new Timer(new AccessCode(key), 10000L, 10000L));
+        when(pairRoomService.isParticipant(anyString(), anyString()))
+                .thenReturn(true);
+
+        // when
+        schedulerService.detach(key, "accessCode");
+
+        // then
+        assertThat(timestampRegistry.has(key)).isFalse();
+    }
+
+
+    @Test
+    @DisplayName("스케줄링 정보를 registry에서 삭제한다.")
+    void remove_scheduling_info_in_scheduling_registry() {
+        // given
+        final String key = "some-access-code";
+        eventStreamsRegistry.register(key);
+        schedulerRegistry.register(key, new FakeScheduledFuture());
+        timestampRegistry.register(key, new Timer(new AccessCode(key), 10000L, 10000L));
+        when(pairRoomService.isParticipant(anyString(), anyString()))
+                .thenReturn(true);
+
+        // when
+        schedulerService.detach(key, "accessToken");
+
+        // then
+        assertThat(schedulerRegistry.has(key)).isFalse();
+    }
+
+    @Test
+    @DisplayName("키에 해당하는 SSE 커넥션를 종료한다.")
+    void disconnect_specific_sse_with_key() {
+        // given
+        final String key = "some-access-code";
+        eventStreamsRegistry.register(key);
+        schedulerRegistry.register(key, new FakeScheduledFuture());
+        timestampRegistry.register(key, new Timer(new AccessCode(key), 10000L, 10000L));
+        when(pairRoomService.isParticipant(anyString(), anyString()))
+                .thenReturn(true);
+
+        // when
+        schedulerService.detach(key, "accessToken");
+
+        // then
+        assertThat(eventStreamsRegistry.hasNoStreams(key)).isTrue();
+    }
+
+    @Test
+    @DisplayName("해당 방에 등록되지 않은 사용자가 타이머를 비활성화할 경우 예외를 발생시킨다.")
+    void return_exception_if_user_who_is_not_registered_in_the_room() {
+        // given
+        final String key = "some-access-code";
+        eventStreamsRegistry.register(key);
+        schedulerRegistry.register(key, new FakeScheduledFuture());
+        timestampRegistry.register(key, new Timer(new AccessCode(key), 10000L, 10000L));
+        when(pairRoomService.isParticipant(anyString(), anyString()))
+                .thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> schedulerService.detach(key, "accessToken"))
+                .isInstanceOf(AuthorizationException.class);
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- closes: #780 

## 구현한 기능
페어룸이 회고를 마치고 라이프 사이클이 끝나기 전 메모리에서 관리되는 모든 Timer 관련 리소스를 정리한다. 

## 상세 설명
1. 구현 API(/api/{accessCode}/timer/disable) 호출 시 메모리에서 관리 되고 있는 해당 페어룸 시간정보(timestamp) 삭제
2. 구현 API 호출 시 메모리에서 관리 되고 있는 해당 페어룸 스케줄러(ShceduledFuture)삭제
3. 구현 API 호출 시 메모리에서 관리 되고 있는 해당 페어룸 SSE 연결 모두 끊음 (SSE 전달 데이터/ event: timer, data: disconnect)
4. 해당 페어룸의 구성원(즉, 페어룸과 연관 관계에 있는 Member )들만 해당 API 정상적으로 사용가능하도록 예외 처리

