### PR TITLE
[BE] 페어룸 종료 후 회고 작성 기능 API 구현

### DIFF
--- a/backend/src/main/java/site/coduo/pairroom/controller/PairRoomController.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/PairRoomController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import site.coduo.pairroom.controller.docs.PairRoomDocs;
+import site.coduo.pairroom.controller.dto.request.ExistMemberInPairRoomResponse;
 import site.coduo.pairroom.service.PairRoomService;
 import site.coduo.pairroom.service.dto.PairRoomCreateRequest;
 import site.coduo.pairroom.service.dto.PairRoomCreateResponse;
@@ -98,5 +99,15 @@ public class PairRoomController implements PairRoomDocs {
     public ResponseEntity<Void> deletePairRoom(@PathVariable("accessCode") final String accessCode) {
         pairRoomService.deletePairRoom(accessCode);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/member/{accessCode}/exists")
+    public ResponseEntity<ExistMemberInPairRoomResponse> existMemberInPairRoom(
+            @CookieValue("coduo_whoami") final String credentialToken,
+            @PathVariable("accessCode") final String pairRoomAccessCode
+    ) {
+        final boolean existMemberInPairRoom = pairRoomService.existMemberInPairRoom(credentialToken, pairRoomAccessCode);
+        final ExistMemberInPairRoomResponse response = new ExistMemberInPairRoomResponse(existMemberInPairRoom);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/site/coduo/pairroom/controller/PairRoomController.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/PairRoomController.java
@@ -103,7 +103,7 @@ public class PairRoomController implements PairRoomDocs {
 
     @GetMapping("/member/{accessCode}/exists")
     public ResponseEntity<ExistMemberInPairRoomResponse> existMemberInPairRoom(
-            @CookieValue("coduo_whoami") final String credentialToken,
+            @CookieValue(SIGN_IN_COOKIE_NAME) final String credentialToken,
             @PathVariable("accessCode") final String pairRoomAccessCode
     ) {
         final boolean existMemberInPairRoom = pairRoomService.existMemberInPairRoom(credentialToken, pairRoomAccessCode);

--- a/backend/src/main/java/site/coduo/pairroom/controller/docs/PairRoomDocs.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/docs/PairRoomDocs.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import site.coduo.pairroom.controller.dto.request.ExistMemberInPairRoomResponse;
 import site.coduo.pairroom.service.dto.PairRoomCreateRequest;
 import site.coduo.pairroom.service.dto.PairRoomCreateResponse;
 import site.coduo.pairroom.service.dto.PairRoomExistResponse;
@@ -19,6 +20,7 @@ import site.coduo.pairroom.service.dto.PairRoomMemberResponse;
 import site.coduo.pairroom.service.dto.PairRoomReadRequest;
 import site.coduo.pairroom.service.dto.PairRoomReadResponse;
 import site.coduo.pairroom.service.dto.PairRoomStatusUpdateRequest;
+import site.coduo.retrospect.controller.response.ExistRetrospectWithPairRoomResponse;
 
 @Tag(name = "페어룸 API")
 public interface PairRoomDocs {
@@ -80,5 +82,15 @@ public interface PairRoomDocs {
     ResponseEntity<Void> deletePairRoom(
             @Parameter(description = "페어룸 접근 코드", required = true)
             String accessCode
+    );
+
+    @Operation(summary = "특정 회원이 특정 페어룸에 존재하는지 여부를 조회한다.")
+    @ApiResponse(responseCode = "200", description = "회원 페어룸 참여 여부 조회 성공", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = ExistMemberInPairRoomResponse.class)))
+    ResponseEntity<ExistMemberInPairRoomResponse> existMemberInPairRoom(
+            @Parameter(description = "사용자 식별 보안 코드 (쿠키)", required = true)
+            String credentialToken,
+            @Parameter(description = "페어룸 접근 코드", required = true)
+            String pairRoomAccessCode
     );
 }

--- a/backend/src/main/java/site/coduo/pairroom/controller/dto/request/ExistMemberInPairRoomResponse.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/dto/request/ExistMemberInPairRoomResponse.java
@@ -1,0 +1,4 @@
+package site.coduo.pairroom.controller.dto.request;
+
+public record ExistMemberInPairRoomResponse(boolean exists) {
+}

--- a/backend/src/main/java/site/coduo/pairroom/exception/PairRoomMemberNotJoinException.java
+++ b/backend/src/main/java/site/coduo/pairroom/exception/PairRoomMemberNotJoinException.java
@@ -1,0 +1,8 @@
+package site.coduo.pairroom.exception;
+
+public class PairRoomMemberNotJoinException extends PairRoomException {
+
+    public PairRoomMemberNotJoinException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/site/coduo/pairroom/repository/PairRoomMemberRepository.java
+++ b/backend/src/main/java/site/coduo/pairroom/repository/PairRoomMemberRepository.java
@@ -9,4 +9,6 @@ import site.coduo.member.domain.Member;
 public interface PairRoomMemberRepository extends JpaRepository<PairRoomMemberEntity, Long> {
 
     List<PairRoomMemberEntity> findByMember(Member member);
+
+    boolean existsByPairRoomAndMember(PairRoomEntity pairRoom, Member member);
 }

--- a/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
@@ -3,6 +3,7 @@ package site.coduo.pairroom.service;
 import java.util.List;
 
 import jakarta.annotation.Nullable;
+import jakarta.persistence.EntityNotFoundException;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -124,5 +125,21 @@ public class PairRoomService {
         final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCode);
         checkDeletePairRoom(pairRoomEntity);
         pairRoomEntity.updateStatus(PairRoomStatus.DELETED);
+    }
+
+    public boolean existMemberInPairRoom(final String credentialToken, final String pairRoomAccessCode) {
+        final PairRoomEntity pairRoom = findPairRoom(pairRoomAccessCode);
+        final Member member = memberService.findMemberByCredential(credentialToken);
+        return pairRoomMemberRepository.existsByPairRoomAndMember(pairRoom, member);
+    }
+
+    private PairRoomEntity findPairRoom(final String pairRoomAccessCode) {
+        if (pairRoomAccessCode == null || pairRoomAccessCode.isEmpty()) {
+            throw new IllegalArgumentException("페어룸 접근 코드로 null 혹은 빈 값이 입력될 수 없습니다.");
+        }
+
+        return pairRoomRepository.findByAccessCode(pairRoomAccessCode)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "입력된 페어룸 접근 코드에 대응되는 페어룸이 존재하지 않습니다. - " + pairRoomAccessCode));
     }
 }

--- a/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
@@ -134,7 +134,7 @@ public class PairRoomService {
     }
 
     private PairRoomEntity findPairRoom(final String pairRoomAccessCode) {
-        if (pairRoomAccessCode == null || pairRoomAccessCode.isEmpty()) {
+        if (pairRoomAccessCode == null || pairRoomAccessCode.isBlank()) {
             throw new IllegalArgumentException("페어룸 접근 코드로 null 혹은 빈 값이 입력될 수 없습니다.");
         }
 

--- a/backend/src/main/java/site/coduo/retrospect/controller/RetrospectController.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/RetrospectController.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -45,5 +46,14 @@ public class RetrospectController {
         final Retrospect retrospect = retrospectService.findRetrospectById(retrospectId);
         final FindRetrospectByIdResponse response = FindRetrospectByIdResponse.of(retrospect);
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/retrospects/{retrospectId}")
+    public ResponseEntity<Void> deleteRetrospect(
+            @CookieValue("coduo_whoami") final String credentialToken,
+            @PathVariable("retrospectId") final Long retrospectId
+    ) {
+        retrospectService.deleteRetrospect(credentialToken, retrospectId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/site/coduo/retrospect/controller/RetrospectController.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/RetrospectController.java
@@ -41,7 +41,7 @@ public class RetrospectController implements RetrospectDocs {
     @GetMapping("/retrospects")
     public ResponseEntity<FindRetrospectsResponse> findRetrospects(@CookieValue(SIGN_IN_COOKIE_NAME) final String credentialToken) {
         final List<Retrospect> retrospects = retrospectService.findAllRetrospectsByMember(credentialToken);
-        final FindRetrospectsResponse response = FindRetrospectsResponse.of(retrospects);
+        final FindRetrospectsResponse response = FindRetrospectsResponse.from(retrospects);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/site/coduo/retrospect/controller/RetrospectController.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/RetrospectController.java
@@ -1,5 +1,7 @@
 package site.coduo.retrospect.controller;
 
+import static site.coduo.common.config.web.filter.SignInCookieFilter.SIGN_IN_COOKIE_NAME;
+
 import java.net.URI;
 import java.util.List;
 
@@ -29,7 +31,7 @@ public class RetrospectController implements RetrospectDocs {
 
     @PostMapping("/retrospects")
     public ResponseEntity<Void> createRetrospect(
-            @CookieValue("coduo_whoami") final String credentialToken,
+            @CookieValue(SIGN_IN_COOKIE_NAME) final String credentialToken,
             @RequestBody CreateRetrospectRequest request
     ) {
         retrospectService.createRetrospect(credentialToken, request.pairRoomAccessCode(), request.answers());
@@ -37,7 +39,7 @@ public class RetrospectController implements RetrospectDocs {
     }
 
     @GetMapping("/retrospects")
-    public ResponseEntity<FindRetrospectsResponse> findRetrospects(@CookieValue("coduo_whoami") final String credentialToken) {
+    public ResponseEntity<FindRetrospectsResponse> findRetrospects(@CookieValue(SIGN_IN_COOKIE_NAME) final String credentialToken) {
         final List<Retrospect> retrospects = retrospectService.findAllRetrospectsByMember(credentialToken);
         final FindRetrospectsResponse response = FindRetrospectsResponse.of(retrospects);
         return ResponseEntity.ok(response);
@@ -52,7 +54,7 @@ public class RetrospectController implements RetrospectDocs {
 
     @DeleteMapping("/retrospects/{retrospectId}")
     public ResponseEntity<Void> deleteRetrospect(
-            @CookieValue("coduo_whoami") final String credentialToken,
+            @CookieValue(SIGN_IN_COOKIE_NAME) final String credentialToken,
             @PathVariable("retrospectId") final Long retrospectId
     ) {
         retrospectService.deleteRetrospect(credentialToken, retrospectId);
@@ -61,7 +63,7 @@ public class RetrospectController implements RetrospectDocs {
 
     @GetMapping("/member/retrospect/{accessCode}/exists")
     public ResponseEntity<ExistRetrospectWithPairRoomResponse> existRetrospectWithPairRoom(
-            @CookieValue("coduo_whoami") final String credentialToken,
+            @CookieValue(SIGN_IN_COOKIE_NAME) final String credentialToken,
             @PathVariable("accessCode") final String pairRoomAccessCode
     ) {
         final boolean existRetrospect = retrospectService.existRetrospectWithPairRoom(credentialToken, pairRoomAccessCode);

--- a/backend/src/main/java/site/coduo/retrospect/controller/RetrospectController.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/RetrospectController.java
@@ -6,12 +6,14 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import site.coduo.retrospect.controller.request.CreateRetrospectRequest;
+import site.coduo.retrospect.controller.response.FindRetrospectByIdResponse;
 import site.coduo.retrospect.controller.response.FindRetrospectsResponse;
 import site.coduo.retrospect.domain.Retrospect;
 import site.coduo.retrospect.service.RetrospectService;
@@ -35,6 +37,13 @@ public class RetrospectController {
     public ResponseEntity<FindRetrospectsResponse> findRetrospects(@CookieValue("coduo_whoami") final String credentialToken) {
         final List<Retrospect> retrospects = retrospectService.findAllRetrospectsByMember(credentialToken);
         final FindRetrospectsResponse response = FindRetrospectsResponse.of(retrospects);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/retrospects/{retrospectId}")
+    public ResponseEntity<FindRetrospectByIdResponse> findRetrospectById(@PathVariable("retrospectId") final Long retrospectId) {
+        final Retrospect retrospect = retrospectService.findRetrospectById(retrospectId);
+        final FindRetrospectByIdResponse response = FindRetrospectByIdResponse.of(retrospect);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/site/coduo/retrospect/controller/RetrospectController.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/RetrospectController.java
@@ -1,0 +1,29 @@
+package site.coduo.retrospect.controller;
+
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import site.coduo.retrospect.controller.request.CreateRetrospectRequest;
+import site.coduo.retrospect.service.RetrospectService;
+
+@RequiredArgsConstructor
+@RestController
+public class RetrospectController {
+
+    private final RetrospectService retrospectService;
+
+    @PostMapping("/retrospects")
+    public ResponseEntity<Void> createRetrospect(
+            @CookieValue("coduo_whoami") final String credentialToken,
+            @RequestBody CreateRetrospectRequest request
+    ) {
+        retrospectService.createRetrospect(credentialToken, request.pairRoomAccessCode(), request.answers());
+        return ResponseEntity.created(URI.create("/")).build();
+    }
+}

--- a/backend/src/main/java/site/coduo/retrospect/controller/RetrospectController.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/RetrospectController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
+import site.coduo.retrospect.controller.docs.RetrospectDocs;
 import site.coduo.retrospect.controller.request.CreateRetrospectRequest;
 import site.coduo.retrospect.controller.response.ExistRetrospectWithPairRoomResponse;
 import site.coduo.retrospect.controller.response.FindRetrospectByIdResponse;
@@ -22,7 +23,7 @@ import site.coduo.retrospect.service.RetrospectService;
 
 @RequiredArgsConstructor
 @RestController
-public class RetrospectController {
+public class RetrospectController implements RetrospectDocs {
 
     private final RetrospectService retrospectService;
 

--- a/backend/src/main/java/site/coduo/retrospect/controller/RetrospectController.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/RetrospectController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import site.coduo.retrospect.controller.request.CreateRetrospectRequest;
+import site.coduo.retrospect.controller.response.ExistRetrospectWithPairRoomResponse;
 import site.coduo.retrospect.controller.response.FindRetrospectByIdResponse;
 import site.coduo.retrospect.controller.response.FindRetrospectsResponse;
 import site.coduo.retrospect.domain.Retrospect;
@@ -55,5 +56,15 @@ public class RetrospectController {
     ) {
         retrospectService.deleteRetrospect(credentialToken, retrospectId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/member/retrospect/{accessCode}/exists")
+    public ResponseEntity<ExistRetrospectWithPairRoomResponse> existRetrospectWithPairRoom(
+            @CookieValue("coduo_whoami") final String credentialToken,
+            @PathVariable("accessCode") final String pairRoomAccessCode
+    ) {
+        final boolean existRetrospect = retrospectService.existRetrospectWithPairRoom(credentialToken, pairRoomAccessCode);
+        final ExistRetrospectWithPairRoomResponse response = new ExistRetrospectWithPairRoomResponse(existRetrospect);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/site/coduo/retrospect/controller/RetrospectController.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/RetrospectController.java
@@ -1,15 +1,19 @@
 package site.coduo.retrospect.controller;
 
 import java.net.URI;
+import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import site.coduo.retrospect.controller.request.CreateRetrospectRequest;
+import site.coduo.retrospect.controller.response.FindRetrospectsResponse;
+import site.coduo.retrospect.domain.Retrospect;
 import site.coduo.retrospect.service.RetrospectService;
 
 @RequiredArgsConstructor
@@ -25,5 +29,12 @@ public class RetrospectController {
     ) {
         retrospectService.createRetrospect(credentialToken, request.pairRoomAccessCode(), request.answers());
         return ResponseEntity.created(URI.create("/")).build();
+    }
+
+    @GetMapping("/retrospects")
+    public ResponseEntity<FindRetrospectsResponse> findRetrospects(@CookieValue("coduo_whoami") final String credentialToken) {
+        final List<Retrospect> retrospects = retrospectService.findAllRetrospectsByMember(credentialToken);
+        final FindRetrospectsResponse response = FindRetrospectsResponse.of(retrospects);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/site/coduo/retrospect/controller/RetrospectController.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/RetrospectController.java
@@ -48,7 +48,7 @@ public class RetrospectController implements RetrospectDocs {
     @GetMapping("/retrospects/{retrospectId}")
     public ResponseEntity<FindRetrospectByIdResponse> findRetrospectById(@PathVariable("retrospectId") final Long retrospectId) {
         final Retrospect retrospect = retrospectService.findRetrospectById(retrospectId);
-        final FindRetrospectByIdResponse response = FindRetrospectByIdResponse.of(retrospect);
+        final FindRetrospectByIdResponse response = FindRetrospectByIdResponse.from(retrospect);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/site/coduo/retrospect/controller/RetrospectExceptionHandler.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/RetrospectExceptionHandler.java
@@ -1,0 +1,67 @@
+package site.coduo.retrospect.controller;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+import site.coduo.common.controller.response.ApiErrorResponse;
+import site.coduo.retrospect.controller.error.RetrospectApiError;
+import site.coduo.retrospect.exception.InvalidRetrospectContentException;
+import site.coduo.retrospect.exception.InvalidRetrospectInputValueException;
+import site.coduo.retrospect.exception.InvalidRetrospectQuestionTypeException;
+import site.coduo.retrospect.exception.NotRetrospectOwnerAccessException;
+import site.coduo.retrospect.exception.RetrospectNotFoundException;
+
+@Slf4j
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RetrospectExceptionHandler {
+
+    @ExceptionHandler(InvalidRetrospectContentException.class)
+    public ResponseEntity<ApiErrorResponse> handleInvalidRetrospectContentException(
+            final InvalidRetrospectContentException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(RetrospectApiError.INVALID_RETROSPECT_CONTENT_ERROR.getHttpStatus())
+                .body(new ApiErrorResponse(RetrospectApiError.INVALID_RETROSPECT_CONTENT_ERROR.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidRetrospectInputValueException.class)
+    public ResponseEntity<ApiErrorResponse> handleInvalidRetrospectInputValueException(
+            final InvalidRetrospectInputValueException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(RetrospectApiError.INVALID_RETROSPECT_INPUT_ERROR.getHttpStatus())
+                .body(new ApiErrorResponse(RetrospectApiError.INVALID_RETROSPECT_INPUT_ERROR.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidRetrospectQuestionTypeException.class)
+    public ResponseEntity<ApiErrorResponse> handleInvalidRetrospectQuestionTypeException(
+            final InvalidRetrospectQuestionTypeException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(RetrospectApiError.INVALID_RETROSPECT_QUESTION_TYPE_ERROR.getHttpStatus())
+                .body(new ApiErrorResponse(RetrospectApiError.INVALID_RETROSPECT_QUESTION_TYPE_ERROR.getMessage()));
+    }
+
+    @ExceptionHandler(NotRetrospectOwnerAccessException.class)
+    public ResponseEntity<ApiErrorResponse> handleNotRetrospectOwnerAccessException(
+            final NotRetrospectOwnerAccessException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(RetrospectApiError.NOT_RETROSPECT_OWNER_ACCESS_ERROR.getHttpStatus())
+                .body(new ApiErrorResponse(RetrospectApiError.NOT_RETROSPECT_OWNER_ACCESS_ERROR.getMessage()));
+    }
+
+    @ExceptionHandler(RetrospectNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleRetrospectNotFoundException(
+            final RetrospectNotFoundException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(RetrospectApiError.RETROSPECT_NOT_FOUND_ERROR.getHttpStatus())
+                .body(new ApiErrorResponse(RetrospectApiError.RETROSPECT_NOT_FOUND_ERROR.getMessage()));
+    }
+}

--- a/backend/src/main/java/site/coduo/retrospect/controller/docs/RetrospectDocs.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/docs/RetrospectDocs.java
@@ -1,0 +1,61 @@
+package site.coduo.retrospect.controller.docs;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import site.coduo.retrospect.controller.request.CreateRetrospectRequest;
+import site.coduo.retrospect.controller.response.ExistRetrospectWithPairRoomResponse;
+import site.coduo.retrospect.controller.response.FindRetrospectByIdResponse;
+import site.coduo.retrospect.controller.response.FindRetrospectsResponse;
+
+@Tag(name = "회고 API")
+public interface RetrospectDocs {
+
+    @Operation(summary = "회고를 생성한다.")
+    @ApiResponse(responseCode = "201", description = "회고 생성 성공", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+    ResponseEntity<Void> createRetrospect(
+            @Parameter(description = "사용자 식별 보안 코드 (쿠키)", required = true)
+            String credentialToken,
+            @Parameter(description = "API 요청 바디")
+            CreateRetrospectRequest request
+    );
+
+    @Operation(summary = "특정 사용자의 전체 회고 정보를 조회한다.")
+    @ApiResponse(responseCode = "200", description = "전체 회고 정보 조회 성공", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = FindRetrospectsResponse.class)))
+    ResponseEntity<FindRetrospectsResponse> findRetrospects(
+            @Parameter(description = "사용자 식별 보안 코드 (쿠키)", required = true)
+            String credentialToken
+    );
+
+    @Operation(summary = "특정 회고를 상세 조회 한다.")
+    @ApiResponse(responseCode = "200", description = "회고 상세 조회 성공", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = FindRetrospectByIdResponse.class)))
+    ResponseEntity<FindRetrospectByIdResponse> findRetrospectById(
+            @Parameter(description = "회고 id", required = true) final Long retrospectId
+    );
+
+    @Operation(summary = "특정 회고를 삭제 한다.")
+    @ApiResponse(responseCode = "204", description = "회고 삭제 성공", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+    ResponseEntity<Void> deleteRetrospect(
+            @Parameter(description = "사용자 식별 보안 코드 (쿠키)", required = true)
+            String credentialToken,
+            @Parameter(description = "회고 id", required = true) final Long retrospectId
+    );
+
+    @Operation(summary = "특정 회원, 특정 페어룸에 속한 회고의 존재 여부를 조회한다.")
+    @ApiResponse(responseCode = "200", description = "회고 존재 여부 조회 성공", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = ExistRetrospectWithPairRoomResponse.class)))
+    ResponseEntity<ExistRetrospectWithPairRoomResponse> existRetrospectWithPairRoom(
+            @Parameter(description = "사용자 식별 보안 코드 (쿠키)", required = true)
+            String credentialToken,
+            @Parameter(description = "페어룸 접근 코드", required = true)
+            String pairRoomAccessCode
+    );
+}

--- a/backend/src/main/java/site/coduo/retrospect/controller/docs/RetrospectDocs.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/docs/RetrospectDocs.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import site.coduo.common.controller.response.ApiErrorResponse;
 import site.coduo.retrospect.controller.request.CreateRetrospectRequest;
 import site.coduo.retrospect.controller.response.ExistRetrospectWithPairRoomResponse;
 import site.coduo.retrospect.controller.response.FindRetrospectByIdResponse;
@@ -19,6 +20,9 @@ public interface RetrospectDocs {
 
     @Operation(summary = "회고를 생성한다.")
     @ApiResponse(responseCode = "201", description = "회고 생성 성공", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+    @ApiResponse(responseCode = "400", description = "잘못된 회고 내용 입력",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ApiErrorResponse.class)))
     ResponseEntity<Void> createRetrospect(
             @Parameter(description = "사용자 식별 보안 코드 (쿠키)", required = true)
             String credentialToken,
@@ -37,12 +41,21 @@ public interface RetrospectDocs {
     @Operation(summary = "특정 회고를 상세 조회 한다.")
     @ApiResponse(responseCode = "200", description = "회고 상세 조회 성공", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
             schema = @Schema(implementation = FindRetrospectByIdResponse.class)))
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 회고 조회",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ApiErrorResponse.class)))
     ResponseEntity<FindRetrospectByIdResponse> findRetrospectById(
             @Parameter(description = "회고 id", required = true) final Long retrospectId
     );
 
     @Operation(summary = "특정 회고를 삭제 한다.")
     @ApiResponse(responseCode = "204", description = "회고 삭제 성공", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 회고 삭제",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ApiErrorResponse.class)))
+    @ApiResponse(responseCode = "403", description = "본인 소유가 아닌 회고 삭제 시도",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ApiErrorResponse.class)))
     ResponseEntity<Void> deleteRetrospect(
             @Parameter(description = "사용자 식별 보안 코드 (쿠키)", required = true)
             String credentialToken,

--- a/backend/src/main/java/site/coduo/retrospect/controller/error/RetrospectApiError.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/error/RetrospectApiError.java
@@ -1,0 +1,21 @@
+package site.coduo.retrospect.controller.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RetrospectApiError {
+
+    INVALID_RETROSPECT_CONTENT_ERROR(HttpStatus.BAD_REQUEST, "잘못된 회고 내용입니다."),
+    INVALID_RETROSPECT_QUESTION_TYPE_ERROR(HttpStatus.BAD_REQUEST, "잘못된 회고 질문 유형입니다."),
+    INVALID_RETROSPECT_INPUT_ERROR(HttpStatus.BAD_REQUEST, "잘못된 회고 입력 값입니다."),
+    NOT_RETROSPECT_OWNER_ACCESS_ERROR(HttpStatus.FORBIDDEN, "회고 소유자 외 접근할 수 없는 작업입니다."),
+    RETROSPECT_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "해당 요청의 회고가 존재하지 않습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/backend/src/main/java/site/coduo/retrospect/controller/request/CreateRetrospectRequest.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/request/CreateRetrospectRequest.java
@@ -2,5 +2,13 @@ package site.coduo.retrospect.controller.request;
 
 import java.util.List;
 
-public record CreateRetrospectRequest(String pairRoomAccessCode, List<String> answers) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회고 생성 요청 바디")
+public record CreateRetrospectRequest(
+        @Schema(description = "페어룸 접근 코드")
+        String pairRoomAccessCode,
+        @Schema(description = "회고 내용")
+        List<String> answers
+) {
 }

--- a/backend/src/main/java/site/coduo/retrospect/controller/request/CreateRetrospectRequest.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/request/CreateRetrospectRequest.java
@@ -1,0 +1,6 @@
+package site.coduo.retrospect.controller.request;
+
+import java.util.List;
+
+public record CreateRetrospectRequest(String pairRoomAccessCode, List<String> answers) {
+}

--- a/backend/src/main/java/site/coduo/retrospect/controller/response/ExistRetrospectWithPairRoomResponse.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/response/ExistRetrospectWithPairRoomResponse.java
@@ -1,4 +1,10 @@
 package site.coduo.retrospect.controller.response;
 
-public record ExistRetrospectWithPairRoomResponse(boolean existRetrospect) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "특정 페어룸에 특정 회고 존재 여부 응답 바디")
+public record ExistRetrospectWithPairRoomResponse(
+        @Schema(description = "존재 여부", example = "true")
+        boolean existRetrospect
+) {
 }

--- a/backend/src/main/java/site/coduo/retrospect/controller/response/ExistRetrospectWithPairRoomResponse.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/response/ExistRetrospectWithPairRoomResponse.java
@@ -1,0 +1,4 @@
+package site.coduo.retrospect.controller.response;
+
+public record ExistRetrospectWithPairRoomResponse(boolean existRetrospect) {
+}

--- a/backend/src/main/java/site/coduo/retrospect/controller/response/FindRetrospectByIdResponse.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/response/FindRetrospectByIdResponse.java
@@ -1,0 +1,16 @@
+package site.coduo.retrospect.controller.response;
+
+import java.util.List;
+
+import site.coduo.retrospect.domain.Retrospect;
+
+public record FindRetrospectByIdResponse(String pairRoomAccessCode, List<String> answers) {
+
+    public static FindRetrospectByIdResponse of(Retrospect retrospect) {
+        final List<String> answers = retrospect.getContents().getValues()
+                .stream()
+                .map(retrospectContent -> retrospectContent.getAnswer().getValue())
+                .toList();
+        return new FindRetrospectByIdResponse(retrospect.getPairRoom().getAccessCodeText(), answers);
+    }
+}

--- a/backend/src/main/java/site/coduo/retrospect/controller/response/FindRetrospectByIdResponse.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/response/FindRetrospectByIdResponse.java
@@ -6,7 +6,7 @@ import site.coduo.retrospect.domain.Retrospect;
 
 public record FindRetrospectByIdResponse(String pairRoomAccessCode, List<String> answers) {
 
-    public static FindRetrospectByIdResponse of(Retrospect retrospect) {
+    public static FindRetrospectByIdResponse from(final Retrospect retrospect) {
         final List<String> answers = retrospect.getContents().getValues()
                 .stream()
                 .map(retrospectContent -> retrospectContent.getAnswer().getValue())

--- a/backend/src/main/java/site/coduo/retrospect/controller/response/FindRetrospectByIdResponse.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/response/FindRetrospectByIdResponse.java
@@ -2,9 +2,16 @@ package site.coduo.retrospect.controller.response;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import site.coduo.retrospect.domain.Retrospect;
 
-public record FindRetrospectByIdResponse(String pairRoomAccessCode, List<String> answers) {
+@Schema(description = "특정 회고 id 조회 응답 바디")
+public record FindRetrospectByIdResponse(
+        @Schema(description = "페어룸 접근 코드")
+        String pairRoomAccessCode,
+        @Schema(description = "회고 내용")
+        List<String> answers
+) {
 
     public static FindRetrospectByIdResponse from(final Retrospect retrospect) {
         final List<String> answers = retrospect.getContents().getValues()

--- a/backend/src/main/java/site/coduo/retrospect/controller/response/FindRetrospectsResponse.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/response/FindRetrospectsResponse.java
@@ -1,0 +1,25 @@
+package site.coduo.retrospect.controller.response;
+
+import java.util.List;
+
+import site.coduo.retrospect.domain.Retrospect;
+
+public record FindRetrospectsResponse(List<Data> retrospects) {
+
+    public static FindRetrospectsResponse of(List<Retrospect> retrospects) {
+        final List<Data> data = retrospects.stream()
+                .map(retrospect -> new Data(
+                        retrospect.getId(),
+                        retrospect.getPairRoom().getAccessCodeText(),
+                        retrospect.getContents().getFirst().getAnswer().getValue()
+                )).toList();
+
+        return new FindRetrospectsResponse(data);
+    }
+
+    record Data(
+            Long retrospectId,
+            String pairRoomAccessCode,
+            String answer
+    ){}
+}

--- a/backend/src/main/java/site/coduo/retrospect/controller/response/FindRetrospectsResponse.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/response/FindRetrospectsResponse.java
@@ -6,7 +6,7 @@ import site.coduo.retrospect.domain.Retrospect;
 
 public record FindRetrospectsResponse(List<Data> retrospects) {
 
-    public static FindRetrospectsResponse of(List<Retrospect> retrospects) {
+    public static FindRetrospectsResponse from(List<Retrospect> retrospects) {
         final List<Data> data = retrospects.stream()
                 .map(retrospect -> new Data(
                         retrospect.getId(),

--- a/backend/src/main/java/site/coduo/retrospect/controller/response/FindRetrospectsResponse.java
+++ b/backend/src/main/java/site/coduo/retrospect/controller/response/FindRetrospectsResponse.java
@@ -2,9 +2,14 @@ package site.coduo.retrospect.controller.response;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import site.coduo.retrospect.domain.Retrospect;
 
-public record FindRetrospectsResponse(List<Data> retrospects) {
+@Schema(description = "특정 사용자 회고 전체 조회 응답 바디")
+public record FindRetrospectsResponse(
+        @Schema(description = "바디 데이터")
+        List<Data> retrospects
+) {
 
     public static FindRetrospectsResponse from(List<Retrospect> retrospects) {
         final List<Data> data = retrospects.stream()
@@ -18,8 +23,11 @@ public record FindRetrospectsResponse(List<Data> retrospects) {
     }
 
     record Data(
+            @Schema(description = "회고 아이디", example = "1")
             Long retrospectId,
+            @Schema(description = "페어룸 접근 코드")
             String pairRoomAccessCode,
+            @Schema(description = "첫번째 회고 답변", example = "답변1")
             String answer
     ){}
 }

--- a/backend/src/main/java/site/coduo/retrospect/domain/Retrospect.java
+++ b/backend/src/main/java/site/coduo/retrospect/domain/Retrospect.java
@@ -3,6 +3,8 @@ package site.coduo.retrospect.domain;
 import lombok.Getter;
 import site.coduo.member.domain.Member;
 import site.coduo.pairroom.domain.PairRoom;
+import site.coduo.retrospect.exception.InvalidRetrospectContentException;
+import site.coduo.retrospect.exception.InvalidRetrospectInputValueException;
 
 @Getter
 public class Retrospect {
@@ -47,19 +49,19 @@ public class Retrospect {
 
     private void validatePairRoom(final PairRoom pairRoom) {
         if (pairRoom == null) {
-            throw new IllegalArgumentException("페어룸 객체로 null을 입력할 수 없습니다.");
+            throw new InvalidRetrospectInputValueException("페어룸 객체로 null을 입력할 수 없습니다.");
         }
     }
 
     private void validateMember(final Member member) {
         if (member == null) {
-            throw new IllegalArgumentException("회원 객체로 null을 입력할 수 없습니다.");
+            throw new InvalidRetrospectInputValueException("회원 객체로 null을 입력할 수 없습니다.");
         }
     }
 
     private void validateContents(final RetrospectContents contents) {
         if (contents == null) {
-            throw new IllegalArgumentException("회고 내용들로 null을 입력할 수 없습니다.");
+            throw new InvalidRetrospectContentException("회고 내용들로 null을 입력할 수 없습니다.");
         }
     }
 }

--- a/backend/src/main/java/site/coduo/retrospect/domain/Retrospect.java
+++ b/backend/src/main/java/site/coduo/retrospect/domain/Retrospect.java
@@ -1,0 +1,65 @@
+package site.coduo.retrospect.domain;
+
+import lombok.Getter;
+import site.coduo.member.domain.Member;
+import site.coduo.pairroom.domain.PairRoom;
+
+@Getter
+public class Retrospect {
+
+    private static final long DEFAULT_ID = 0;
+
+    private final long id;
+    private final PairRoom pairRoom;
+    private final Member member;
+    private final RetrospectContents contents;
+
+    public Retrospect(
+            final PairRoom pairRoom,
+            final Member member,
+            final RetrospectContents contents
+    ) {
+        this(DEFAULT_ID, pairRoom, member, contents);
+    }
+
+    public Retrospect(
+            final long id,
+            final PairRoom pairRoom,
+            final Member member,
+            final RetrospectContents contents
+    ) {
+        validateRetrospectId(id);
+        validatePairRoom(pairRoom);
+        validateMember(member);
+        validateContents(contents);
+
+        this.id = id;
+        this.contents = contents;
+        this.pairRoom = pairRoom;
+        this.member = member;
+    }
+
+    private void validateRetrospectId(final long id) {
+        if (id < 0) {
+            throw new IllegalArgumentException("회고 아이디 값은 음수가 입력될 수 없습니다. - " + id);
+        }
+    }
+
+    private void validatePairRoom(final PairRoom pairRoom) {
+        if (pairRoom == null) {
+            throw new IllegalArgumentException("페어룸 객체로 null을 입력할 수 없습니다.");
+        }
+    }
+
+    private void validateMember(final Member member) {
+        if (member == null) {
+            throw new IllegalArgumentException("회원 객체로 null을 입력할 수 없습니다.");
+        }
+    }
+
+    private void validateContents(final RetrospectContents contents) {
+        if (contents == null) {
+            throw new IllegalArgumentException("회고 내용들로 null을 입력할 수 없습니다.");
+        }
+    }
+}

--- a/backend/src/main/java/site/coduo/retrospect/domain/RetrospectAnswer.java
+++ b/backend/src/main/java/site/coduo/retrospect/domain/RetrospectAnswer.java
@@ -1,6 +1,7 @@
 package site.coduo.retrospect.domain;
 
 import lombok.Getter;
+import site.coduo.retrospect.exception.InvalidRetrospectContentException;
 
 @Getter
 public class RetrospectAnswer {
@@ -17,13 +18,14 @@ public class RetrospectAnswer {
 
     private void validateValueIsNull(final String value) {
         if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException("회고 답변 내용으로 null 혹은 공백을 입력할 수 없습니다. - " + value);
+            throw new InvalidRetrospectContentException("회고 답변 내용으로 null 혹은 공백을 입력할 수 없습니다. - " + value);
         }
     }
 
     private void validateValueLength(final String value) {
         if (value.length() > MAXIMUM_CONTENT_LENGTH_LIMIT) {
-            throw new IllegalArgumentException("회고 답변 길이는 " + MAXIMUM_CONTENT_LENGTH_LIMIT + "자 이하여야 합니다. - " + value.length());
+            throw new InvalidRetrospectContentException(
+                    "회고 답변 길이는 " + MAXIMUM_CONTENT_LENGTH_LIMIT + "자 이하여야 합니다. - " + value.length());
         }
     }
 }

--- a/backend/src/main/java/site/coduo/retrospect/domain/RetrospectAnswer.java
+++ b/backend/src/main/java/site/coduo/retrospect/domain/RetrospectAnswer.java
@@ -1,0 +1,20 @@
+package site.coduo.retrospect.domain;
+
+import lombok.Getter;
+
+@Getter
+public class RetrospectAnswer {
+
+    private final String value;
+
+    public RetrospectAnswer(final String value) {
+        validateValue(value);
+        this.value = value;
+    }
+
+    private void validateValue(final String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("회고 답변 내용으로 null 혹은 공백을 입력할 수 없습니다. - " + value);
+        }
+    }
+}

--- a/backend/src/main/java/site/coduo/retrospect/domain/RetrospectAnswer.java
+++ b/backend/src/main/java/site/coduo/retrospect/domain/RetrospectAnswer.java
@@ -5,16 +5,25 @@ import lombok.Getter;
 @Getter
 public class RetrospectAnswer {
 
+    private static final int MAXIMUM_CONTENT_LENGTH_LIMIT = 1000;
+
     private final String value;
 
     public RetrospectAnswer(final String value) {
-        validateValue(value);
+        validateValueIsNull(value);
+        validateValueLength(value);
         this.value = value;
     }
 
-    private void validateValue(final String value) {
+    private void validateValueIsNull(final String value) {
         if (value == null || value.isBlank()) {
             throw new IllegalArgumentException("회고 답변 내용으로 null 혹은 공백을 입력할 수 없습니다. - " + value);
+        }
+    }
+
+    private void validateValueLength(final String value) {
+        if (value.length() > MAXIMUM_CONTENT_LENGTH_LIMIT) {
+            throw new IllegalArgumentException("회고 답변 길이는 " + MAXIMUM_CONTENT_LENGTH_LIMIT + "자 이하여야 합니다. - " + value.length());
         }
     }
 }

--- a/backend/src/main/java/site/coduo/retrospect/domain/RetrospectContent.java
+++ b/backend/src/main/java/site/coduo/retrospect/domain/RetrospectContent.java
@@ -1,0 +1,30 @@
+package site.coduo.retrospect.domain;
+
+import lombok.Getter;
+
+@Getter
+public class RetrospectContent {
+
+    private final RetrospectQuestionType questionType;
+    private final RetrospectAnswer answer;
+
+    public RetrospectContent(final RetrospectQuestionType questionType, final RetrospectAnswer answer) {
+        validateQuestionType(questionType);
+        validateAnswer(answer);
+
+        this.answer = answer;
+        this.questionType = questionType;
+    }
+
+    private void validateQuestionType(final RetrospectQuestionType questionType) {
+        if (questionType == null) {
+            throw new IllegalArgumentException("회고 문항 유형 객체로 null이 입력될 수 없습니다.");
+        }
+    }
+
+    private void validateAnswer(final RetrospectAnswer answer) {
+        if (answer == null) {
+            throw new IllegalArgumentException("회고 답변 객체로 null을 입력할 수 없습니다.");
+        }
+    }
+}

--- a/backend/src/main/java/site/coduo/retrospect/domain/RetrospectContent.java
+++ b/backend/src/main/java/site/coduo/retrospect/domain/RetrospectContent.java
@@ -1,6 +1,7 @@
 package site.coduo.retrospect.domain;
 
 import lombok.Getter;
+import site.coduo.retrospect.exception.InvalidRetrospectContentException;
 
 @Getter
 public class RetrospectContent {
@@ -18,13 +19,13 @@ public class RetrospectContent {
 
     private void validateQuestionType(final RetrospectQuestionType questionType) {
         if (questionType == null) {
-            throw new IllegalArgumentException("회고 문항 유형 객체로 null이 입력될 수 없습니다.");
+            throw new InvalidRetrospectContentException("회고 문항 유형 객체로 null이 입력될 수 없습니다.");
         }
     }
 
     private void validateAnswer(final RetrospectAnswer answer) {
         if (answer == null) {
-            throw new IllegalArgumentException("회고 답변 객체로 null을 입력할 수 없습니다.");
+            throw new InvalidRetrospectContentException("회고 답변 객체로 null을 입력할 수 없습니다.");
         }
     }
 }

--- a/backend/src/main/java/site/coduo/retrospect/domain/RetrospectContents.java
+++ b/backend/src/main/java/site/coduo/retrospect/domain/RetrospectContents.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.IntStream;
 
 import lombok.Getter;
+import site.coduo.retrospect.exception.InvalidRetrospectContentException;
 
 @Getter
 public class RetrospectContents {
@@ -19,11 +20,11 @@ public class RetrospectContents {
 
     private void validateValues(final List<RetrospectContent> values) {
         if (values == null) {
-            throw new IllegalArgumentException("회고 문항 내용들로 null을 입력할 수 없습니다.");
+            throw new InvalidRetrospectContentException("회고 문항 내용들로 null을 입력할 수 없습니다.");
         }
 
         if (values.size() != RETROSPECT_CONTENTS_SIZE) {
-            throw new IllegalArgumentException("회고 내용 개수는 " + RETROSPECT_CONTENTS_SIZE + "개여야 합니다. - " + values.size());
+            throw new InvalidRetrospectContentException("회고 내용 개수는 " + RETROSPECT_CONTENTS_SIZE + "개여야 합니다. - " + values.size());
         }
     }
 
@@ -38,7 +39,7 @@ public class RetrospectContents {
 
     private static void validateAnswers(final List<String> answers) {
         if (answers == null) {
-            throw new IllegalArgumentException("회고 문항 내용 문자열 값들로 null을 입력할 수 없습니다.");
+            throw new InvalidRetrospectContentException("회고 문항 내용 문자열 값들로 null을 입력할 수 없습니다.");
         }
     }
 

--- a/backend/src/main/java/site/coduo/retrospect/domain/RetrospectContents.java
+++ b/backend/src/main/java/site/coduo/retrospect/domain/RetrospectContents.java
@@ -46,4 +46,8 @@ public class RetrospectContents {
         final RetrospectQuestionType retrospectQuestionType = RetrospectQuestionType.findByIndex(index);
         return new RetrospectContent(retrospectQuestionType, retrospectAnswers.get(index));
     }
+
+    public RetrospectContent getFirst() {
+        return values.get(0);
+    }
 }

--- a/backend/src/main/java/site/coduo/retrospect/domain/RetrospectContents.java
+++ b/backend/src/main/java/site/coduo/retrospect/domain/RetrospectContents.java
@@ -1,7 +1,7 @@
 package site.coduo.retrospect.domain;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.IntStream;
 
 import lombok.Getter;
 import site.coduo.retrospect.exception.InvalidRetrospectContentException;
@@ -24,16 +24,19 @@ public class RetrospectContents {
         }
 
         if (values.size() != RETROSPECT_CONTENTS_SIZE) {
-            throw new InvalidRetrospectContentException("회고 내용 개수는 " + RETROSPECT_CONTENTS_SIZE + "개여야 합니다. - " + values.size());
+            throw new InvalidRetrospectContentException(
+                    "회고 내용 개수는 " + RETROSPECT_CONTENTS_SIZE + "개여야 합니다. - " + values.size());
         }
     }
 
     public static RetrospectContents of(final List<String> answers) {
         validateAnswers(answers);
         final List<RetrospectAnswer> retrospectAnswers = answers.stream().map(RetrospectAnswer::new).toList();
-        final List<RetrospectContent> retrospectContents = IntStream.range(0, answers.size())
-                .mapToObj(index -> convertRetrospectContent(retrospectAnswers, index))
-                .toList();
+        final List<RetrospectContent> retrospectContents = new ArrayList<>();
+        for (int i = 0; i < answers.size(); i++) {
+            retrospectContents.add(convertRetrospectContent(retrospectAnswers, i));
+        }
+
         return new RetrospectContents(retrospectContents);
     }
 
@@ -43,7 +46,8 @@ public class RetrospectContents {
         }
     }
 
-    private static RetrospectContent convertRetrospectContent(final List<RetrospectAnswer> retrospectAnswers, final int index) {
+    private static RetrospectContent convertRetrospectContent(final List<RetrospectAnswer> retrospectAnswers,
+                                                              final int index) {
         final RetrospectQuestionType retrospectQuestionType = RetrospectQuestionType.findByIndex(index);
         return new RetrospectContent(retrospectQuestionType, retrospectAnswers.get(index));
     }

--- a/backend/src/main/java/site/coduo/retrospect/domain/RetrospectContents.java
+++ b/backend/src/main/java/site/coduo/retrospect/domain/RetrospectContents.java
@@ -1,0 +1,49 @@
+package site.coduo.retrospect.domain;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import lombok.Getter;
+
+@Getter
+public class RetrospectContents {
+
+    private static final int RETROSPECT_CONTENTS_SIZE = 4;
+
+    private final List<RetrospectContent> values;
+
+    public RetrospectContents(final List<RetrospectContent> values) {
+        validateValues(values);
+        this.values = values;
+    }
+
+    private void validateValues(final List<RetrospectContent> values) {
+        if (values == null) {
+            throw new IllegalArgumentException("회고 문항 내용들로 null을 입력할 수 없습니다.");
+        }
+
+        if (values.size() != RETROSPECT_CONTENTS_SIZE) {
+            throw new IllegalArgumentException("회고 내용 개수는 " + RETROSPECT_CONTENTS_SIZE + "개여야 합니다. - " + values.size());
+        }
+    }
+
+    public static RetrospectContents of(final List<String> answers) {
+        validateAnswers(answers);
+        final List<RetrospectAnswer> retrospectAnswers = answers.stream().map(RetrospectAnswer::new).toList();
+        final List<RetrospectContent> retrospectContents = IntStream.range(0, answers.size())
+                .mapToObj(index -> convertRetrospectContent(retrospectAnswers, index))
+                .toList();
+        return new RetrospectContents(retrospectContents);
+    }
+
+    private static void validateAnswers(final List<String> answers) {
+        if (answers == null) {
+            throw new IllegalArgumentException("회고 문항 내용 문자열 값들로 null을 입력할 수 없습니다.");
+        }
+    }
+
+    private static RetrospectContent convertRetrospectContent(final List<RetrospectAnswer> retrospectAnswers, final int index) {
+        final RetrospectQuestionType retrospectQuestionType = RetrospectQuestionType.findByIndex(index);
+        return new RetrospectContent(retrospectQuestionType, retrospectAnswers.get(index));
+    }
+}

--- a/backend/src/main/java/site/coduo/retrospect/domain/RetrospectQuestionType.java
+++ b/backend/src/main/java/site/coduo/retrospect/domain/RetrospectQuestionType.java
@@ -3,6 +3,7 @@ package site.coduo.retrospect.domain;
 import java.util.Arrays;
 
 import lombok.Getter;
+import site.coduo.retrospect.exception.InvalidRetrospectQuestionTypeException;
 
 @Getter
 public enum RetrospectQuestionType {
@@ -22,6 +23,6 @@ public enum RetrospectQuestionType {
         return Arrays.stream(RetrospectQuestionType.values())
                 .filter(type -> type.getIndex() == index)
                 .findAny()
-                .orElseThrow(() -> new IllegalArgumentException("입력된 인덱스에 일치하는 회고 문항 타입이 존재하지 않습니다. - " + index));
+                .orElseThrow(() -> new InvalidRetrospectQuestionTypeException("입력된 인덱스에 일치하는 회고 문항 타입이 존재하지 않습니다. - " + index));
     }
 }

--- a/backend/src/main/java/site/coduo/retrospect/domain/RetrospectQuestionType.java
+++ b/backend/src/main/java/site/coduo/retrospect/domain/RetrospectQuestionType.java
@@ -1,0 +1,27 @@
+package site.coduo.retrospect.domain;
+
+import java.util.Arrays;
+
+import lombok.Getter;
+
+@Getter
+public enum RetrospectQuestionType {
+    FIRST(0),
+    SECOND(1),
+    THIRD(2),
+    FOURTH(3),
+    ;
+
+    private final int index;
+
+    RetrospectQuestionType(final int index) {
+        this.index = index;
+    }
+
+    public static RetrospectQuestionType findByIndex(final int index) {
+        return Arrays.stream(RetrospectQuestionType.values())
+                .filter(type -> type.getIndex() == index)
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("입력된 인덱스에 일치하는 회고 문항 타입이 존재하지 않습니다. - " + index));
+    }
+}

--- a/backend/src/main/java/site/coduo/retrospect/exception/InvalidRetrospectContentException.java
+++ b/backend/src/main/java/site/coduo/retrospect/exception/InvalidRetrospectContentException.java
@@ -1,0 +1,8 @@
+package site.coduo.retrospect.exception;
+
+public class InvalidRetrospectContentException extends RetrospectException {
+
+    public InvalidRetrospectContentException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/site/coduo/retrospect/exception/InvalidRetrospectInputValueException.java
+++ b/backend/src/main/java/site/coduo/retrospect/exception/InvalidRetrospectInputValueException.java
@@ -1,0 +1,8 @@
+package site.coduo.retrospect.exception;
+
+public class InvalidRetrospectInputValueException extends RetrospectException {
+
+    public InvalidRetrospectInputValueException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/site/coduo/retrospect/exception/InvalidRetrospectQuestionTypeException.java
+++ b/backend/src/main/java/site/coduo/retrospect/exception/InvalidRetrospectQuestionTypeException.java
@@ -1,0 +1,8 @@
+package site.coduo.retrospect.exception;
+
+public class InvalidRetrospectQuestionTypeException extends RetrospectException {
+
+    public InvalidRetrospectQuestionTypeException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/site/coduo/retrospect/exception/NotRetrospectOwnerAccessException.java
+++ b/backend/src/main/java/site/coduo/retrospect/exception/NotRetrospectOwnerAccessException.java
@@ -1,0 +1,8 @@
+package site.coduo.retrospect.exception;
+
+public class NotRetrospectOwnerAccessException extends RetrospectException {
+
+    public NotRetrospectOwnerAccessException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/site/coduo/retrospect/exception/RetrospectException.java
+++ b/backend/src/main/java/site/coduo/retrospect/exception/RetrospectException.java
@@ -1,0 +1,12 @@
+package site.coduo.retrospect.exception;
+
+public class RetrospectException extends RuntimeException {
+
+    public RetrospectException(final String message) {
+        super(message);
+    }
+
+    public RetrospectException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/site/coduo/retrospect/exception/RetrospectNotFoundException.java
+++ b/backend/src/main/java/site/coduo/retrospect/exception/RetrospectNotFoundException.java
@@ -1,0 +1,8 @@
+package site.coduo.retrospect.exception;
+
+public class RetrospectNotFoundException extends RetrospectException {
+
+    public RetrospectNotFoundException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/site/coduo/retrospect/repository/RetrospectContentEntity.java
+++ b/backend/src/main/java/site/coduo/retrospect/repository/RetrospectContentEntity.java
@@ -37,7 +37,7 @@ public class RetrospectContentEntity {
     @Column(name = "QUESTION_TYPE", nullable = false)
     private RetrospectQuestionType questionType;
 
-    @Column(name = "CONTENT", length = 500, nullable = false)
+    @Column(name = "CONTENT", length = 1100, nullable = false)
     private String content;
 
     public RetrospectContentEntity(

--- a/backend/src/main/java/site/coduo/retrospect/repository/RetrospectContentEntity.java
+++ b/backend/src/main/java/site/coduo/retrospect/repository/RetrospectContentEntity.java
@@ -1,0 +1,60 @@
+package site.coduo.retrospect.repository;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.coduo.retrospect.domain.RetrospectQuestionType;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "RETROSPECT_CONTENT")
+@Entity
+public class RetrospectContentEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "RETROSPECT_ID")
+    private RetrospectEntity retrospect;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "QUESTION_TYPE", nullable = false)
+    private RetrospectQuestionType questionType;
+
+    @Column(name = "CONTENT", length = 500, nullable = false)
+    private String content;
+
+    public RetrospectContentEntity(
+            final RetrospectEntity retrospect,
+            final RetrospectQuestionType questionType,
+            final String content
+    ) {
+        this(0L, retrospect, questionType, content);
+    }
+
+    public RetrospectContentEntity(
+            final Long id,
+            final RetrospectEntity retrospect,
+            final RetrospectQuestionType questionType,
+            final String content
+    ) {
+        this.id = id;
+        this.retrospect = retrospect;
+        this.questionType = questionType;
+        this.content = content;
+    }
+}

--- a/backend/src/main/java/site/coduo/retrospect/repository/RetrospectContentEntity.java
+++ b/backend/src/main/java/site/coduo/retrospect/repository/RetrospectContentEntity.java
@@ -15,6 +15,8 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import site.coduo.retrospect.domain.RetrospectAnswer;
+import site.coduo.retrospect.domain.RetrospectContent;
 import site.coduo.retrospect.domain.RetrospectQuestionType;
 
 @Getter
@@ -56,5 +58,9 @@ public class RetrospectContentEntity {
         this.retrospect = retrospect;
         this.questionType = questionType;
         this.content = content;
+    }
+
+    public RetrospectContent toDomain() {
+        return new RetrospectContent(questionType, new RetrospectAnswer(content));
     }
 }

--- a/backend/src/main/java/site/coduo/retrospect/repository/RetrospectContentRepository.java
+++ b/backend/src/main/java/site/coduo/retrospect/repository/RetrospectContentRepository.java
@@ -1,0 +1,10 @@
+package site.coduo.retrospect.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RetrospectContentRepository extends JpaRepository<RetrospectContentEntity, Long> {
+
+    List<RetrospectContentEntity> findAllByRetrospect(RetrospectEntity retrospect);
+}

--- a/backend/src/main/java/site/coduo/retrospect/repository/RetrospectContentRepository.java
+++ b/backend/src/main/java/site/coduo/retrospect/repository/RetrospectContentRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RetrospectContentRepository extends JpaRepository<RetrospectContentEntity, Long> {
 
     List<RetrospectContentEntity> findAllByRetrospect(RetrospectEntity retrospect);
+
+    void deleteAllByRetrospect(RetrospectEntity retrospect);
 }

--- a/backend/src/main/java/site/coduo/retrospect/repository/RetrospectEntity.java
+++ b/backend/src/main/java/site/coduo/retrospect/repository/RetrospectEntity.java
@@ -1,0 +1,46 @@
+package site.coduo.retrospect.repository;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.coduo.common.infrastructure.audit.entity.BaseTimeEntity;
+import site.coduo.member.domain.Member;
+import site.coduo.pairroom.repository.PairRoomEntity;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "RETROSPECT")
+@Entity
+public class RetrospectEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "PAIR_ROOM_ID")
+    private PairRoomEntity pairRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MEMBER_ID")
+    private Member member;
+
+    public RetrospectEntity(final PairRoomEntity pairRoom, final Member member) {
+        this(0L, pairRoom, member);
+    }
+
+    public RetrospectEntity(final Long id, final PairRoomEntity pairRoom, final Member member) {
+        this.id = id;
+        this.pairRoom = pairRoom;
+        this.member = member;
+    }
+}

--- a/backend/src/main/java/site/coduo/retrospect/repository/RetrospectRepository.java
+++ b/backend/src/main/java/site/coduo/retrospect/repository/RetrospectRepository.java
@@ -1,5 +1,6 @@
 package site.coduo.retrospect.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ import site.coduo.pairroom.repository.PairRoomEntity;
 public interface RetrospectRepository extends JpaRepository<RetrospectEntity, Long> {
 
     Optional<RetrospectEntity> findByPairRoomAndMember(PairRoomEntity pairRoom, Member member);
+
+    List<RetrospectEntity> findAllByMember(Member member);
 }

--- a/backend/src/main/java/site/coduo/retrospect/repository/RetrospectRepository.java
+++ b/backend/src/main/java/site/coduo/retrospect/repository/RetrospectRepository.java
@@ -1,0 +1,13 @@
+package site.coduo.retrospect.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import site.coduo.member.domain.Member;
+import site.coduo.pairroom.repository.PairRoomEntity;
+
+public interface RetrospectRepository extends JpaRepository<RetrospectEntity, Long> {
+
+    Optional<RetrospectEntity> findByPairRoomAndMember(PairRoomEntity pairRoom, Member member);
+}

--- a/backend/src/main/java/site/coduo/retrospect/repository/RetrospectRepository.java
+++ b/backend/src/main/java/site/coduo/retrospect/repository/RetrospectRepository.java
@@ -13,4 +13,6 @@ public interface RetrospectRepository extends JpaRepository<RetrospectEntity, Lo
     Optional<RetrospectEntity> findByPairRoomAndMember(PairRoomEntity pairRoom, Member member);
 
     List<RetrospectEntity> findAllByMember(Member member);
+
+    boolean existsByMemberAndPairRoom(Member member, PairRoomEntity pairRoom);
 }

--- a/backend/src/main/java/site/coduo/retrospect/service/RetrospectService.java
+++ b/backend/src/main/java/site/coduo/retrospect/service/RetrospectService.java
@@ -14,6 +14,7 @@ import site.coduo.pairroom.repository.PairRoomEntity;
 import site.coduo.pairroom.repository.PairRoomMemberRepository;
 import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.retrospect.domain.Retrospect;
+import site.coduo.retrospect.domain.RetrospectContent;
 import site.coduo.retrospect.domain.RetrospectContents;
 import site.coduo.retrospect.repository.RetrospectContentEntity;
 import site.coduo.retrospect.repository.RetrospectContentRepository;
@@ -87,5 +88,27 @@ public class RetrospectService {
                         retrospectContent.getAnswer().getValue()))
                 .toList();
         retrospectContentRepository.saveAll(retrospectContentEntities);
+    }
+
+    public List<Retrospect> findAllRetrospectsByMember(final String credentialToken) {
+        final Member member = findMember(credentialToken);
+        final List<RetrospectEntity> retrospectEntities = retrospectRepository.findAllByMember(member);
+
+        return retrospectEntities.stream()
+                .map(this::convertRetrospect)
+                .toList();
+    }
+
+    private Retrospect convertRetrospect(final RetrospectEntity retrospectEntity) {
+        final List<RetrospectContent> retrospectContents = retrospectContentRepository.findAllByRetrospect(retrospectEntity)
+                .stream()
+                .map(RetrospectContentEntity::toDomain)
+                .toList();
+
+        return new Retrospect(
+                retrospectEntity.getPairRoom().toDomain(),
+                retrospectEntity.getMember(),
+                new RetrospectContents(retrospectContents)
+        );
     }
 }

--- a/backend/src/main/java/site/coduo/retrospect/service/RetrospectService.java
+++ b/backend/src/main/java/site/coduo/retrospect/service/RetrospectService.java
@@ -133,4 +133,10 @@ public class RetrospectService {
             throw new IllegalStateException("본인 소유가 아닌 회고는 삭제할 수 없습니다.");
         }
     }
+
+    public boolean existRetrospectWithPairRoom(final String credentialToken, final String pairRoomAccessCode) {
+        final Member member = findMember(credentialToken);
+        final PairRoomEntity pairRoom = findPairRoom(pairRoomAccessCode);
+        return retrospectRepository.existsByMemberAndPairRoom(member, pairRoom);
+    }
 }

--- a/backend/src/main/java/site/coduo/retrospect/service/RetrospectService.java
+++ b/backend/src/main/java/site/coduo/retrospect/service/RetrospectService.java
@@ -117,4 +117,20 @@ public class RetrospectService {
                 .orElseThrow(() -> new EntityNotFoundException("해당 아이디에 일치하는 회고 데이터가 존재하지 않습니다."));
         return convertRetrospect(retrospectEntity);
     }
+
+    @Transactional
+    public void deleteRetrospect(final String credentialToken, Long retrospectId) {
+        final RetrospectEntity retrospectEntity = retrospectRepository.findById(retrospectId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 아이디에 일치하는 회고 데이터가 존재하지 않습니다."));
+        checkRetrospectOwner(retrospectEntity, credentialToken);
+        retrospectContentRepository.deleteAllByRetrospect(retrospectEntity);
+        retrospectRepository.delete(retrospectEntity);
+    }
+
+    private void checkRetrospectOwner(final RetrospectEntity retrospectEntity, final String credentialToken) {
+        final Member client = findMember(credentialToken);
+        if (retrospectEntity.getMember() != client) {
+            throw new IllegalStateException("본인 소유가 아닌 회고는 삭제할 수 없습니다.");
+        }
+    }
 }

--- a/backend/src/main/java/site/coduo/retrospect/service/RetrospectService.java
+++ b/backend/src/main/java/site/coduo/retrospect/service/RetrospectService.java
@@ -111,4 +111,10 @@ public class RetrospectService {
                 new RetrospectContents(retrospectContents)
         );
     }
+
+    public Retrospect findRetrospectById(final Long retrospectId) {
+        final RetrospectEntity retrospectEntity = retrospectRepository.findById(retrospectId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 아이디에 일치하는 회고 데이터가 존재하지 않습니다."));
+        return convertRetrospect(retrospectEntity);
+    }
 }

--- a/backend/src/main/java/site/coduo/retrospect/service/RetrospectService.java
+++ b/backend/src/main/java/site/coduo/retrospect/service/RetrospectService.java
@@ -1,0 +1,91 @@
+package site.coduo.retrospect.service;
+
+import java.util.List;
+
+import jakarta.persistence.EntityNotFoundException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import site.coduo.member.domain.Member;
+import site.coduo.member.service.MemberService;
+import site.coduo.pairroom.repository.PairRoomEntity;
+import site.coduo.pairroom.repository.PairRoomMemberRepository;
+import site.coduo.pairroom.repository.PairRoomRepository;
+import site.coduo.retrospect.domain.Retrospect;
+import site.coduo.retrospect.domain.RetrospectContents;
+import site.coduo.retrospect.repository.RetrospectContentEntity;
+import site.coduo.retrospect.repository.RetrospectContentRepository;
+import site.coduo.retrospect.repository.RetrospectEntity;
+import site.coduo.retrospect.repository.RetrospectRepository;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class RetrospectService {
+
+    private final PairRoomRepository pairRoomRepository;
+    private final PairRoomMemberRepository pairRoomMemberRepository;
+    private final RetrospectRepository retrospectRepository;
+    private final RetrospectContentRepository retrospectContentRepository;
+    private final MemberService memberService;
+
+    @Transactional
+    public void createRetrospect(
+            final String credentialToken,
+            final String pairRoomAccessCode,
+            final List<String> answers
+    ) {
+        final PairRoomEntity pairRoom = findPairRoom(pairRoomAccessCode);
+        final Member member = findMember(credentialToken);
+        checkMemberIsJoinInPairRoom(member, pairRoom);
+        createRetrospect(pairRoom, member, answers);
+    }
+
+    private PairRoomEntity findPairRoom(final String pairRoomAccessCode) {
+        if (pairRoomAccessCode == null || pairRoomAccessCode.isEmpty()) {
+            throw new IllegalArgumentException("페어룸 접근 코드로 null 혹은 빈 값이 입력될 수 없습니다.");
+        }
+
+        return pairRoomRepository.findByAccessCode(pairRoomAccessCode)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "입력된 페어룸 접근 코드에 대응되는 페어룸이 존재하지 않습니다. - " + pairRoomAccessCode));
+    }
+
+    private Member findMember(final String credentialToken) {
+        if (credentialToken == null) {
+            throw new IllegalArgumentException("보안 토큰으로 null이 입력될 수 없습니다.");
+        }
+
+        return memberService.findMemberByCredential(credentialToken);
+    }
+
+    private void checkMemberIsJoinInPairRoom(final Member member, final PairRoomEntity pairRoom) {
+        if (!pairRoomMemberRepository.existsByPairRoomAndMember(pairRoom, member)) {
+            throw new IllegalArgumentException("입력된 페어룸, 사용자가 서로 참조되어 있지 않습니다.");
+        }
+    }
+
+    private void createRetrospect(
+            final PairRoomEntity pairRoom,
+            final Member member,
+            final List<String> answers
+    ) {
+        final RetrospectContents retrospectContents = RetrospectContents.of(answers);
+        final Retrospect retrospect = new Retrospect(pairRoom.toDomain(), member, retrospectContents);
+        final RetrospectEntity savedRetrospectEntity = retrospectRepository.save(new RetrospectEntity(pairRoom, member));
+        createRetrospectContents(retrospect, savedRetrospectEntity);
+    }
+
+    private void createRetrospectContents(final Retrospect retrospect, final RetrospectEntity retrospectEntity) {
+        final List<RetrospectContentEntity> retrospectContentEntities = retrospect.getContents().getValues()
+                .stream()
+                .map(retrospectContent -> new RetrospectContentEntity(
+                        retrospectEntity,
+                        retrospectContent.getQuestionType(),
+                        retrospectContent.getAnswer().getValue()))
+                .toList();
+        retrospectContentRepository.saveAll(retrospectContentEntities);
+    }
+}

--- a/backend/src/test/java/site/coduo/acceptance/AcceptanceFixture.java
+++ b/backend/src/test/java/site/coduo/acceptance/AcceptanceFixture.java
@@ -63,8 +63,8 @@ abstract class AcceptanceFixture {
     void tearDown() {
         retrospectContentRepository.deleteAll();
         retrospectRepository.deleteAll();
-        pairRoomMemberRepository.deleteAll();
         timerRepository.deleteAll();
+        pairRoomMemberRepository.deleteAll();
         memberRepository.deleteAll();
         openGraphRepository.deleteAll();
         referenceLinkRepository.deleteAll();

--- a/backend/src/test/java/site/coduo/acceptance/AcceptanceFixture.java
+++ b/backend/src/test/java/site/coduo/acceptance/AcceptanceFixture.java
@@ -16,6 +16,8 @@ import site.coduo.pairroom.repository.PairRoomMemberRepository;
 import site.coduo.referencelink.repository.CategoryRepository;
 import site.coduo.referencelink.repository.OpenGraphRepository;
 import site.coduo.referencelink.repository.ReferenceLinkRepository;
+import site.coduo.retrospect.repository.RetrospectContentRepository;
+import site.coduo.retrospect.repository.RetrospectRepository;
 import site.coduo.timer.repository.TimerRepository;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -43,6 +45,12 @@ abstract class AcceptanceFixture {
     @Autowired
     private PairRoomMemberRepository pairRoomMemberRepository;
 
+    @Autowired
+    private RetrospectRepository retrospectRepository;
+
+    @Autowired
+    private RetrospectContentRepository retrospectContentRepository;
+
     @LocalServerPort
     private int port;
 
@@ -53,6 +61,8 @@ abstract class AcceptanceFixture {
 
     @AfterEach
     void tearDown() {
+        retrospectContentRepository.deleteAll();
+        retrospectRepository.deleteAll();
         pairRoomMemberRepository.deleteAll();
         timerRepository.deleteAll();
         memberRepository.deleteAll();

--- a/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
@@ -1,16 +1,32 @@
 package site.coduo.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import site.coduo.member.domain.Member;
+import site.coduo.member.infrastructure.security.JwtProvider;
+import site.coduo.pairroom.domain.MissionUrl;
+import site.coduo.pairroom.domain.Pair;
+import site.coduo.pairroom.domain.PairName;
+import site.coduo.pairroom.domain.PairRoom;
 import site.coduo.pairroom.domain.PairRoomStatus;
+import site.coduo.pairroom.domain.accesscode.AccessCode;
+import site.coduo.pairroom.repository.PairRoomEntity;
+import site.coduo.pairroom.repository.PairRoomMemberEntity;
+import site.coduo.pairroom.repository.PairRoomMemberRepository;
+import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.pairroom.service.dto.PairRoomCreateRequest;
 import site.coduo.pairroom.service.dto.PairRoomCreateResponse;
 import site.coduo.pairroom.service.dto.PairRoomExistResponse;
@@ -31,6 +47,14 @@ class PairRoomAcceptanceTest extends AcceptanceFixture {
                 .extract()
                 .as(PairRoomCreateResponse.class);
     }
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private PairRoomRepository pairRoomRepository;
+    @Autowired
+    private PairRoomMemberRepository pairRoomMemberRepository;
 
     @Test
     @DisplayName("페어룸 요청 시 정보를 반환한다.")
@@ -175,5 +199,48 @@ class PairRoomAcceptanceTest extends AcceptanceFixture {
 
                 .then()
                 .statusCode(204);
+    }
+
+    @DisplayName("특정 회원이 특정 페어룸에 존재하는지 여부를 조회한다.")
+    @Test
+    void existMemberInPairRoom() {
+        // Given
+        final Member savedMember = memberRepository.save(
+                Member.builder()
+                        .userId("userid")
+                        .accessToken("access")
+                        .loginId("login")
+                        .username("username")
+                        .profileImage("some image")
+                        .build()
+        );
+        final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
+                new PairRoom(PairRoomStatus.IN_PROGRESS,
+                        new Pair(new PairName("레디"), new PairName("파슬리")),
+                        new MissionUrl("https://missionUrl.xxx"),
+                        new AccessCode("ac"))
+        ));
+        pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember));
+
+        // When
+        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final ExtractableResponse<Response> response = RestAssured
+                .given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookies(Map.of("coduo_whoami", credentialToken))
+
+                .when()
+                .get("/api/member/ac/exists")
+
+                .then()
+                .log().all()
+                .extract();
+
+        // Then
+        assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            softly.assertThat((Boolean) response.jsonPath().get("exists")).isEqualTo(true);
+        });
     }
 }

--- a/backend/src/test/java/site/coduo/acceptance/RetrospectAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/RetrospectAcceptanceTest.java
@@ -1,11 +1,13 @@
 package site.coduo.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.*;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.util.List;
 import java.util.Map;
 
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -96,6 +98,54 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
 
                 .then()
                 .statusCode(HttpStatus.CREATED.value());
+    }
+
+    @DisplayName("잘못된 회고 내용과 함께 회고 생성 요청을 하면 예외를 반환받는다.")
+    @Test
+    void createRequestWithInvalidRetrospectContent() {
+        // Given
+        final Member savedMember = memberRepository.save(
+                Member.builder()
+                        .userId("userid")
+                        .accessToken("access")
+                        .loginId("login")
+                        .username("username")
+                        .profileImage("some image")
+                        .build()
+        );
+        final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
+                new PairRoom(PairRoomStatus.IN_PROGRESS,
+                        new Pair(new PairName("레디"), new PairName("파슬리")),
+                        new MissionUrl("https://missionUrl.xxx"),
+                        new AccessCode("123456"))
+        ));
+        pairRoomMemberRepository.save(
+                new PairRoomMemberEntity(savedPairRoom, savedMember));
+
+        // When
+        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final CreateRetrospectRequest request = new CreateRetrospectRequest(
+                "123456",
+                List.of("", "회고 답변 2", "회고 답변 3", "회고 답변 4")
+        );
+        final ExtractableResponse<Response> response = RestAssured
+                .given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookies(Map.of("coduo_whoami", credentialToken))
+                .body(request)
+
+                .when()
+                .post("/api/retrospects")
+
+                .then()
+                .extract();
+
+        // Then
+        assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            softly.assertThat((String)response.jsonPath().get("message")).isEqualTo("잘못된 회고 내용입니다.");
+        });
     }
 
     @DisplayName("특정 사용자의 모든 회고 데이터를 조회한다.")
@@ -206,6 +256,57 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
         });
     }
 
+    @DisplayName("존재하지 않은 회고를 조회하려하면 예외를 반환받는다.")
+    @Test
+    void findNotExistRetrospect() {
+        // Given
+        final Member savedMember = memberRepository.save(
+                Member.builder()
+                        .userId("userid")
+                        .accessToken("access")
+                        .loginId("login")
+                        .username("username")
+                        .profileImage("some image")
+                        .build()
+        );
+        final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
+                new PairRoom(PairRoomStatus.IN_PROGRESS,
+                        new Pair(new PairName("레디"), new PairName("파슬리")),
+                        new MissionUrl("https://missionUrl.xxx"),
+                        new AccessCode("ac"))
+        ));
+        pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember));
+
+        final RetrospectEntity retrospectEntity = retrospectRepository.save(
+                new RetrospectEntity(savedPairRoom, savedMember));
+        final List<RetrospectContentEntity> retrospectContentEntities = List.of(
+                new RetrospectContentEntity(retrospectEntity, RetrospectQuestionType.FIRST, "답변1"),
+                new RetrospectContentEntity(retrospectEntity, RetrospectQuestionType.SECOND, "답변2"),
+                new RetrospectContentEntity(retrospectEntity, RetrospectQuestionType.THIRD, "답변3"),
+                new RetrospectContentEntity(retrospectEntity, RetrospectQuestionType.FOURTH, "답변4")
+        );
+        retrospectContentRepository.saveAll(retrospectContentEntities);
+
+        // When
+        final long targetId = retrospectEntity.getId();
+        final ExtractableResponse<Response> response = RestAssured
+                .given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+
+                .when()
+                .get("/api/retrospects/" + 1000)
+
+                .then()
+                .extract();
+
+        // Then
+        assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+            softly.assertThat((String) response.jsonPath().get("message")).isEqualTo("해당 요청의 회고가 존재하지 않습니다.");
+        });
+    }
+
     @DisplayName("특정 아이디의 회고를 삭제한다.")
     @Test
     void deleteRetrospect() {
@@ -254,6 +355,67 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
 
         // Then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    @DisplayName("소유자외 사용자가 권한 없는 접근을 시도하면 예외를 반환받는다.")
+    @Test
+    void notOwnerAccessToForbiddenJon() {
+        // Given
+        final Member owner = memberRepository.save(
+                Member.builder()
+                        .userId("userid1")
+                        .accessToken("access1")
+                        .loginId("login1")
+                        .username("username1")
+                        .profileImage("some image1")
+                        .build()
+        );
+        final Member other = memberRepository.save(
+                Member.builder()
+                        .userId("userid2")
+                        .accessToken("access2")
+                        .loginId("login2")
+                        .username("username2")
+                        .profileImage("some image2")
+                        .build()
+        );
+        final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
+                new PairRoom(PairRoomStatus.IN_PROGRESS,
+                        new Pair(new PairName("레디"), new PairName("파슬리")),
+                        new MissionUrl("https://missionUrl.xxx"),
+                        new AccessCode("123456"))
+        ));
+        pairRoomMemberRepository.save(
+                new PairRoomMemberEntity(savedPairRoom, owner));
+
+        final RetrospectEntity retrospectEntity = retrospectRepository.save(
+                new RetrospectEntity(savedPairRoom, owner));
+        final List<RetrospectContentEntity> retrospectContentEntities = List.of(
+                new RetrospectContentEntity(retrospectEntity, RetrospectQuestionType.FIRST, "답변1"),
+                new RetrospectContentEntity(retrospectEntity, RetrospectQuestionType.SECOND, "답변2"),
+                new RetrospectContentEntity(retrospectEntity, RetrospectQuestionType.THIRD, "답변3"),
+                new RetrospectContentEntity(retrospectEntity, RetrospectQuestionType.FOURTH, "답변4")
+        );
+        retrospectContentRepository.saveAll(retrospectContentEntities);
+
+        // When
+        final String credentialToken = jwtProvider.sign(other.getUserId());
+        final long targetId = retrospectEntity.getId();
+        final ExtractableResponse<Response> response = RestAssured
+                .given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookies(Map.of("coduo_whoami", credentialToken))
+
+                .when()
+                .delete("/api/retrospects/" + targetId)
+
+                .then()
+                .extract();
+
+        // Then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat((String)response.jsonPath().get("message")).isEqualTo("회고 소유자 외 접근할 수 없는 작업입니다.");
     }
 
     @DisplayName("특정 회원이 특정 페어룸에 작성한 회고가 존재하는지 여부를 조회한다.")

--- a/backend/src/test/java/site/coduo/acceptance/RetrospectAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/RetrospectAcceptanceTest.java
@@ -150,4 +150,57 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
             softly.assertThat((String) response.jsonPath().get("retrospects[0].answer")).isEqualTo("답변1");
         });
     }
+
+    @DisplayName("특정 아이디의 회고 데이터를 상세 조회한다.")
+    @Test
+    void findRetrospectById() {
+        // Given
+        final Member savedMember = memberRepository.save(
+                Member.builder()
+                        .userId("userid")
+                        .accessToken("access")
+                        .loginId("login")
+                        .username("username")
+                        .profileImage("some image")
+                        .build()
+        );
+        final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
+                new PairRoom(PairRoomStatus.IN_PROGRESS,
+                        new Pair(new PairName("레디"), new PairName("파슬리")),
+                        new MissionUrl("https://missionUrl.xxx"),
+                        new AccessCode("ac"))
+        ));
+        pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember));
+
+        final RetrospectEntity retrospectEntity = retrospectRepository.save(new RetrospectEntity(savedPairRoom, savedMember));
+        final List<RetrospectContentEntity> retrospectContentEntities = List.of(
+                new RetrospectContentEntity(retrospectEntity, RetrospectQuestionType.FIRST, "답변1"),
+                new RetrospectContentEntity(retrospectEntity, RetrospectQuestionType.SECOND, "답변2"),
+                new RetrospectContentEntity(retrospectEntity, RetrospectQuestionType.THIRD, "답변3"),
+                new RetrospectContentEntity(retrospectEntity, RetrospectQuestionType.FOURTH, "답변4")
+        );
+        retrospectContentRepository.saveAll(retrospectContentEntities);
+
+        // When
+        final long targetId = retrospectEntity.getId();
+        final ExtractableResponse<Response> response = RestAssured
+                .given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+
+                .when()
+                .get("/api/retrospects/" + targetId)
+
+                .then()
+                .log().all()
+                .extract();
+
+        // Then
+        final List<String> expect = List.of("답변1", "답변2", "답변3", "답변4");
+        assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            softly.assertThat((String) response.jsonPath().get("pairRoomAccessCode")).isEqualTo("ac");
+            softly.assertThat((List)response.jsonPath().get("answers")).isEqualTo(expect);
+        });
+    }
 }

--- a/backend/src/test/java/site/coduo/acceptance/RetrospectAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/RetrospectAcceptanceTest.java
@@ -1,0 +1,84 @@
+package site.coduo.acceptance;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import io.restassured.RestAssured;
+import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberRepository;
+import site.coduo.member.infrastructure.security.JwtProvider;
+import site.coduo.pairroom.domain.MissionUrl;
+import site.coduo.pairroom.domain.Pair;
+import site.coduo.pairroom.domain.PairName;
+import site.coduo.pairroom.domain.PairRoom;
+import site.coduo.pairroom.domain.PairRoomStatus;
+import site.coduo.pairroom.domain.accesscode.AccessCode;
+import site.coduo.pairroom.repository.PairRoomEntity;
+import site.coduo.pairroom.repository.PairRoomMemberEntity;
+import site.coduo.pairroom.repository.PairRoomMemberRepository;
+import site.coduo.pairroom.repository.PairRoomRepository;
+import site.coduo.retrospect.controller.request.CreateRetrospectRequest;
+
+class RetrospectAcceptanceTest extends AcceptanceFixture {
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PairRoomRepository pairRoomRepository;
+
+    @Autowired
+    private PairRoomMemberRepository pairRoomMemberRepository;
+
+    @DisplayName("회고를 생성한다.")
+    @Test
+    void createRetrospect() {
+        // Given
+        final Member savedMember = memberRepository.save(
+                Member.builder()
+                        .userId("userid")
+                        .accessToken("access")
+                        .loginId("login")
+                        .username("username")
+                        .profileImage("some image")
+                        .build()
+        );
+        final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
+                new PairRoom(PairRoomStatus.IN_PROGRESS,
+                        new Pair(new PairName("레디"), new PairName("파슬리")),
+                        new MissionUrl("https://missionUrl.xxx"),
+                        new AccessCode("123456"))
+        ));
+        pairRoomMemberRepository.save(
+                new PairRoomMemberEntity(savedPairRoom, savedMember));
+
+        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final CreateRetrospectRequest request = new CreateRetrospectRequest(
+                "123456",
+                List.of("회고 답변 1", "회고 답변 2", "회고 답변 3", "회고 답변 4")
+        );
+
+        // When && Then
+        RestAssured
+                .given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookies(Map.of("coduo_whoami", credentialToken))
+                .body(request)
+
+                .when()
+                .post("/api/retrospects")
+
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
+    }
+}

--- a/backend/src/test/java/site/coduo/retrospect/controller/response/FindRetrospectByIdResponseTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/controller/response/FindRetrospectByIdResponseTest.java
@@ -1,0 +1,41 @@
+package site.coduo.retrospect.controller.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import site.coduo.fixture.PairRoomFixture;
+import site.coduo.member.domain.Member;
+import site.coduo.pairroom.domain.PairRoom;
+import site.coduo.retrospect.domain.Retrospect;
+import site.coduo.retrospect.domain.RetrospectContents;
+
+class FindRetrospectByIdResponseTest {
+
+    @DisplayName("Retrospect 객체를 입력받으면 DTO로 변환해 반환한다.")
+    @Test
+    void createObjectOfRetrospect() {
+        // Given
+        final long id = 1;
+        final PairRoom pairRoom = PairRoomFixture.FRAM_LEMONE_ROOM;
+        final Member member = Member.builder()
+                .userId("userid")
+                .accessToken("access")
+                .loginId("login")
+                .username("username")
+                .profileImage("some image")
+                .build();
+        final RetrospectContents retrospectContents = RetrospectContents.of(
+                List.of("회고 답변1", "회고 답변2", "회고 답변3", "회고 답변4"));
+        final Retrospect retrospect = new Retrospect(id, pairRoom, member, retrospectContents);
+
+        // When
+        final FindRetrospectByIdResponse response = FindRetrospectByIdResponse.of(retrospect);
+
+        // Then
+        assertThat(response).isNotNull();
+    }
+}

--- a/backend/src/test/java/site/coduo/retrospect/controller/response/FindRetrospectByIdResponseTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/controller/response/FindRetrospectByIdResponseTest.java
@@ -17,7 +17,7 @@ class FindRetrospectByIdResponseTest {
 
     @DisplayName("Retrospect 객체를 입력받으면 DTO로 변환해 반환한다.")
     @Test
-    void createObjectOfRetrospect() {
+    void createObjectFromRetrospect() {
         // Given
         final long id = 1;
         final PairRoom pairRoom = PairRoomFixture.FRAM_LEMONE_ROOM;
@@ -33,7 +33,7 @@ class FindRetrospectByIdResponseTest {
         final Retrospect retrospect = new Retrospect(id, pairRoom, member, retrospectContents);
 
         // When
-        final FindRetrospectByIdResponse response = FindRetrospectByIdResponse.of(retrospect);
+        final FindRetrospectByIdResponse response = FindRetrospectByIdResponse.from(retrospect);
 
         // Then
         assertThat(response).isNotNull();

--- a/backend/src/test/java/site/coduo/retrospect/controller/response/FindRetrospectsResponseTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/controller/response/FindRetrospectsResponseTest.java
@@ -1,0 +1,41 @@
+package site.coduo.retrospect.controller.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import site.coduo.fixture.PairRoomFixture;
+import site.coduo.member.domain.Member;
+import site.coduo.pairroom.domain.PairRoom;
+import site.coduo.retrospect.domain.Retrospect;
+import site.coduo.retrospect.domain.RetrospectContents;
+
+class FindRetrospectsResponseTest {
+
+    @DisplayName("Retrospect 객체들을 입력받으면 DTO로 변환해 반환한다.")
+    @Test
+    void createObjectOfRetrospect() {
+        // Given
+        final long id = 1;
+        final PairRoom pairRoom = PairRoomFixture.FRAM_LEMONE_ROOM;
+        final Member member = Member.builder()
+                .userId("userid")
+                .accessToken("access")
+                .loginId("login")
+                .username("username")
+                .profileImage("some image")
+                .build();
+        final RetrospectContents retrospectContents = RetrospectContents.of(
+                List.of("회고 답변1", "회고 답변2", "회고 답변3", "회고 답변4"));
+        final Retrospect retrospect = new Retrospect(id, pairRoom, member, retrospectContents);
+
+        // When
+        final FindRetrospectsResponse response = FindRetrospectsResponse.of(List.of(retrospect));
+
+        // Then
+        assertThat(response).isNotNull();
+    }
+}

--- a/backend/src/test/java/site/coduo/retrospect/controller/response/FindRetrospectsResponseTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/controller/response/FindRetrospectsResponseTest.java
@@ -17,7 +17,7 @@ class FindRetrospectsResponseTest {
 
     @DisplayName("Retrospect 객체들을 입력받으면 DTO로 변환해 반환한다.")
     @Test
-    void createObjectOfRetrospect() {
+    void createObjectFromRetrospect() {
         // Given
         final long id = 1;
         final PairRoom pairRoom = PairRoomFixture.FRAM_LEMONE_ROOM;
@@ -33,7 +33,7 @@ class FindRetrospectsResponseTest {
         final Retrospect retrospect = new Retrospect(id, pairRoom, member, retrospectContents);
 
         // When
-        final FindRetrospectsResponse response = FindRetrospectsResponse.of(List.of(retrospect));
+        final FindRetrospectsResponse response = FindRetrospectsResponse.from(List.of(retrospect));
 
         // Then
         assertThat(response).isNotNull();

--- a/backend/src/test/java/site/coduo/retrospect/domain/RetrospectAnswerTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/domain/RetrospectAnswerTest.java
@@ -1,0 +1,35 @@
+package site.coduo.retrospect.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+class RetrospectAnswerTest {
+
+    @DisplayName("유효한 회고 답변 값이 입력되면 객체를 생성한다.")
+    @Test
+    void createObject() {
+        // Given
+        final String input = "회고 답변!";
+
+        // When
+        final RetrospectAnswer retrospectAnswer = new RetrospectAnswer(input);
+
+        // Then
+        assertThat(retrospectAnswer).isNotNull();
+    }
+
+    @DisplayName("유효하지 않은 회고 답변 값이 입력되면 예외를 발생시킨다.")
+    @NullAndEmptySource
+    @ParameterizedTest
+    void validateValue(final String input) {
+        // When & Then
+        assertThatThrownBy(() -> new RetrospectAnswer(input))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("회고 답변 내용으로 null 혹은 공백을 입력할 수 없습니다. - " + input);
+    }
+}

--- a/backend/src/test/java/site/coduo/retrospect/domain/RetrospectAnswerTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/domain/RetrospectAnswerTest.java
@@ -26,10 +26,22 @@ class RetrospectAnswerTest {
     @DisplayName("유효하지 않은 회고 답변 값이 입력되면 예외를 발생시킨다.")
     @NullAndEmptySource
     @ParameterizedTest
-    void validateValue(final String input) {
+    void validateValueIsNull(final String input) {
         // When & Then
         assertThatThrownBy(() -> new RetrospectAnswer(input))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("회고 답변 내용으로 null 혹은 공백을 입력할 수 없습니다. - " + input);
+    }
+
+    @DisplayName("유효하지 않은 길이의 회고 답변이 입력되면 예외를 발생시킨다.")
+    @Test
+    void validateValueLength() {
+        // Given
+        final String input = "A".repeat(1001);
+
+        // When & Then
+        assertThatThrownBy(() -> new RetrospectAnswer(input))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("회고 답변 길이는 1000자 이하여야 합니다. - " + input.length());
     }
 }

--- a/backend/src/test/java/site/coduo/retrospect/domain/RetrospectAnswerTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/domain/RetrospectAnswerTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
+import site.coduo.retrospect.exception.InvalidRetrospectContentException;
+
 class RetrospectAnswerTest {
 
     @DisplayName("유효한 회고 답변 값이 입력되면 객체를 생성한다.")
@@ -29,7 +31,7 @@ class RetrospectAnswerTest {
     void validateValueIsNull(final String input) {
         // When & Then
         assertThatThrownBy(() -> new RetrospectAnswer(input))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(InvalidRetrospectContentException.class)
                 .hasMessage("회고 답변 내용으로 null 혹은 공백을 입력할 수 없습니다. - " + input);
     }
 
@@ -41,7 +43,7 @@ class RetrospectAnswerTest {
 
         // When & Then
         assertThatThrownBy(() -> new RetrospectAnswer(input))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(InvalidRetrospectContentException.class)
                 .hasMessage("회고 답변 길이는 1000자 이하여야 합니다. - " + input.length());
     }
 }

--- a/backend/src/test/java/site/coduo/retrospect/domain/RetrospectContentTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/domain/RetrospectContentTest.java
@@ -1,0 +1,48 @@
+package site.coduo.retrospect.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RetrospectContentTest {
+
+    @DisplayName("유효한 회고 문항 유형, 답변이 입력되면 객체를 생성한다.")
+    @Test
+    void createObject() {
+        // Given
+        final RetrospectQuestionType retrospectQuestionType = RetrospectQuestionType.FIRST;
+        final RetrospectAnswer retrospectAnswer = new RetrospectAnswer("hi");
+
+        // When
+        final RetrospectContent retrospectContent = new RetrospectContent(retrospectQuestionType, retrospectAnswer);
+
+        // Then
+        assertThat(retrospectContent).isNotNull();
+    }
+
+    @DisplayName("회고 문항으로 null이 입력되면 예외를 발생시킨다.")
+    @Test
+    void inputNullForRetrospectQuestionType() {
+        // Given
+        final RetrospectAnswer retrospectAnswer = new RetrospectAnswer("hi");
+
+        // When & Then
+        assertThatThrownBy(() -> new RetrospectContent(null, retrospectAnswer))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("회고 문항 유형 객체로 null이 입력될 수 없습니다.");
+    }
+
+    @DisplayName("회고 답변으로 null이 입력되면 예외를 발생시킨다.")
+    @Test
+    void inputNullForRetrospectAnswer() {
+        // Given
+        final RetrospectQuestionType retrospectQuestionType = RetrospectQuestionType.FIRST;
+
+        // When & Then
+        assertThatThrownBy(() -> new RetrospectContent(retrospectQuestionType, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("회고 답변 객체로 null을 입력할 수 없습니다.");
+    }
+}

--- a/backend/src/test/java/site/coduo/retrospect/domain/RetrospectContentTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/domain/RetrospectContentTest.java
@@ -6,6 +6,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import site.coduo.retrospect.exception.InvalidRetrospectContentException;
+
 class RetrospectContentTest {
 
     @DisplayName("유효한 회고 문항 유형, 답변이 입력되면 객체를 생성한다.")
@@ -30,7 +32,7 @@ class RetrospectContentTest {
 
         // When & Then
         assertThatThrownBy(() -> new RetrospectContent(null, retrospectAnswer))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(InvalidRetrospectContentException.class)
                 .hasMessage("회고 문항 유형 객체로 null이 입력될 수 없습니다.");
     }
 
@@ -42,7 +44,7 @@ class RetrospectContentTest {
 
         // When & Then
         assertThatThrownBy(() -> new RetrospectContent(retrospectQuestionType, null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(InvalidRetrospectContentException.class)
                 .hasMessage("회고 답변 객체로 null을 입력할 수 없습니다.");
     }
 }

--- a/backend/src/test/java/site/coduo/retrospect/domain/RetrospectContentsTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/domain/RetrospectContentsTest.java
@@ -1,0 +1,76 @@
+package site.coduo.retrospect.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RetrospectContentsTest {
+
+    @DisplayName("유효한 회고 내용 값들을 입력하면 객체를 생성한다.")
+    @Test
+    void createObject() {
+        // Given
+        final List<RetrospectContent> input = List.of(
+                new RetrospectContent(RetrospectQuestionType.FIRST, new RetrospectAnswer("답변1")),
+                new RetrospectContent(RetrospectQuestionType.SECOND, new RetrospectAnswer("답변2")),
+                new RetrospectContent(RetrospectQuestionType.THIRD, new RetrospectAnswer("답변3")),
+                new RetrospectContent(RetrospectQuestionType.FOURTH, new RetrospectAnswer("답변4"))
+        );
+
+        // When
+        final RetrospectContents retrospectContents = new RetrospectContents(input);
+
+        // Then
+        assertThat(retrospectContents).isNotNull();
+    }
+
+    @DisplayName("회고 내용 값들로 null이 입력되면 예외를 발생시킨다.")
+    @Test
+    void validateRetrospectContentsIsNull() {
+        // When & Then
+        assertThatThrownBy(() -> new RetrospectContents(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("회고 문항 내용들로 null을 입력할 수 없습니다.");
+    }
+
+    @DisplayName("유효하지 않은 개수의 회고 내용 값들이 입력되면 예외를 발생시킨다.")
+    @Test
+    void validateRetrospectContentsSize() {
+        // Given
+        final List<RetrospectContent> input = List.of(
+                new RetrospectContent(RetrospectQuestionType.FIRST, new RetrospectAnswer("답변1")),
+                new RetrospectContent(RetrospectQuestionType.SECOND, new RetrospectAnswer("답변2"))
+        );
+
+        // When & Then
+        assertThatThrownBy(() -> new RetrospectContents(input))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("회고 내용 개수는 4개여야 합니다. - " + input.size());
+    }
+
+    @DisplayName("유효한 회고 내용 문자열 값들이 입력되면 객체를 생성한다.")
+    @Test
+    void createObjectOfRetrospectContentStrings() {
+        // Given
+        final List<String> input = List.of("회고 답변1", "회고 답변2", "회고 답변3", "회고 답변4");
+
+        // When
+        final RetrospectContents retrospectContents = RetrospectContents.of(input);
+
+        // Then
+        assertThat(retrospectContents).isNotNull();
+    }
+
+    @DisplayName("회고 내용 문자열 값들로 null이 입력되면 예외를 발생시킨다.")
+    @Test
+    void validateRetrospectContentStringsIsNull() {
+        // When & Then
+        assertThatThrownBy(() -> RetrospectContents.of(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("회고 문항 내용 문자열 값들로 null을 입력할 수 없습니다.");
+    }
+}

--- a/backend/src/test/java/site/coduo/retrospect/domain/RetrospectContentsTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/domain/RetrospectContentsTest.java
@@ -8,6 +8,8 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import site.coduo.retrospect.exception.InvalidRetrospectContentException;
+
 class RetrospectContentsTest {
 
     @DisplayName("유효한 회고 내용 값들을 입력하면 객체를 생성한다.")
@@ -33,7 +35,7 @@ class RetrospectContentsTest {
     void validateRetrospectContentsIsNull() {
         // When & Then
         assertThatThrownBy(() -> new RetrospectContents(null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(InvalidRetrospectContentException.class)
                 .hasMessage("회고 문항 내용들로 null을 입력할 수 없습니다.");
     }
 
@@ -48,7 +50,7 @@ class RetrospectContentsTest {
 
         // When & Then
         assertThatThrownBy(() -> new RetrospectContents(input))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(InvalidRetrospectContentException.class)
                 .hasMessage("회고 내용 개수는 4개여야 합니다. - " + input.size());
     }
 
@@ -70,7 +72,7 @@ class RetrospectContentsTest {
     void validateRetrospectContentStringsIsNull() {
         // When & Then
         assertThatThrownBy(() -> RetrospectContents.of(null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(InvalidRetrospectContentException.class)
                 .hasMessage("회고 문항 내용 문자열 값들로 null을 입력할 수 없습니다.");
     }
 

--- a/backend/src/test/java/site/coduo/retrospect/domain/RetrospectContentsTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/domain/RetrospectContentsTest.java
@@ -73,4 +73,18 @@ class RetrospectContentsTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("회고 문항 내용 문자열 값들로 null을 입력할 수 없습니다.");
     }
+
+    @DisplayName("첫 번째 회고 내용 객체를 반환한다.")
+    @Test
+    void getFirst() {
+        // Given
+        final RetrospectContents retrospectContents = RetrospectContents.of(List.of("회고 답변1", "회고 답변2", "회고 답변3", "회고 답변4"));
+
+        // When
+        final RetrospectContent first = retrospectContents.getFirst();
+
+        // Then
+        final String answerValue = first.getAnswer().getValue();
+        assertThat(answerValue).isEqualTo("회고 답변1");
+    }
 }

--- a/backend/src/test/java/site/coduo/retrospect/domain/RetrospectQuestionTypeTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/domain/RetrospectQuestionTypeTest.java
@@ -1,0 +1,47 @@
+package site.coduo.retrospect.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class RetrospectQuestionTypeTest {
+
+    @DisplayName("인덱스가 입력되면 대응되는 값을 찾아 반환한다.")
+    @MethodSource("inputAndExpect")
+    @ParameterizedTest
+    void findByIndex(final int index, final RetrospectQuestionType expect) {
+        // When
+        final RetrospectQuestionType retrospectQuestionType = RetrospectQuestionType.findByIndex(index);
+
+        // Then
+        assertThat(retrospectQuestionType).isEqualTo(expect);
+    }
+
+    private static Stream<Arguments> inputAndExpect() {
+        return Stream.of(
+                Arguments.of(0, RetrospectQuestionType.FIRST),
+                Arguments.of(1, RetrospectQuestionType.SECOND),
+                Arguments.of(2, RetrospectQuestionType.THIRD),
+                Arguments.of(3, RetrospectQuestionType.FOURTH)
+        );
+    }
+
+    @DisplayName("유효하지 않은 인덱스가 입력되면 예외를 발생시킨다.")
+    @Test
+    void inputInvalidIndex() {
+        // Given
+        final int input = -1;
+
+        // When & Then
+        assertThatThrownBy(() -> RetrospectQuestionType.findByIndex(input))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("입력된 인덱스에 일치하는 회고 문항 타입이 존재하지 않습니다. - " + input);
+    }
+}

--- a/backend/src/test/java/site/coduo/retrospect/domain/RetrospectQuestionTypeTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/domain/RetrospectQuestionTypeTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import site.coduo.retrospect.exception.InvalidRetrospectQuestionTypeException;
+
 class RetrospectQuestionTypeTest {
 
     @DisplayName("인덱스가 입력되면 대응되는 값을 찾아 반환한다.")
@@ -41,7 +43,7 @@ class RetrospectQuestionTypeTest {
 
         // When & Then
         assertThatThrownBy(() -> RetrospectQuestionType.findByIndex(input))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(InvalidRetrospectQuestionTypeException.class)
                 .hasMessage("입력된 인덱스에 일치하는 회고 문항 타입이 존재하지 않습니다. - " + input);
     }
 }

--- a/backend/src/test/java/site/coduo/retrospect/domain/RetrospectTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/domain/RetrospectTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import site.coduo.fixture.PairRoomFixture;
 import site.coduo.member.domain.Member;
 import site.coduo.pairroom.domain.PairRoom;
+import site.coduo.retrospect.exception.InvalidRetrospectContentException;
+import site.coduo.retrospect.exception.InvalidRetrospectInputValueException;
 
 class RetrospectTest {
 
@@ -98,7 +100,7 @@ class RetrospectTest {
 
         // When & Then
         assertThatThrownBy(() -> new Retrospect(id, null, member, retrospectContents))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(InvalidRetrospectInputValueException.class)
                 .hasMessage("페어룸 객체로 null을 입력할 수 없습니다.");
     }
 
@@ -113,7 +115,7 @@ class RetrospectTest {
 
         // When & Then
         assertThatThrownBy(() -> new Retrospect(id, pairRoom, null, retrospectContents))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(InvalidRetrospectInputValueException.class)
                 .hasMessage("회원 객체로 null을 입력할 수 없습니다.");
     }
 
@@ -133,7 +135,7 @@ class RetrospectTest {
 
         // When & Then
         assertThatThrownBy(() -> new Retrospect(id, pairRoom, member, null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(InvalidRetrospectContentException.class)
                 .hasMessage("회고 내용들로 null을 입력할 수 없습니다.");
     }
 }

--- a/backend/src/test/java/site/coduo/retrospect/domain/RetrospectTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/domain/RetrospectTest.java
@@ -1,0 +1,139 @@
+package site.coduo.retrospect.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import site.coduo.fixture.PairRoomFixture;
+import site.coduo.member.domain.Member;
+import site.coduo.pairroom.domain.PairRoom;
+
+class RetrospectTest {
+
+    @DisplayName("유효한 id, 페어룸, 회원, 회고 내용 값들을 입력하면 객체를 생성한다.")
+    @Test
+    void createObject() {
+        // Given
+        final long id = 1;
+        final PairRoom pairRoom = PairRoomFixture.FRAM_LEMONE_ROOM;
+        final Member member = Member.builder()
+                .userId("userid")
+                .accessToken("access")
+                .loginId("login")
+                .username("username")
+                .profileImage("some image")
+                .build();
+        final RetrospectContents retrospectContents = RetrospectContents.of(
+                List.of("회고 답변1", "회고 답변2", "회고 답변3", "회고 답변4"));
+
+        // When
+        final Retrospect retrospect = new Retrospect(id, pairRoom, member, retrospectContents);
+
+        // Then
+        assertThat(retrospect).isNotNull();
+    }
+
+    @DisplayName("아이디 값을 제외하고 객체를 생성하면 기본 값으로 0이 입력된다.")
+    @Test
+    void createObjectWithoutId() {
+        // Given
+        final PairRoom pairRoom = PairRoomFixture.FRAM_LEMONE_ROOM;
+        final Member member = Member.builder()
+                .userId("userid")
+                .accessToken("access")
+                .loginId("login")
+                .username("username")
+                .profileImage("some image")
+                .build();
+        final RetrospectContents retrospectContents = RetrospectContents.of(
+                List.of("회고 답변1", "회고 답변2", "회고 답변3", "회고 답변4"));
+
+        // When
+        final Retrospect retrospect = new Retrospect(pairRoom, member, retrospectContents);
+        
+        // Then
+        assertThat(retrospect.getId()).isEqualTo(0);
+    }
+    
+    @DisplayName("아이디로 음수가 입력되면 예외를 발생시킨다.")  
+    @Test        
+    void inputMinusId() {
+        // Given
+        final long id = -1;
+        final PairRoom pairRoom = PairRoomFixture.FRAM_LEMONE_ROOM;
+        final Member member = Member.builder()
+                .userId("userid")
+                .accessToken("access")
+                .loginId("login")
+                .username("username")
+                .profileImage("some image")
+                .build();
+        final RetrospectContents retrospectContents = RetrospectContents.of(
+                List.of("회고 답변1", "회고 답변2", "회고 답변3", "회고 답변4"));
+                
+        // When & Then
+        assertThatThrownBy(() -> new Retrospect(id, pairRoom, member, retrospectContents))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("회고 아이디 값은 음수가 입력될 수 없습니다. - " + id);
+    }
+
+    @DisplayName("페어룸으로 null이 입력되면 예외를 발생시킨다.")
+    @Test
+    void inputNullPairRoom() {
+        // Given
+        final long id = 1;
+        final Member member = Member.builder()
+                .userId("userid")
+                .accessToken("access")
+                .loginId("login")
+                .username("username")
+                .profileImage("some image")
+                .build();
+        final RetrospectContents retrospectContents = RetrospectContents.of(
+                List.of("회고 답변1", "회고 답변2", "회고 답변3", "회고 답변4"));
+
+        // When & Then
+        assertThatThrownBy(() -> new Retrospect(id, null, member, retrospectContents))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("페어룸 객체로 null을 입력할 수 없습니다.");
+    }
+
+    @DisplayName("회원으로 null이 입력되면 예외를 발생시킨다.")
+    @Test
+    void inputNullMember() {
+        // Given
+        final long id = 1;
+        final PairRoom pairRoom = PairRoomFixture.FRAM_LEMONE_ROOM;
+        final RetrospectContents retrospectContents = RetrospectContents.of(
+                List.of("회고 답변1", "회고 답변2", "회고 답변3", "회고 답변4"));
+
+        // When & Then
+        assertThatThrownBy(() -> new Retrospect(id, pairRoom, null, retrospectContents))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("회원 객체로 null을 입력할 수 없습니다.");
+    }
+
+    @DisplayName("아이디 값을 제외하고 객체를 생성하면 기본 값으로 0이 입력된다.")
+    @Test
+    void inputNullContents() {
+        // Given
+        final long id = 1;
+        final PairRoom pairRoom = PairRoomFixture.FRAM_LEMONE_ROOM;
+        final Member member = Member.builder()
+                .userId("userid")
+                .accessToken("access")
+                .loginId("login")
+                .username("username")
+                .profileImage("some image")
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> new Retrospect(id, pairRoom, member, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("회고 내용들로 null을 입력할 수 없습니다.");
+    }
+}

--- a/backend/src/test/java/site/coduo/retrospect/repository/RetrospectContentEntityTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/repository/RetrospectContentEntityTest.java
@@ -1,0 +1,46 @@
+package site.coduo.retrospect.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import site.coduo.member.domain.Member;
+import site.coduo.pairroom.domain.MissionUrl;
+import site.coduo.pairroom.domain.Pair;
+import site.coduo.pairroom.domain.PairName;
+import site.coduo.pairroom.domain.PairRoom;
+import site.coduo.pairroom.domain.PairRoomStatus;
+import site.coduo.pairroom.domain.accesscode.AccessCode;
+import site.coduo.pairroom.repository.PairRoomEntity;
+import site.coduo.retrospect.domain.RetrospectContent;
+import site.coduo.retrospect.domain.RetrospectQuestionType;
+
+class RetrospectContentEntityTest {
+
+    @DisplayName("도메인 객체 RetrospectContent 객체를 생성해 반환한다.")
+    @Test
+    void toDomain() {
+        // Given
+        final Member member = Member.builder()
+                .userId("userid")
+                .accessToken("access")
+                .loginId("login")
+                .username("username")
+                .profileImage("some image")
+                .build();
+        final PairRoomEntity pairRoomEntity = PairRoomEntity.from(new PairRoom(PairRoomStatus.IN_PROGRESS,
+                new Pair(new PairName("레디"), new PairName("파슬리")),
+                new MissionUrl("https://missionUrl.xxx"),
+                new AccessCode("123456")));
+        final RetrospectEntity retrospectEntity = new RetrospectEntity(1L, pairRoomEntity, member);
+        final RetrospectContentEntity retrospectContentEntity = new RetrospectContentEntity(1L, retrospectEntity,
+                RetrospectQuestionType.FIRST, "hihi");
+
+        // When
+        final RetrospectContent domain = retrospectContentEntity.toDomain();
+
+        // Then
+        assertThat(domain).isNotNull();
+    }
+}

--- a/backend/src/test/java/site/coduo/retrospect/service/RetrospectServiceTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/service/RetrospectServiceTest.java
@@ -219,4 +219,38 @@ class RetrospectServiceTest {
                 .map(retrospectContent -> retrospectContent.getAnswer().getValue());
         assertThat(findAnswers).isEqualTo(answers);
     }
+
+    @DisplayName("특정 id의 회고 정보를 상세 조회한다.")
+    @Test
+    void findRetrospectById() {
+        // Given
+        final Member savedMember = memberRepository.save(
+                Member.builder()
+                        .userId("userid")
+                        .accessToken("access")
+                        .loginId("login")
+                        .username("username")
+                        .profileImage("some image")
+                        .build()
+        );
+        final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
+                new PairRoom(PairRoomStatus.IN_PROGRESS,
+                        new Pair(new PairName("레디"), new PairName("파슬리")),
+                        new MissionUrl("https://missionUrl.xxx"),
+                        new AccessCode("123456"))
+        ));
+        pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember));
+        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final String pairRoomAccessCode = "123456";
+        final List<String> answers = List.of("답변1", "답변2", "답변3", "답변4");
+        retrospectService.createRetrospect(credentialToken, pairRoomAccessCode, answers);
+        final RetrospectEntity savedRetrospectEntity = retrospectRepository.findByPairRoomAndMember(savedPairRoom, savedMember).get();
+
+        // When
+        final Long targetId = savedRetrospectEntity.getId();
+        final Retrospect retrospect = retrospectService.findRetrospectById(targetId);
+
+        // Then
+        assertThat(retrospect).isNotNull();
+    }
 }

--- a/backend/src/test/java/site/coduo/retrospect/service/RetrospectServiceTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/service/RetrospectServiceTest.java
@@ -1,0 +1,171 @@
+package site.coduo.retrospect.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.persistence.EntityNotFoundException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberRepository;
+import site.coduo.member.infrastructure.security.JwtProvider;
+import site.coduo.pairroom.domain.MissionUrl;
+import site.coduo.pairroom.domain.Pair;
+import site.coduo.pairroom.domain.PairName;
+import site.coduo.pairroom.domain.PairRoom;
+import site.coduo.pairroom.domain.PairRoomStatus;
+import site.coduo.pairroom.domain.accesscode.AccessCode;
+import site.coduo.pairroom.repository.PairRoomEntity;
+import site.coduo.pairroom.repository.PairRoomMemberEntity;
+import site.coduo.pairroom.repository.PairRoomMemberRepository;
+import site.coduo.pairroom.repository.PairRoomRepository;
+import site.coduo.retrospect.repository.RetrospectContentEntity;
+import site.coduo.retrospect.repository.RetrospectContentRepository;
+import site.coduo.retrospect.repository.RetrospectEntity;
+import site.coduo.retrospect.repository.RetrospectRepository;
+
+@SpringBootTest
+class RetrospectServiceTest {
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PairRoomRepository pairRoomRepository;
+
+    @Autowired
+    private PairRoomMemberRepository pairRoomMemberRepository;
+
+    @Autowired
+    private RetrospectRepository retrospectRepository;
+
+    @Autowired
+    private RetrospectContentRepository retrospectContentRepository;
+
+    @Autowired
+    private RetrospectService retrospectService;
+
+    @AfterEach
+    public void reset() {
+        retrospectContentRepository.deleteAll();
+        retrospectRepository.deleteAll();
+        pairRoomMemberRepository.deleteAll();
+        memberRepository.deleteAll();
+        pairRoomRepository.deleteAll();
+    }
+
+    @DisplayName("보안 토큰, 페어룸 접근 코드, 회고 문항 답변이 입력되면 회고와 회고 내용을 생성해 DB에 저장한다.")
+    @Test
+    void createRetrospect() {
+        // Given
+        final Member savedMember = memberRepository.save(
+                Member.builder()
+                        .userId("userid")
+                        .accessToken("access")
+                        .loginId("login")
+                        .username("username")
+                        .profileImage("some image")
+                        .build()
+        );
+        final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
+                new PairRoom(PairRoomStatus.IN_PROGRESS,
+                        new Pair(new PairName("레디"), new PairName("파슬리")),
+                        new MissionUrl("https://missionUrl.xxx"),
+                        new AccessCode("123456"))
+        ));
+        pairRoomMemberRepository.save(
+                new PairRoomMemberEntity(savedPairRoom, savedMember));
+
+        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final String pairRoomAccessCode = "123456";
+        final List<String> answers = List.of("답변1", "답변2", "답변3", "답변4");
+
+        // When
+        retrospectService.createRetrospect(credentialToken, pairRoomAccessCode, answers);
+
+        // Then
+        final Optional<RetrospectEntity> retrospectEntity = retrospectRepository.findByPairRoomAndMember(savedPairRoom,
+                savedMember);
+        assertThat(retrospectEntity).isPresent();
+
+        final List<RetrospectContentEntity> retrospectContentEntities = retrospectContentRepository.findAllByRetrospect(
+                retrospectEntity.get());
+        assertThat(retrospectContentEntities).isNotEmpty();
+    }
+
+    @DisplayName("입력된 페어룸 접근 코드에 대응되는 페어룸 정보가 존재하지 않는다면 예외를 발생시킨다.")
+    @Test
+    void notExistPairRoomByAccessCode() {
+        // Given
+        final Member savedMember = memberRepository.save(
+                Member.builder()
+                        .userId("userid")
+                        .accessToken("access")
+                        .loginId("login")
+                        .username("username")
+                        .profileImage("some image")
+                        .build()
+        );
+
+        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final String pairRoomAccessCode = "kelly-code";
+        final List<String> answers = List.of("답변1", "답변2", "답변3", "답변4");
+
+        // When & Then
+        assertThatThrownBy(() -> retrospectService.createRetrospect(credentialToken, pairRoomAccessCode, answers))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("입력된 페어룸 접근 코드에 대응되는 페어룸이 존재하지 않습니다. - " + pairRoomAccessCode);
+    }
+
+    @DisplayName("입력된 페어룸, 사용자 데이터가 서로 참조되어 있지 않다면 예외를 발생시킨다.")
+    @Test
+    void notJoinPairRoomAndMember() {
+        // Given
+        final Member savedMember1 = memberRepository.save(
+                Member.builder()
+                        .userId("userid1")
+                        .accessToken("access1")
+                        .loginId("login1")
+                        .username("username1")
+                        .profileImage("some image")
+                        .build()
+        );
+        final Member savedMember2 = memberRepository.save(
+                Member.builder()
+                        .userId("userid2")
+                        .accessToken("access2")
+                        .loginId("login2")
+                        .username("username2")
+                        .profileImage("some image")
+                        .build()
+        );
+        final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
+                new PairRoom(PairRoomStatus.IN_PROGRESS,
+                        new Pair(new PairName("레디"), new PairName("파슬리")),
+                        new MissionUrl("https://missionUrl.xxx"),
+                        new AccessCode("123456"))
+        ));
+        pairRoomMemberRepository.save(
+                new PairRoomMemberEntity(savedPairRoom, savedMember1));
+
+        final String credentialToken = jwtProvider.sign(savedMember2.getUserId());
+        final String pairRoomAccessCode = "123456";
+        final List<String> answers = List.of("답변1", "답변2", "답변3", "답변4");
+
+        // When & Then
+        assertThatThrownBy(() -> retrospectService.createRetrospect(credentialToken, pairRoomAccessCode, answers))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("입력된 페어룸, 사용자가 서로 참조되어 있지 않습니다.");
+    }
+}

--- a/backend/src/test/java/site/coduo/retrospect/service/RetrospectServiceTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/service/RetrospectServiceTest.java
@@ -24,6 +24,8 @@ import site.coduo.pairroom.domain.PairName;
 import site.coduo.pairroom.domain.PairRoom;
 import site.coduo.pairroom.domain.PairRoomStatus;
 import site.coduo.pairroom.domain.accesscode.AccessCode;
+import site.coduo.pairroom.exception.PairRoomMemberNotJoinException;
+import site.coduo.pairroom.exception.PairRoomNotFoundException;
 import site.coduo.pairroom.repository.PairRoomEntity;
 import site.coduo.pairroom.repository.PairRoomMemberEntity;
 import site.coduo.pairroom.repository.PairRoomMemberRepository;
@@ -31,6 +33,8 @@ import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.referencelink.repository.CategoryRepository;
 import site.coduo.retrospect.domain.Retrospect;
 import site.coduo.retrospect.domain.RetrospectContent;
+import site.coduo.retrospect.exception.NotRetrospectOwnerAccessException;
+import site.coduo.retrospect.exception.RetrospectNotFoundException;
 import site.coduo.retrospect.repository.RetrospectContentEntity;
 import site.coduo.retrospect.repository.RetrospectContentRepository;
 import site.coduo.retrospect.repository.RetrospectEntity;
@@ -129,7 +133,7 @@ class RetrospectServiceTest {
 
         // When & Then
         assertThatThrownBy(() -> retrospectService.createRetrospect(credentialToken, pairRoomAccessCode, answers))
-                .isInstanceOf(EntityNotFoundException.class)
+                .isInstanceOf(PairRoomNotFoundException.class)
                 .hasMessage("입력된 페어룸 접근 코드에 대응되는 페어룸이 존재하지 않습니다. - " + pairRoomAccessCode);
     }
 
@@ -170,7 +174,7 @@ class RetrospectServiceTest {
 
         // When & Then
         assertThatThrownBy(() -> retrospectService.createRetrospect(credentialToken, pairRoomAccessCode, answers))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(PairRoomMemberNotJoinException.class)
                 .hasMessage("입력된 페어룸, 사용자가 서로 참조되어 있지 않습니다.");
     }
 
@@ -252,7 +256,7 @@ class RetrospectServiceTest {
     void findRetrospectByNotExistId() {
         // When & Then
         assertThatThrownBy(() -> retrospectService.findRetrospectById(-1L))
-                .isInstanceOf(EntityNotFoundException.class)
+                .isInstanceOf(RetrospectNotFoundException.class)
                 .hasMessage("해당 아이디에 일치하는 회고 데이터가 존재하지 않습니다.");
     }
 
@@ -288,7 +292,7 @@ class RetrospectServiceTest {
 
         // Then
         assertThatThrownBy(() -> retrospectService.findRetrospectById(targetId))
-                .isInstanceOf(EntityNotFoundException.class)
+                .isInstanceOf(RetrospectNotFoundException.class)
                 .hasMessage("해당 아이디에 일치하는 회고 데이터가 존재하지 않습니다.");
     }
 
@@ -297,7 +301,7 @@ class RetrospectServiceTest {
     void deleteRetrospectByNotExistId() {
         // When & Then
         assertThatThrownBy(() -> retrospectService.findRetrospectById(-1L))
-                .isInstanceOf(EntityNotFoundException.class)
+                .isInstanceOf(RetrospectNotFoundException.class)
                 .hasMessage("해당 아이디에 일치하는 회고 데이터가 존재하지 않습니다.");
     }
 
@@ -340,7 +344,7 @@ class RetrospectServiceTest {
         final String otherCredentialToken = jwtProvider.sign(other.getUserId());
         final Long targetId = savedRetrospectEntity.getId();
         assertThatThrownBy(() -> retrospectService.deleteRetrospect(otherCredentialToken, targetId))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(NotRetrospectOwnerAccessException.class)
                 .hasMessage("본인 소유가 아닌 회고는 삭제할 수 없습니다.");
     }
 

--- a/backend/src/test/java/site/coduo/retrospect/service/RetrospectServiceTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/service/RetrospectServiceTest.java
@@ -42,28 +42,20 @@ class RetrospectServiceTest {
 
     @Autowired
     private JwtProvider jwtProvider;
-
     @Autowired
     private MemberRepository memberRepository;
-
     @Autowired
     private PairRoomRepository pairRoomRepository;
-
     @Autowired
     private PairRoomMemberRepository pairRoomMemberRepository;
-
     @Autowired
     private RetrospectRepository retrospectRepository;
-
     @Autowired
     private RetrospectContentRepository retrospectContentRepository;
-
     @Autowired
     private TimerRepository timerRepository;
-
     @Autowired
     private CategoryRepository categoryRepository;
-
     @Autowired
     private RetrospectService retrospectService;
 


### PR DESCRIPTION
## 연관된 이슈

- closes: #771 

## 구현한 기능
- 회고 작성 API 구현
- 개인 회고 목록 조회 API 구현
- 특정 회고 상세 조회 API 구현
- 특정 회고 삭제 API 구현
- 특정 페어룸에 특정 회원의 회고가 존재하는지 여부 조회 API 구현
- 특정 회원이 특정 페어룸에 존재하는지 여부 조회 API 구현

## 상세 설명
- 회고 기능에 필요한 기능들을 구현함.
- 프론트 요청으로 특정 회원이 특정 페어룸에 아직 참여 상태인지 조회하는 API도 추가로 구현함.
