### PR TITLE
[BE] 레퍼런스 링크 및 이미지 링크 그리고 오픈그래프 설명 길이 길이 제약 조건 변경

### DIFF
--- a/backend/src/main/java/site/coduo/referencelink/domain/OpenGraph.java
+++ b/backend/src/main/java/site/coduo/referencelink/domain/OpenGraph.java
@@ -11,8 +11,9 @@ import lombok.Getter;
 @Getter
 public class OpenGraph {
 
-    public static final String DEFAULT_VALUE = "";
     public static final String OPEN_GRAPH_META_TAG_SELECTOR = "meta[property=og:%s]";
+    private static final String DEFAULT_VALUE = "";
+    private static final int DESCRIPTION_MAX_LENGTH = 50;
 
     private final String headTitle;
     private final String openGraphTitle;
@@ -27,7 +28,7 @@ public class OpenGraph {
     ) {
         this.headTitle = headTitle;
         this.openGraphTitle = openGraphTitle;
-        this.description = description;
+        this.description = truncate(description);
         this.image = image;
     }
 
@@ -65,12 +66,18 @@ public class OpenGraph {
                 .build();
     }
 
-
     private static String findMetaTag(final Document document, final String key) {
         final Element element = document.selectFirst(String.format(OPEN_GRAPH_META_TAG_SELECTOR, key));
         if (element == null) {
             return DEFAULT_VALUE;
         }
         return element.attr("content");
+    }
+
+    private String truncate(final String description) {
+        if (description.length() <= DESCRIPTION_MAX_LENGTH) {
+            return description;
+        }
+        return description.substring(0, DESCRIPTION_MAX_LENGTH);
     }
 }

--- a/backend/src/main/java/site/coduo/referencelink/repository/OpenGraphEntity.java
+++ b/backend/src/main/java/site/coduo/referencelink/repository/OpenGraphEntity.java
@@ -37,7 +37,7 @@ public class OpenGraphEntity extends BaseTimeEntity {
     @Column(name = "DESCRIPTION", nullable = false)
     private String description;
 
-    @Column(name = "IMAGE", nullable = false)
+    @Column(name = "IMAGE", nullable = false, length = 1024)
     private String image;
 
     @OneToOne

--- a/backend/src/main/java/site/coduo/referencelink/repository/ReferenceLinkEntity.java
+++ b/backend/src/main/java/site/coduo/referencelink/repository/ReferenceLinkEntity.java
@@ -31,15 +31,15 @@ public class ReferenceLinkEntity extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "URL", nullable = false)
+    @Column(name = "URL", nullable = false, length = 1024)
     private String url;
 
     @ManyToOne
     @JoinColumn(name = "CATEGORY_ID", nullable = true)
     private CategoryEntity categoryEntity;
 
-    @JoinColumn(name = "PAIR_ROOM_ID", referencedColumnName = "ID", nullable = false)
     @ManyToOne
