### PR TITLE
[FE] 🚧 완료 상태 페어룸 2차 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -85,11 +85,15 @@ const App = () => {
                 </Suspense>
               ),
             },
+            {
+              path: ':accessCode/completed',
+              element: (
+                <Suspense fallback={<Loading />}>
+                  <CompletedPairRoom />
+                </Suspense>
+              ),
+            },
           ],
-        },
-        {
-          path: 'room/:accessCode/completed',
-          element: <CompletedPairRoom />,
         },
         {
           path: 'sign-up',

--- a/frontend/src/apis/member.ts
+++ b/frontend/src/apis/member.ts
@@ -51,7 +51,7 @@ interface GetUserRetrospectExistsRequest {
 
 export const getUserRetrospectExists = async (accessCode: string): Promise<GetUserRetrospectExistsRequest> => {
   const response = await fetcher.get({
-    url: `${API_URL}/member/${accessCode}/exists`,
+    url: `${API_URL}/member/retrospect/${accessCode}/exists`,
     errorMessage: ERROR_MESSAGES.GET_USER_RETROSPECT_EXISTS,
   });
 

--- a/frontend/src/apis/member.ts
+++ b/frontend/src/apis/member.ts
@@ -45,10 +45,21 @@ export const getMyPairRooms = async (): Promise<GetMyPairRoomsResponse[]> => {
   return response.json();
 };
 
+interface GetUserIsInPairRoomRequest {
+  accessCode: string;
+}
+export const getUserIsInPairRoom = async (accessCode: string): Promise<GetUserIsInPairRoomRequest> => {
+  const response = await fetcher.get({
+    url: `${API_URL}/member/${accessCode}/exists`,
+    errorMessage: ERROR_MESSAGES.GET_USER_IS_IN_PAIR_ROOM,
+  });
+
+  return await response.json();
+};
+
 interface GetUserRetrospectExistsRequest {
   accessCode: string;
 }
-
 export const getUserRetrospectExists = async (accessCode: string): Promise<GetUserRetrospectExistsRequest> => {
   const response = await fetcher.get({
     url: `${API_URL}/member/retrospect/${accessCode}/exists`,

--- a/frontend/src/apis/member.ts
+++ b/frontend/src/apis/member.ts
@@ -44,3 +44,16 @@ export const getMyPairRooms = async (): Promise<GetMyPairRoomsResponse[]> => {
 
   return response.json();
 };
+
+interface GetUserRetrospectExistsRequest {
+  accessCode: string;
+}
+
+export const getUserRetrospectExists = async (accessCode: string): Promise<GetUserRetrospectExistsRequest> => {
+  const response = await fetcher.get({
+    url: `${API_URL}/member/${accessCode}/exists`,
+    errorMessage: ERROR_MESSAGES.GET_USER_RETROSPECT_EXISTS,
+  });
+
+  return await response.json();
+};

--- a/frontend/src/apis/retrospect.ts
+++ b/frontend/src/apis/retrospect.ts
@@ -1,0 +1,21 @@
+import fetcher from '@/apis/fetcher';
+
+import { ERROR_MESSAGES } from '@/constants/message';
+
+export interface Retrospect {
+  retrospectId: number;
+  pairRoomAccessCode: string;
+  answer: string;
+}
+
+interface GetUserRetrospectsRequest {
+  retrospects: Retrospect[];
+}
+
+export const getUserRetrospects = async (accessCode: string): Promise<GetUserRetrospectsRequest> => {
+  const response = await fetcher.get({
+    url: `/retrospects/${accessCode}`,
+    errorMessage: ERROR_MESSAGES.GET_USER_RETROSPECTS,
+  });
+  return await response.json();
+};

--- a/frontend/src/components/CompletedPairRoom/RetrospectButton/RetroSpectButtonDisabled.tsx
+++ b/frontend/src/components/CompletedPairRoom/RetrospectButton/RetroSpectButtonDisabled.tsx
@@ -8,7 +8,7 @@ const RetrospectButtonDisabled = () => {
       <Button size="lg" disabled={true}>
         회고 작성
       </Button>
-      <S.ButtonPrompt>로그인 후 페어룸에 참여하면 회고를 작성할 수 있어요.</S.ButtonPrompt>
+      <S.ButtonPrompt>로그인 후 현재 페어룸에 페어로 등록된 사람만 회고를 작성할 수 있어요.</S.ButtonPrompt>
     </S.Layout>
   );
 };

--- a/frontend/src/components/CompletedPairRoom/RetrospectButton/RetroSpectButtonDisabled.tsx
+++ b/frontend/src/components/CompletedPairRoom/RetrospectButton/RetroSpectButtonDisabled.tsx
@@ -1,0 +1,16 @@
+import Button from '@/components/common/Button/Button';
+
+import * as S from './RetrospectButton.styles';
+
+const RetrospectButtonDisabled = () => {
+  return (
+    <S.Layout>
+      <Button size="lg" disabled={true}>
+        회고 작성
+      </Button>
+      <S.ButtonPrompt>로그인 후 페어룸에 참여하면 회고를 작성할 수 있어요.</S.ButtonPrompt>
+    </S.Layout>
+  );
+};
+
+export default RetrospectButtonDisabled;

--- a/frontend/src/components/CompletedPairRoom/RetrospectButton/RetrospectButton.styles.ts
+++ b/frontend/src/components/CompletedPairRoom/RetrospectButton/RetrospectButton.styles.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export const Layout = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+`;
+export const ButtonPrompt = styled.div`
+  color: ${({ theme }) => theme.color.black[70]};
+  font-size: ${({ theme }) => theme.fontSize.sm};
+`;

--- a/frontend/src/components/CompletedPairRoom/RetrospectButton/RetrospectButton.tsx
+++ b/frontend/src/components/CompletedPairRoom/RetrospectButton/RetrospectButton.tsx
@@ -1,0 +1,40 @@
+import { useNavigate } from 'react-router-dom';
+
+import Button from '@/components/common/Button/Button';
+
+import { useGetUserRetrospectExists } from '@/queries/CompletedPairRoom/useGetUserRetrospectExists';
+
+import * as S from './RetrospectButton.styles';
+
+const id = 1; //TODO: 회고 api 연동 후 삭제
+
+interface RetrospectButtonProps {
+  accessCode: string;
+}
+
+const RetrospectButton = ({ accessCode }: RetrospectButtonProps) => {
+  const navigate = useNavigate();
+  const { data: isUserRetrospectExist } = useGetUserRetrospectExists(accessCode);
+
+  const handleRetrospectButtonClick = () => {
+    if (isUserRetrospectExist) {
+      navigate(`/retrospect/${id}`);
+    } else {
+      navigate(`/retrospect`, { state: { accessCode } });
+    }
+  };
+  return (
+    <S.Layout>
+      <Button size="lg" onClick={handleRetrospectButtonClick}>
+        {isUserRetrospectExist ? '회고 확인' : '회고 작성'}
+      </Button>
+      <S.ButtonPrompt>
+        {isUserRetrospectExist
+          ? '작성된 회고를 확인하러 가 볼까요?'
+          : '이번 페어 프로그래밍은 어떠셨나요? 회고를 작성해주세요.'}
+      </S.ButtonPrompt>
+    </S.Layout>
+  );
+};
+
+export default RetrospectButton;

--- a/frontend/src/components/CompletedPairRoom/RetrospectButton/RetrospectButton.tsx
+++ b/frontend/src/components/CompletedPairRoom/RetrospectButton/RetrospectButton.tsx
@@ -1,7 +1,9 @@
 import { useNavigate } from 'react-router-dom';
 
 import Button from '@/components/common/Button/Button';
+import RetrospectButtonDisabled from '@/components/CompletedPairRoom/RetrospectButton/RetroSpectButtonDisabled';
 
+import { useGetUserPairRoomExists } from '@/queries/CompletedPairRoom/useGetUserPairRoomExists';
 import { useGetUserRetrospectExists } from '@/queries/CompletedPairRoom/useGetUserRetrospectExists';
 
 import * as S from './RetrospectButton.styles';
@@ -14,7 +16,11 @@ interface RetrospectButtonProps {
 
 const RetrospectButton = ({ accessCode }: RetrospectButtonProps) => {
   const navigate = useNavigate();
+  const { data: isUserInPairRoom } = useGetUserPairRoomExists(accessCode);
+
   const { data: isUserRetrospectExist } = useGetUserRetrospectExists(accessCode);
+
+  if (!isUserInPairRoom) return <RetrospectButtonDisabled />;
 
   const handleRetrospectButtonClick = () => {
     if (isUserRetrospectExist) {

--- a/frontend/src/components/CompletedPairRoom/RetrospectButton/RetrospectButton.tsx
+++ b/frontend/src/components/CompletedPairRoom/RetrospectButton/RetrospectButton.tsx
@@ -3,12 +3,12 @@ import { useNavigate } from 'react-router-dom';
 import Button from '@/components/common/Button/Button';
 import RetrospectButtonDisabled from '@/components/CompletedPairRoom/RetrospectButton/RetroSpectButtonDisabled';
 
+import { getUserRetrospects } from '@/apis/retrospect';
+
 import { useGetUserPairRoomExists } from '@/queries/CompletedPairRoom/useGetUserPairRoomExists';
 import { useGetUserRetrospectExists } from '@/queries/CompletedPairRoom/useGetUserRetrospectExists';
 
 import * as S from './RetrospectButton.styles';
-
-const id = 1; //TODO: 회고 api 연동 후 삭제
 
 interface RetrospectButtonProps {
   accessCode: string;
@@ -22,9 +22,13 @@ const RetrospectButton = ({ accessCode }: RetrospectButtonProps) => {
 
   if (!isUserInPairRoom) return <RetrospectButtonDisabled />;
 
-  const handleRetrospectButtonClick = () => {
+  const handleRetrospectButtonClick = async () => {
     if (isUserRetrospectExist) {
-      navigate(`/retrospect/${id}`);
+      const data = await getUserRetrospects(accessCode);
+      const retrospectId = data.retrospects.find(
+        (retrospect) => retrospect.pairRoomAccessCode === accessCode,
+      )?.retrospectId;
+      navigate(`/retrospect/${retrospectId}`);
     } else {
       navigate(`/retrospect`, { state: { accessCode } });
     }

--- a/frontend/src/components/CompletedPairRoom/RetrospectButton/RetrospectButton.tsx
+++ b/frontend/src/components/CompletedPairRoom/RetrospectButton/RetrospectButton.tsx
@@ -5,7 +5,7 @@ import RetrospectButtonDisabled from '@/components/CompletedPairRoom/RetrospectB
 
 import { getUserRetrospects } from '@/apis/retrospect';
 
-import { useGetUserPairRoomExists } from '@/queries/CompletedPairRoom/useGetUserPairRoomExists';
+import { useGetUserIsInPairRoom } from '@/queries/CompletedPairRoom/useGetUserIsInPairRoom';
 import { useGetUserRetrospectExists } from '@/queries/CompletedPairRoom/useGetUserRetrospectExists';
 
 import * as S from './RetrospectButton.styles';
@@ -16,7 +16,7 @@ interface RetrospectButtonProps {
 
 const RetrospectButton = ({ accessCode }: RetrospectButtonProps) => {
   const navigate = useNavigate();
-  const { data: isUserInPairRoom } = useGetUserPairRoomExists(accessCode);
+  const { data: isUserInPairRoom } = useGetUserIsInPairRoom(accessCode);
 
   const { data: isUserRetrospectExist } = useGetUserRetrospectExists(accessCode);
 

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -19,5 +19,6 @@ export const ERROR_MESSAGES = {
   DELETE_MEMBER: '회원 탈퇴에 실패했습니다. 다시 시도해 주세요.',
   UPDATE_PAIR_ROOM_STATUS: '페어 프로그래밍을 완료하는 데 실패했습니다. 다시 시도해 주세요.',
   GET_USER_IS_IN_PAIR_ROOM: '페어룸 참여 여부를 확인하지 못했습니다. 다시 시도해 주세요.',
+  GET_USER_RETROSPECTS: '회고 정보를 가져오지 못했습니다. 다시 시도해 주세요.',
   GET_USER_RETROSPECT_EXISTS: '회고 작성 여부를 확인하지 못했습니다. 다시 시도해 주세요.',
 };

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -18,4 +18,5 @@ export const ERROR_MESSAGES = {
   GET_MEMBER: '회원 정보를 가져오지 못했습니다. 다시 시도해 주세요.',
   DELETE_MEMBER: '회원 탈퇴에 실패했습니다. 다시 시도해 주세요.',
   UPDATE_PAIR_ROOM_STATUS: '페어 프로그래밍을 완료하는 데 실패했습니다. 다시 시도해 주세요.',
+  GET_USER_RETROSPECT_EXISTS: '회고 작성 여부를 확인하지 못했습니다. 다시 시도해 주세요.',
 };

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -18,5 +18,6 @@ export const ERROR_MESSAGES = {
   GET_MEMBER: '회원 정보를 가져오지 못했습니다. 다시 시도해 주세요.',
   DELETE_MEMBER: '회원 탈퇴에 실패했습니다. 다시 시도해 주세요.',
   UPDATE_PAIR_ROOM_STATUS: '페어 프로그래밍을 완료하는 데 실패했습니다. 다시 시도해 주세요.',
+  GET_USER_IS_IN_PAIR_ROOM: '페어룸 참여 여부를 확인하지 못했습니다. 다시 시도해 주세요.',
   GET_USER_RETROSPECT_EXISTS: '회고 작성 여부를 확인하지 못했습니다. 다시 시도해 주세요.',
 };

--- a/frontend/src/constants/queryKeys.ts
+++ b/frontend/src/constants/queryKeys.ts
@@ -12,4 +12,5 @@ export const QUERY_KEYS = {
   GET_TODOS: 'getTodos',
   GET_USER_IS_IN_PAIR_ROOM: 'getUserIsInPairRoom',
   GET_USER_RETROSPECT_EXISTS: 'getUserRetrospectExists',
+  GET_USER_RETROSPECTS: 'getUserRetrospects',
 };

--- a/frontend/src/constants/queryKeys.ts
+++ b/frontend/src/constants/queryKeys.ts
@@ -10,5 +10,6 @@ export const QUERY_KEYS = {
   GET_SIGN_IN: 'getSignIn',
   GET_SIGN_OUT: 'getSignOut',
   GET_TODOS: 'getTodos',
+  GET_USER_IS_IN_PAIR_ROOM: 'getUserIsInPairRoom',
   GET_USER_RETROSPECT_EXISTS: 'getUserRetrospectExists',
 };

--- a/frontend/src/constants/queryKeys.ts
+++ b/frontend/src/constants/queryKeys.ts
@@ -10,4 +10,5 @@ export const QUERY_KEYS = {
   GET_SIGN_IN: 'getSignIn',
   GET_SIGN_OUT: 'getSignOut',
   GET_TODOS: 'getTodos',
+  GET_USER_RETROSPECT_EXISTS: 'getUserRetrospectExists',
 };

--- a/frontend/src/pages/CompletedPairRoom/CompletedPairRoom.styles.ts
+++ b/frontend/src/pages/CompletedPairRoom/CompletedPairRoom.styles.ts
@@ -78,14 +78,3 @@ export const GithubLogo = styled.img`
   width: 2rem;
   height: 2rem;
 `;
-
-export const ButtonPromptContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1rem;
-`;
-export const ButtonPrompt = styled.div`
-  color: ${({ theme }) => theme.color.black[70]};
-  font-size: ${({ theme }) => theme.fontSize.sm};
-`;

--- a/frontend/src/pages/CompletedPairRoom/CompletedPairRoom.tsx
+++ b/frontend/src/pages/CompletedPairRoom/CompletedPairRoom.tsx
@@ -1,44 +1,25 @@
-import { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import { GithubLogoWhite } from '@/assets';
 
 import Loading from '@/pages/Loading/Loading';
 
 import { ScrollAnimationContainer } from '@/components/common/Animation/ScrollAnimationContainer';
-import Button from '@/components/common/Button/Button';
 import ReferenceCard from '@/components/CompletedPairRoom/ReferenceCard/ReferenceCard';
+import RetrospectButton from '@/components/CompletedPairRoom/RetrospectButton/RetroSpectButton';
+import RetrospectButtonDisabled from '@/components/CompletedPairRoom/RetrospectButton/RetroSpectButtonDisabled';
 import TodoListCard from '@/components/CompletedPairRoom/TodoListCard/TodoListCard';
 
 import useUserStore from '@/stores/userStore';
-
-import { getPairRoomExists } from '@/apis/pairRoom';
 
 import useGetPairRoom from '@/queries/PairRoom/useGetPairRoom';
 
 import * as S from './CompletedPairRoom.styles';
 
 const CompletedPairRoom = () => {
-  const navigate = useNavigate();
   const { accessCode } = useParams();
 
   const { userStatus } = useUserStore();
-
-  useEffect(() => {
-    const checkPairRoomExists = async () => {
-      if (!accessCode) navigate('/error');
-
-      const { exists } = await getPairRoomExists(accessCode || '');
-
-      if (!exists) navigate('/error');
-    };
-    checkPairRoomExists();
-  }, [accessCode]);
-
-  const handleRetrospectWriting = () => {
-    // navigate(''); TODO: 회고 작성 페이지로 이동
-  };
-
   const { driver, navigator, missionUrl, isFetching } = useGetPairRoom(accessCode || '');
 
   if (isFetching) {
@@ -66,22 +47,11 @@ const CompletedPairRoom = () => {
           )}
         </ScrollAnimationContainer>
         <ScrollAnimationContainer animationDirection="right" animationDelay={0.4}>
-          <S.ButtonPromptContainer>
-            <Button
-              size="lg"
-              disabled={userStatus === 'SIGNED_IN' ? false : true}
-              onClick={() => {
-                handleRetrospectWriting();
-              }}
-            >
-              회고 작성
-            </Button>
-            <S.ButtonPrompt>
-              {userStatus === 'SIGNED_IN'
-                ? '이번 페어 프로그래밍은 어떠셨나요? 회고를 작성해주세요.'
-                : '로그인 후 페어룸에 참여하면 회고를 작성할 수 있어요.'}
-            </S.ButtonPrompt>
-          </S.ButtonPromptContainer>
+          {userStatus === 'SIGNED_IN' ? (
+            <RetrospectButton accessCode={accessCode || ''} />
+          ) : (
+            <RetrospectButtonDisabled />
+          )}
         </ScrollAnimationContainer>
       </S.CompletedPairRoomInformationContainer>
       <ScrollAnimationContainer animationDirection="top" animationDelay={0.4}>

--- a/frontend/src/pages/CompletedPairRoom/CompletedPairRoom.tsx
+++ b/frontend/src/pages/CompletedPairRoom/CompletedPairRoom.tsx
@@ -6,7 +6,7 @@ import Loading from '@/pages/Loading/Loading';
 
 import { ScrollAnimationContainer } from '@/components/common/Animation/ScrollAnimationContainer';
 import ReferenceCard from '@/components/CompletedPairRoom/ReferenceCard/ReferenceCard';
-import RetrospectButton from '@/components/CompletedPairRoom/RetrospectButton/RetroSpectButton';
+import RetrospectButton from '@/components/CompletedPairRoom/RetrospectButton/RetrospectButton';
 import RetrospectButtonDisabled from '@/components/CompletedPairRoom/RetrospectButton/RetroSpectButtonDisabled';
 import TodoListCard from '@/components/CompletedPairRoom/TodoListCard/TodoListCard';
 

--- a/frontend/src/pages/PairRoom/PairRoom.tsx
+++ b/frontend/src/pages/PairRoom/PairRoom.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import Loading from '@/pages/Loading/Loading';
 
@@ -19,13 +19,14 @@ import * as S from './PairRoom.styles';
 
 const PairRoom = () => {
   const { accessCode } = useParams();
-
+  const navigate = useNavigate();
   const [driver, setDriver] = useState('');
   const [navigator, setNavigator] = useState('');
 
   const {
     driver: latestDriver,
     navigator: latestNavigator,
+    status,
     missionUrl,
     duration,
     remainingTime,
@@ -34,6 +35,9 @@ const PairRoom = () => {
   const { handleUpdatePairRole } = useUpdatePairRoom(accessCode || '');
 
   useEffect(() => {
+    if (status === 'COMPLETED') {
+      navigate(`/pair-room/${accessCode}/completed`);
+    }
     setDriver(latestDriver);
     setNavigator(latestNavigator);
   }, [latestDriver, latestNavigator]);

--- a/frontend/src/queries/CompletedPairRoom/useGetUserIsInPairRoom.ts
+++ b/frontend/src/queries/CompletedPairRoom/useGetUserIsInPairRoom.ts
@@ -4,7 +4,7 @@ import { getUserIsInPairRoom } from '@/apis/member';
 
 import { QUERY_KEYS } from '@/constants/queryKeys';
 
-export const useGetUserPairRoomExists = (accessCode: string) =>
+export const useGetUserIsInPairRoom = (accessCode: string) =>
   useQuery({
     queryKey: [QUERY_KEYS.GET_USER_IS_IN_PAIR_ROOM],
     queryFn: () => getUserIsInPairRoom(accessCode),

--- a/frontend/src/queries/CompletedPairRoom/useGetUserPairRoomExists.ts
+++ b/frontend/src/queries/CompletedPairRoom/useGetUserPairRoomExists.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getUserIsInPairRoom } from '@/apis/member';
+
+import { QUERY_KEYS } from '@/constants/queryKeys';
+
+export const useGetUserPairRoomExists = (accessCode: string) =>
+  useQuery({
+    queryKey: [QUERY_KEYS.GET_USER_IS_IN_PAIR_ROOM],
+    queryFn: () => getUserIsInPairRoom(accessCode),
+    enabled: !!accessCode,
+  });

--- a/frontend/src/queries/CompletedPairRoom/useGetUserRetrospectExists.ts
+++ b/frontend/src/queries/CompletedPairRoom/useGetUserRetrospectExists.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getUserRetrospectExists } from '@/apis/member';
+
+import { QUERY_KEYS } from '@/constants/queryKeys';
+
+export const useGetUserRetrospectExists = (accessCode: string) =>
+  useQuery({
+    queryKey: [QUERY_KEYS.GET_USER_RETROSPECT_EXISTS],
+    queryFn: () => getUserRetrospectExists(accessCode),
+    enabled: !!accessCode,
+  });

--- a/frontend/src/queries/PairRoom/useGetPairRoom.ts
+++ b/frontend/src/queries/PairRoom/useGetPairRoom.ts
@@ -28,6 +28,7 @@ const useGetPairRoom = (accessCode: string) => {
   return {
     driver: pairRoom?.driver || '',
     navigator: pairRoom?.navigator || '',
+    status: pairRoom?.status || '',
     missionUrl: pairRoom?.missionUrl || '',
     duration: timer?.duration || 0,
     remainingTime: timer?.remainingTime || 0,


### PR DESCRIPTION
## 연관된 이슈

- closes: #800 

## 구현한 기능

🚧 완료 상태 페어룸 2차 구현

## 상세 설명
회고 작성 버튼 컴포넌트로 분리
PrivateRoutes에 CompletedPairRoom 삽입
회고 작성 여부 확인 api 구현
페어룸 상태를 확인해서 완료 페이지로 리다이렉트하는 로직 추가
회원이 페어룸에 참여했는지 여부로 회고 작성 가능 여부 판별 로직 추가
작성된 회고로 이동 기능 구현

아마 api/retrospect 부분이 conflict날 것 같은데, 제가 추가한 메서드는 하나라 나중에 머지할 때 수정하면 될 것 같아요!