### PR TITLE
[FE] 페어룸을 링크로 직접 접근하지 못하도록 제한

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import Loading from '@/pages/Loading/Loading';
 import Main from '@/pages/Main/Main';
 import MyPage from '@/pages/MyPage/MyPage';
 import PairRoomOnboarding from '@/pages/PairRoomOnboarding/PairRoomOnboarding';
+import PrivateRoutes from '@/pages/PrivateRoutes';
 import SignUp from '@/pages/SignUp/SignUp';
 
 import HowToPair from '@/components/Landing/HowToPair/HowToPair';
@@ -69,19 +70,21 @@ const App = () => {
         },
         {
           path: 'onboarding',
-          element: (
-            <Suspense fallback={<Loading />}>
-              <PairRoomOnboarding />{' '}
-            </Suspense>
-          ),
+          element: <PairRoomOnboarding />,
         },
         {
-          path: 'room/:accessCode',
-          element: (
-            <Suspense fallback={<Loading />}>
-              <PairRoom />
-            </Suspense>
-          ),
+          path: 'room',
+          element: <PrivateRoutes />,
+          children: [
+            {
+              path: ':accessCode',
+              element: (
+                <Suspense fallback={<Loading />}>
+                  <PairRoom />
+                </Suspense>
+              ),
+            },
+          ],
         },
         {
           path: 'sign-up',

--- a/frontend/src/components/Main/PairRoomCreateModal/PairRoomCreateComplete/PairRoomCreateComplete.tsx
+++ b/frontend/src/components/Main/PairRoomCreateModal/PairRoomCreateComplete/PairRoomCreateComplete.tsx
@@ -7,8 +7,6 @@ import { Modal } from '@/components/common/Modal';
 
 import useCopyClipBoard from '@/hooks/common/useCopyClipboard';
 
-import { BUTTON_TEXT } from '@/constants/button';
-
 import * as S from '../PairRoomCreateModal.styles';
 
 interface PairRoomCreateCompleteProps {
@@ -36,7 +34,7 @@ const PairRoomCreateComplete = ({ accessCode, closeModal }: PairRoomCreateComple
       </S.ModalBodyWrapper>
       <Modal.Footer>
         <Button onClick={closeModal} filled={false}>
-          {BUTTON_TEXT.CLOSE}
+          닫기
         </Button>
         <Link to={`/room/${accessCode}/onboarding`}>
           <Button>이동</Button>

--- a/frontend/src/components/Main/PairRoomEntryModal/PairRoomEntryModal.tsx
+++ b/frontend/src/components/Main/PairRoomEntryModal/PairRoomEntryModal.tsx
@@ -10,8 +10,6 @@ import { getPairRoomExists } from '@/apis/pairRoom';
 
 import useInput from '@/hooks/common/useInput';
 
-import { BUTTON_TEXT } from '@/constants/button';
-
 interface PairRoomEntryModal {
   isOpen: boolean;
   closeModal: () => void;
@@ -49,10 +47,10 @@ const PairRoomEntryModal = ({ isOpen, closeModal }: PairRoomEntryModal) => {
       </Modal.Body>
       <Modal.Footer>
         <Button onClick={closeModal} filled={false}>
-          {BUTTON_TEXT.CLOSE}
+          닫기
         </Button>
         <Button disabled={!value} onClick={enterPairRoom}>
-          {BUTTON_TEXT.COMPLETE}
+          완료
         </Button>
       </Modal.Footer>
     </Modal>

--- a/frontend/src/components/Main/PairRoomEntryModal/PairRoomEntryModal.tsx
+++ b/frontend/src/components/Main/PairRoomEntryModal/PairRoomEntryModal.tsx
@@ -31,7 +31,7 @@ const PairRoomEntryModal = ({ isOpen, closeModal }: PairRoomEntryModal) => {
       return;
     }
 
-    navigate(`/room/${value}`);
+    navigate(`/room/${value}`, { state: { valid: true }, replace: true });
   };
 
   return (

--- a/frontend/src/components/MyPage/PairRoomButton/PairRoomButton.styles.ts
+++ b/frontend/src/components/MyPage/PairRoomButton/PairRoomButton.styles.ts
@@ -5,6 +5,8 @@ import styled, { keyframes, css } from 'styled-components';
 
 import type { PairRoomStatus } from '@/apis/pairRoom';
 
+import { Z_INDEX } from '@/constants/style';
+
 const flow = keyframes`
   0% {
     background-position: 200% 0;
@@ -122,7 +124,7 @@ export const PairRoomButton = styled.button<{ $status: PairRoomStatus }>`
     position: absolute;
     top: 0;
     left: 0;
-    z-index: -1;
+    z-index: ${Z_INDEX.MINUS};
 
     width: 100%;
     height: 100%;

--- a/frontend/src/components/MyPage/PairRoomButton/PairRoomButton.tsx
+++ b/frontend/src/components/MyPage/PairRoomButton/PairRoomButton.tsx
@@ -38,7 +38,7 @@ const PairRoomButton = ({ driver, navigator, status, accessCode }: PairRoomButto
         <Spinner />
       ) : (
         <>
-          <S.LinkWrapper to={`/room/${accessCode}`}>
+          <S.LinkWrapper to={`/room/${accessCode}`} state={{ valid: true }} replace={true}>
             <S.PairRoomButton $status={status}>
               <S.RoleTextContainer>
                 <S.RoleText $status={status}>

--- a/frontend/src/components/MyPage/PairRoomDeleteModal/PariRoomDeleteModal.styles.ts
+++ b/frontend/src/components/MyPage/PairRoomDeleteModal/PariRoomDeleteModal.styles.ts
@@ -13,33 +13,39 @@ export const DangerText = styled.span`
 `;
 
 export const FilledButton = styled(Button)`
-  background-color: ${({ theme }) => theme.color.danger[600]};
-  font-size: ${({ theme }) => theme.fontSize.md};
   border-color: ${({ theme }) => theme.color.danger[600]};
 
+  background-color: ${({ theme }) => theme.color.danger[600]};
+  font-size: ${({ theme }) => theme.fontSize.md};
+
   &:hover {
-    background-color: ${({ theme }) => theme.color.danger[700]};
     border-color: ${({ theme }) => theme.color.danger[700]};
+
+    background-color: ${({ theme }) => theme.color.danger[700]};
   }
 
   &:active {
-    background-color: ${({ theme }) => theme.color.danger[800]};
     border-color: ${({ theme }) => theme.color.danger[800]};
+
+    background-color: ${({ theme }) => theme.color.danger[800]};
   }
 `;
 
 export const OutlinedButton = styled(Button)`
-  color: ${({ theme }) => theme.color.danger[600]};
-  font-size: ${({ theme }) => theme.fontSize.md};
   border-color: ${({ theme }) => theme.color.danger[600]};
 
+  color: ${({ theme }) => theme.color.danger[600]};
+  font-size: ${({ theme }) => theme.fontSize.md};
+
   &:hover {
-    color: ${({ theme }) => theme.color.danger[700]};
     border-color: ${({ theme }) => theme.color.danger[700]};
+
+    color: ${({ theme }) => theme.color.danger[700]};
   }
 
   &:active {
-    color: ${({ theme }) => theme.color.danger[800]};
     border-color: ${({ theme }) => theme.color.danger[800]};
+
+    color: ${({ theme }) => theme.color.danger[800]};
   }
 `;

--- a/frontend/src/components/PairRoom/TimerCard/TimerEditPanel/TimerEditPanel.tsx
+++ b/frontend/src/components/PairRoom/TimerCard/TimerEditPanel/TimerEditPanel.tsx
@@ -14,8 +14,6 @@ import useModal from '@/hooks/common/useModal';
 
 import useUpdateDuration from '@/queries/PairRoom/useUpdateDuration';
 
-import { BUTTON_TEXT } from '@/constants/button';
-
 import * as S from './TimerEditPanel.styles';
 
 interface TimerEditPanelProps {
@@ -64,10 +62,10 @@ const TimerEditPanel = ({ isActive }: TimerEditPanelProps) => {
             <Input id="timer" value={value} placeholder="타이머 시간 (분)" onChange={handleChange} />
             <S.ButtonContainer>
               <Button type="button" color="secondary" size="sm" filled={false} rounded={true} onClick={closePanel}>
-                {BUTTON_TEXT.CLOSE}
+                닫기
               </Button>
               <Button type="submit" color="secondary" size="sm" rounded={true} disabled={isButtonDisabled}>
-                {BUTTON_TEXT.COMPLETE}
+                완료
               </Button>
             </S.ButtonContainer>
           </S.Form>

--- a/frontend/src/components/PairRoomOnboarding/PairRoomSettingSection/PairRoomSettingSection.tsx
+++ b/frontend/src/components/PairRoomOnboarding/PairRoomSettingSection/PairRoomSettingSection.tsx
@@ -9,8 +9,6 @@ import usePairRoomInformation from '@/hooks/PairRoomOnboarding/usePairRoomInform
 
 import useAddPairRoom from '@/queries/Main/useAddPairRoom';
 
-import { BUTTON_TEXT } from '@/constants/button';
-
 import * as S from './PairRoomSettingSection.styles';
 
 interface PairRoomSettingSectionProps {
@@ -65,7 +63,7 @@ const PairRoomSettingSection = ({ repositoryName }: PairRoomSettingSectionProps)
       {moveIndex >= 3 && (
         <S.ButtonWrapper>
           <Button disabled={validationList.some((valid) => !valid)} onClick={handleSuccess}>
-            {BUTTON_TEXT.COMPLETE}
+            완료
           </Button>
         </S.ButtonWrapper>
       )}

--- a/frontend/src/components/common/Background/WaveBackground.styles.ts
+++ b/frontend/src/components/common/Background/WaveBackground.styles.ts
@@ -1,5 +1,7 @@
 import styled, { keyframes } from 'styled-components';
 
+import { Z_INDEX } from '@/constants/style';
+
 const drift = keyframes`
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
@@ -9,7 +11,7 @@ export const WaveBackground = styled.div`
   overflow: hidden;
 
   position: fixed;
-  z-index: -1;
+  z-index: ${Z_INDEX.MINUS};
 
   width: 100vw;
   height: calc(100vh - 7rem);

--- a/frontend/src/components/common/Dropdown/Dropdown/Dropdown.styles.tsx
+++ b/frontend/src/components/common/Dropdown/Dropdown/Dropdown.styles.tsx
@@ -4,6 +4,8 @@ import styled from 'styled-components';
 import Button from '@/components/common/Button/Button';
 import { Direction } from '@/components/common/Dropdown/Dropdown/Dropdown';
 
+import { Z_INDEX } from '@/constants/style';
+
 const getDirection = {
   lower: {
     open: 180,
@@ -79,7 +81,7 @@ export const ItemList = styled.ul<{ $height: string; $direction: Direction }>`
   top: ${({ $direction }) => ($direction === 'lower' ? '5rem' : '')};
   bottom: ${({ $direction }) => ($direction === 'lower' ? '' : '5rem')};
   left: 0;
-  z-index: 1000;
+  z-index: ${Z_INDEX.DROPDOWN};
 
   width: 100%;
   max-height: 20rem;

--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -1,12 +1,14 @@
 import styled from 'styled-components';
 
+import { Z_INDEX } from '@/constants/style';
+
 export const Layout = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
 
   position: fixed;
-  z-index: 99;
+  z-index: ${Z_INDEX.HEADER};
 
   width: 100%;
   height: 7rem;

--- a/frontend/src/components/common/Modal/Modal.styles.ts
+++ b/frontend/src/components/common/Modal/Modal.styles.ts
@@ -1,5 +1,7 @@
 import styled, { keyframes, css } from 'styled-components';
 
+import { Z_INDEX } from '@/constants/style';
+
 import type { Size, Position, BackdropType } from './Modal.type';
 
 const fadeIn = keyframes`
@@ -40,6 +42,7 @@ export const Layout = styled.div<{ $position: Position }>`
 
   position: fixed;
   top: 0;
+  z-index: ${Z_INDEX.MODAL};
 
   width: 100%;
   height: 100%;

--- a/frontend/src/components/common/ScrollIcon/ScrollIcon.styles.ts
+++ b/frontend/src/components/common/ScrollIcon/ScrollIcon.styles.ts
@@ -1,6 +1,8 @@
 import { RiArrowDownDoubleLine } from 'react-icons/ri';
 import styled, { css, keyframes } from 'styled-components';
 
+import { Z_INDEX } from '@/constants/style';
+
 const bounce = keyframes`
   0%, 20%, 50%, 80%, 100% {
     transform: translateY(0);
@@ -37,7 +39,7 @@ export const Layout = styled.div<{ $isBottom: boolean }>`
   position: fixed;
   bottom: 2rem;
   left: calc(50% - 3rem);
-  z-index: 10;
+  z-index: ${Z_INDEX.PLUS};
 
   padding: 1.5rem;
   border-radius: 3rem;

--- a/frontend/src/components/common/ToastList/ToastList.styles.ts
+++ b/frontend/src/components/common/ToastList/ToastList.styles.ts
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 
+import { Z_INDEX } from '@/constants/style';
+
 export const Layout = styled.div`
   display: flex;
   flex-direction: column;
@@ -8,5 +10,5 @@ export const Layout = styled.div`
   position: fixed;
   top: 9rem;
   right: 2rem;
-  z-index: 9999;
+  z-index: ${Z_INDEX.TOAST};
 `;

--- a/frontend/src/components/common/Tooltip/Tooltip.styles.ts
+++ b/frontend/src/components/common/Tooltip/Tooltip.styles.ts
@@ -2,6 +2,8 @@ import styled, { css, keyframes } from 'styled-components';
 
 import { Direction } from '@/components/common/Tooltip/Tooltip.type';
 
+import { Z_INDEX } from '@/constants/style';
+
 const fadeIn = keyframes`
   0% {
     opacity: 0;
@@ -115,7 +117,7 @@ export const Content = styled.div<{ $color: string; $direction: Direction }>`
   display: none;
 
   position: absolute;
-  z-index: 100;
+  z-index: ${Z_INDEX.TOOLTIP};
 
   width: fit-content;
   min-width: 20rem;

--- a/frontend/src/constants/button.ts
+++ b/frontend/src/constants/button.ts
@@ -1,8 +1,0 @@
-export const BUTTON_TEXT = {
-  CLOSE: '닫기',
-  BACK: '이전',
-  NEXT: '다음',
-  COMPLETE: '완료',
-  CANCEL: '취소',
-  CONFIRM: '확인',
-};

--- a/frontend/src/constants/style.ts
+++ b/frontend/src/constants/style.ts
@@ -1,0 +1,9 @@
+export const Z_INDEX = {
+  MINUS: -1,
+  PLUS: 1,
+  DROPDOWN: 99,
+  TOOLTIP: 100,
+  HEADER: 999,
+  MODAL: 9998,
+  TOAST: 9999,
+};

--- a/frontend/src/hooks/PairRoom/usePairRoomValid.ts
+++ b/frontend/src/hooks/PairRoom/usePairRoomValid.ts
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+
+import useToastStore from '@/stores/toastStore';
+
+import { getPairRoomExists } from '@/apis/pairRoom';
+
+const usePairRoomValid = (accessCode: string) => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const { addToast } = useToastStore();
+
+  useEffect(() => {
+    const checkAccessValid = async () => {
+      if (!location.state?.valid) {
+        navigate('/main');
+        addToast({ status: 'ERROR', message: '유효하지 않은 접근입니다. 올바른 경로로 접근해 주세요.' });
+        return;
+      }
+
+      if (!accessCode) {
+        navigate('/main');
+        addToast({ status: 'ERROR', message: '존재하지 않는 페어룸 코드입니다. 다시 확인해 주세요.' });
+        return;
+      }
+
+      const { exists } = await getPairRoomExists(accessCode);
+
+      if (!exists) {
+        navigate('/main');
+        addToast({ status: 'ERROR', message: '존재하지 않는 페어룸 코드입니다. 다시 확인해 주세요.' });
+        return;
+      }
+    };
+
+    checkAccessValid();
+  }, [accessCode]);
+};
+
+export default usePairRoomValid;

--- a/frontend/src/pages/PairRoom/PairRoom.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import Loading from '@/pages/Loading/Loading';
 
@@ -10,11 +10,8 @@ import ReferenceCard from '@/components/PairRoom/ReferenceCard/ReferenceCard';
 import TimerCard from '@/components/PairRoom/TimerCard/TimerCard';
 import TodoListCard from '@/components/PairRoom/TodoListCard/TodoListCard';
 
-import useToastStore from '@/stores/toastStore';
-
-import { getPairRoomExists } from '@/apis/pairRoom';
-
 import useModal from '@/hooks/common/useModal';
+import usePairRoomValid from '@/hooks/PairRoom/usePairRoomValid';
 
 import useGetPairRoom from '@/queries/PairRoom/useGetPairRoom';
 import useUpdatePairRoom from '@/queries/PairRoom/useUpdatePairRoom';
@@ -22,37 +19,9 @@ import useUpdatePairRoom from '@/queries/PairRoom/useUpdatePairRoom';
 import * as S from './PairRoom.styles';
 
 const PairRoom = () => {
-  const navigate = useNavigate();
-  const location = useLocation();
   const { accessCode } = useParams();
 
-  const { addToast } = useToastStore();
-
-  useEffect(() => {
-    const checkAccessValid = async () => {
-      if (!location.state?.valid) {
-        navigate('/main');
-        addToast({ status: 'ERROR', message: '유효하지 않은 접근입니다. 올바른 경로로 접근해 주세요.' });
-        return;
-      }
-
-      if (!accessCode) {
-        navigate('/main');
-        addToast({ status: 'ERROR', message: '존재하지 않는 페어룸 코드입니다. 다시 확인해 주세요.' });
-        return;
-      }
-
-      const { exists } = await getPairRoomExists(accessCode);
-
-      if (!exists) {
-        navigate('/main');
-        addToast({ status: 'ERROR', message: '존재하지 않는 페어룸 코드입니다. 다시 확인해 주세요.' });
-        return;
-      }
-    };
-
-    checkAccessValid();
-  }, [accessCode]);
+  usePairRoomValid(accessCode || '');
 
   const [driver, setDriver] = useState('');
   const [navigator, setNavigator] = useState('');

--- a/frontend/src/pages/PairRoom/PairRoom.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.tsx
@@ -11,7 +11,6 @@ import TimerCard from '@/components/PairRoom/TimerCard/TimerCard';
 import TodoListCard from '@/components/PairRoom/TodoListCard/TodoListCard';
 
 import useModal from '@/hooks/common/useModal';
-import usePairRoomValid from '@/hooks/PairRoom/usePairRoomValid';
 
 import useGetPairRoom from '@/queries/PairRoom/useGetPairRoom';
 import useUpdatePairRoom from '@/queries/PairRoom/useUpdatePairRoom';
@@ -20,8 +19,6 @@ import * as S from './PairRoom.styles';
 
 const PairRoom = () => {
   const { accessCode } = useParams();
-
-  usePairRoomValid(accessCode || '');
 
   const [driver, setDriver] = useState('');
   const [navigator, setNavigator] = useState('');

--- a/frontend/src/pages/PairRoom/PairRoom.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 
 import Loading from '@/pages/Loading/Loading';
 
@@ -9,6 +9,8 @@ import PairRoleCard from '@/components/PairRoom/PairRoleCard/PairRoleCard';
 import ReferenceCard from '@/components/PairRoom/ReferenceCard/ReferenceCard';
 import TimerCard from '@/components/PairRoom/TimerCard/TimerCard';
 import TodoListCard from '@/components/PairRoom/TodoListCard/TodoListCard';
+
+import useToastStore from '@/stores/toastStore';
 
 import { getPairRoomExists } from '@/apis/pairRoom';
 
@@ -21,18 +23,35 @@ import * as S from './PairRoom.styles';
 
 const PairRoom = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { accessCode } = useParams();
 
+  const { addToast } = useToastStore();
+
   useEffect(() => {
-    const checkPairRoomExists = async () => {
-      if (!accessCode) navigate('/error');
+    const checkAccessValid = async () => {
+      if (!location.state?.valid) {
+        navigate('/main');
+        addToast({ status: 'ERROR', message: '유효하지 않은 접근입니다. 올바른 경로로 접근해 주세요.' });
+        return;
+      }
 
-      const { exists } = await getPairRoomExists(accessCode || '');
+      if (!accessCode) {
+        navigate('/main');
+        addToast({ status: 'ERROR', message: '존재하지 않는 페어룸 코드입니다. 다시 확인해 주세요.' });
+        return;
+      }
 
-      if (!exists) navigate('/error');
+      const { exists } = await getPairRoomExists(accessCode);
+
+      if (!exists) {
+        navigate('/main');
+        addToast({ status: 'ERROR', message: '존재하지 않는 페어룸 코드입니다. 다시 확인해 주세요.' });
+        return;
+      }
     };
 
-    checkPairRoomExists();
+    checkAccessValid();
   }, [accessCode]);
 
   const [driver, setDriver] = useState('');

--- a/frontend/src/pages/PrivateRoutes.tsx
+++ b/frontend/src/pages/PrivateRoutes.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { Navigate, Outlet, useLocation, useParams } from 'react-router-dom';
+
+import Loading from '@/pages/Loading/Loading';
+
+import useToastStore from '@/stores/toastStore';
+
+import { getPairRoomExists } from '@/apis/pairRoom';
+
+const PrivateRoutes = () => {
+  const location = useLocation();
+  const { accessCode } = useParams();
+
+  const [isValid, setIsValid] = useState<boolean | null>(null);
+
+  const { addToast } = useToastStore();
+
+  const validateAccess = async () => {
+    if (!accessCode || !location.state?.valid) {
+      setIsValid(false);
+      addToast({ status: 'ERROR', message: '유효하지 않은 접근입니다. 올바른 경로로 접근해 주세요.' });
+      return;
+    }
+
+    const { exists } = await getPairRoomExists(accessCode);
+
+    if (!exists) {
+      setIsValid(false);
+      addToast({ status: 'ERROR', message: '유효하지 않은 접근입니다. 올바른 경로로 접근해 주세요.' });
+      return;
+    }
+
+    setIsValid(true);
+  };
+
+  useEffect(() => {
+    validateAccess();
+  }, []);
+
+  if (isValid === null) return <Loading />;
+
+  if (!isValid) return <Navigate to="/main" replace />;
+
+  return <Outlet />;
+};
+
+export default PrivateRoutes;

--- a/frontend/src/queries/Main/useAddPairRoom.ts
+++ b/frontend/src/queries/Main/useAddPairRoom.ts
@@ -14,7 +14,7 @@ const useAddPairRoom = () => {
   const { mutate, isPending } = useMutation({
     mutationFn: addPairRoom,
     onError: (error) => addToast({ status: 'ERROR', message: error.message }),
-    onSuccess: (accessCode) => navigate(`/room/${accessCode}`),
+    onSuccess: (accessCode) => navigate(`/room/${accessCode}`, { state: { valid: true }, replace: true }),
   });
 
   const handleAddPairRoom = async (driver: string, navigator: string, missionUrl: string, timerDuration: string) => {


### PR DESCRIPTION
## 연관된 이슈

- closes: #815 

## 구현한 기능
- 페어룸을 링크로 직접 접근할 경우 에러 토스트 표시

## 상세 설명
> <img width="546" alt="스크린샷 2024-10-17 오후 3 52 58" src="https://github.com/user-attachments/assets/4a5c61cd-3ec2-4ac7-aa6a-b559fafa2685">

> 개발 환경이어서 2번 출력되었습니다 😅

- 페어룸으로 리다이렉션 되는 로직에 `valid` 상태를 추가하여 페어룸 접근 시 `valid` 상태가 유효한 경우에만 접근이 가능하도록 구현했습니다.
- 유효하지 않은 경우 메인 페이지로 리다이렉트 되고, 에러 토스트가 표시됩니다.