+    @JoinColumn(name = "PAIR_ROOM_ID", referencedColumnName = "ID", nullable = false)
     private PairRoomEntity pairRoomEntity;
 
     public ReferenceLinkEntity(final ReferenceLink referenceLink, final CategoryEntity categoryEntity,

--- a/backend/src/test/java/site/coduo/referencelink/domain/OpenGraphTest.java
+++ b/backend/src/test/java/site/coduo/referencelink/domain/OpenGraphTest.java
@@ -9,6 +9,8 @@ import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class OpenGraphTest {
 
@@ -19,11 +21,11 @@ class OpenGraphTest {
     void fill_default_value_when_no_open_graph_properties_in_document() {
         // given
         final String htmlString = "<HTML>"
-                + "<HEAD>"
-                + "</HEAD>"
-                + "<BODY>"
-                + "</BODY>"
-                + "</HTML>";
+                                  + "<HEAD>"
+                                  + "</HEAD>"
+                                  + "<BODY>"
+                                  + "</BODY>"
+                                  + "</HTML>";
         final Document document = Jsoup.parse(htmlString);
 
         // when
@@ -47,14 +49,14 @@ class OpenGraphTest {
         void create_open_graph_with_null_headTitle() {
             // given
             final String htmlString = "<HTML>"
-                    + "<HEAD>"
-                    + "<meta property=\"og:title\" content=\"Open Graph Title Hello\">"
-                    + "<meta property=\"og:description\" content=\"Description Hello\">"
-                    + "<meta property=\"og:image\" content=\"Image Hello\">"
-                    + "</HEAD>"
-                    + "<BODY>"
-                    + "</BODY>"
-                    + "</HTML>";
+                                      + "<HEAD>"
+                                      + "<meta property=\"og:title\" content=\"Open Graph Title Hello\">"
+                                      + "<meta property=\"og:description\" content=\"Description Hello\">"
+                                      + "<meta property=\"og:image\" content=\"Image Hello\">"
+                                      + "</HEAD>"
+                                      + "<BODY>"
+                                      + "</BODY>"
+                                      + "</HTML>";
             final Document document = Jsoup.parse(htmlString);
             final OpenGraph openGraph = OpenGraph.from(document);
 
@@ -72,14 +74,14 @@ class OpenGraphTest {
         void create_open_graph_with_null_openGraphTitle() {
             // given
             final String htmlString = "<HTML>"
-                    + "<HEAD>"
-                    + "<TITLE>Jsoup Test</TITLE>"
-                    + "<meta property=\"og:description\" content=\"Description Hello\">"
-                    + "<meta property=\"og:image\" content=\"Image Hello\">"
-                    + "</HEAD>"
-                    + "<BODY>"
-                    + "</BODY>"
-                    + "</HTML>";
+                                      + "<HEAD>"
+                                      + "<TITLE>Jsoup Test</TITLE>"
+                                      + "<meta property=\"og:description\" content=\"Description Hello\">"
+                                      + "<meta property=\"og:image\" content=\"Image Hello\">"
+                                      + "</HEAD>"
+                                      + "<BODY>"
+                                      + "</BODY>"
+                                      + "</HTML>";
             final Document document = Jsoup.parse(htmlString);
             final OpenGraph openGraph = OpenGraph.from(document);
 
@@ -97,14 +99,14 @@ class OpenGraphTest {
         void create_open_graph_with_null_description() {
             // given
             final String htmlString = "<HTML>"
-                    + "<HEAD>"
-                    + "<TITLE>Jsoup Test</TITLE>"
-                    + "<meta property=\"og:title\" content=\"Open Graph Title Hello\">"
-                    + "<meta property=\"og:image\" content=\"Image Hello\">"
-                    + "</HEAD>"
-                    + "<BODY>"
-                    + "</BODY>"
-                    + "</HTML>";
+                                      + "<HEAD>"
+                                      + "<TITLE>Jsoup Test</TITLE>"
+                                      + "<meta property=\"og:title\" content=\"Open Graph Title Hello\">"
+                                      + "<meta property=\"og:image\" content=\"Image Hello\">"
+                                      + "</HEAD>"
+                                      + "<BODY>"
+                                      + "</BODY>"
+                                      + "</HTML>";
             final Document document = Jsoup.parse(htmlString);
             final OpenGraph openGraph = OpenGraph.from(document);
 
@@ -122,14 +124,14 @@ class OpenGraphTest {
         void create_open_graph_with_null_image() {
             // given
             final String htmlString = "<HTML>"
-                    + "<HEAD>"
-                    + "<TITLE>Jsoup Test</TITLE>"
-                    + "<meta property=\"og:title\" content=\"Open Graph Title Hello\">"
-                    + "<meta property=\"og:description\" content=\"Description Hello\">"
-                    + "</HEAD>"
-                    + "<BODY>"
-                    + "</BODY>"
-                    + "</HTML>";
+                                      + "<HEAD>"
+                                      + "<TITLE>Jsoup Test</TITLE>"
+                                      + "<meta property=\"og:title\" content=\"Open Graph Title Hello\">"
+                                      + "<meta property=\"og:description\" content=\"Description Hello\">"
+                                      + "</HEAD>"
+                                      + "<BODY>"
+                                      + "</BODY>"
+                                      + "</HTML>";
             final Document document = Jsoup.parse(htmlString);
             final OpenGraph openGraph = OpenGraph.from(document);
 
@@ -141,5 +143,21 @@ class OpenGraphTest {
                     () -> assertThat(openGraph.getImage()).isEqualTo(DEFAULT_VALUE)
             );
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {51, 100})
+    @DisplayName("description이 50자 넘어가면 50자를 잘라서 저장한다.")
+    void truncate_description(final int repeatCount) {
+        //given
+        final OpenGraph openGraph = OpenGraph.builder()
+                .openGraphTitle("my page title")
+                .headTitle("my header")
+                .description("1".repeat(repeatCount))
+                .image("")
+                .build();
+
+        //when && then
+        assertThat(openGraph.getDescription()).hasSize(50);
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- closes: #741 

## 구현한 기능

## 상세 설명

엔티티의 길이 제한이 default가 255여서 해당 길이를 초과하는 경우 예외가 발생했었습니다. 
default 제한을 1024로 올려 문제를 해결하였습니다.

추가로 오픈그래프의 description 같은 경우 프론트에서 보여지는 부분이 50을 넘기지 않아 50자를 초과할 시 커팅하여 저장하도록 구현하였습니다. 