### PR TITLE
[FE] 페어룸 온보딩 이름 입력 접근성 개선

### DIFF
--- a/frontend/src/components/PairRoom/ReferenceCard/AddReferenceForm/CategoryDropdown/CategoryDropdown.tsx
+++ b/frontend/src/components/PairRoom/ReferenceCard/AddReferenceForm/CategoryDropdown/CategoryDropdown.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable jsx-a11y/no-autofocus */
-
 import Dropdown from '@/components/common/Dropdown/Dropdown/Dropdown';
 import Input from '@/components/common/Input/Input';
 import { Category } from '@/components/PairRoom/ReferenceCard/ReferenceCard.type';

--- a/frontend/src/components/PairRoomOnboarding/PairNameInput/PairNameInput.tsx
+++ b/frontend/src/components/PairRoomOnboarding/PairNameInput/PairNameInput.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-autofocus */
 import { useState, useEffect } from 'react';
 
 import { LogoIcon } from '@/assets';
@@ -52,6 +53,7 @@ const PairNameInput = ({
         {isInputOpen ? (
           <S.InputWrapper>
             <Input
+              autoFocus
               placeholder="이름을 입력해주세요"
               value={pairName.value}
               status={pairName.status}
@@ -66,8 +68,11 @@ const PairNameInput = ({
           </S.InputWrapper>
         ) : (
           <>
-            <S.AddButton onClick={openAddPairModal}>
-              <div>
+            <S.AddButton
+              aria-label="페어 정보 연동하기 버튼, 클릭하시면 페어 정보 연동 모달이 열립니다."
+              onClick={openAddPairModal}
+            >
+              <div aria-hidden="true">
                 <img src={LogoIcon} alt="" />
               </div>
               <p>페어 정보 연동하기</p>


### PR DESCRIPTION
## 연관된 이슈

- closes: #874 

## 구현한 기능
- [x] 페어 정보 연동하기 버튼에 `aria-label` 추가
- [x] 페어 이름 입력 버튼에 `autoFocus` 를 추가하여 `연동 없이 시작하기` 버튼을 눌렀을 때 포커스가 바로 이동하도록 구현