### PR TITLE
[FE] RetrospectId 삭제 및 회고 페이지 라우터 수정

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -102,6 +102,10 @@ const App = () => {
               path: ':accessCode/retrospect',
               element: <Retrospect />,
             },
+            {
+              path: ':accessCode/retrospectForm',
+              element: <Retrospect readOnly={false} />,
+            },
           ],
         },
         {
@@ -119,10 +123,6 @@ const App = () => {
         {
           path: 'my-page',
           element: <MyPage />,
-        },
-        {
-          path: 'retrospect',
-          element: <Retrospect readOnly={false} />,
         },
 
         {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -98,6 +98,10 @@ const App = () => {
                 </Suspense>
               ),
             },
+            {
+              path: ':accessCode/retrospect',
+              element: <Retrospect />,
+            },
           ],
         },
         {
@@ -120,10 +124,7 @@ const App = () => {
           path: 'retrospect',
           element: <Retrospect readOnly={false} />,
         },
-        {
-          path: 'retrospect/:retrospectId',
-          element: <Retrospect />,
-        },
+
         {
           path: 'error',
           element: <Error />,

--- a/frontend/src/apis/retrospect.ts
+++ b/frontend/src/apis/retrospect.ts
@@ -18,32 +18,30 @@ export const addRetrospect = async ({ accessCode, answers }: AddRetrospectReques
 };
 
 interface GetRetrospectRequest {
-  retrospectId: string;
+  accessCode: string;
 }
 
 interface GetRetrospectResponse {
-  accessCode: string;
   answers: string[];
 }
 
-export const getRetrospectAnswer = async ({ retrospectId }: GetRetrospectRequest): Promise<GetRetrospectResponse> => {
+export const getRetrospectAnswer = async ({ accessCode }: GetRetrospectRequest): Promise<GetRetrospectResponse> => {
   const response = await fetcher.get({
-    url: `${API_URL}/retrospects/${retrospectId}`,
+    url: `${API_URL}/retrospects/${accessCode}`,
     errorMessage: ERROR_MESSAGES.GET_RETROSPECT,
   });
 
   return await response.json();
 };
 
-export const deleteRetrospectAnswer = async ({ retrospectId }: GetRetrospectRequest) => {
+export const deleteRetrospectAnswer = async ({ accessCode }: GetRetrospectRequest) => {
   await fetcher.delete({
-    url: `${API_URL}/retrospects/${retrospectId}`,
+    url: `${API_URL}/retrospects/${accessCode}`,
     errorMessage: ERROR_MESSAGES.DELETE_RETROSPECT,
   });
 };
 
 export interface Retrospect {
-  retrospectId: string;
   accessCode: string;
   answer: string;
 }

--- a/frontend/src/components/CompletedPairRoom/RetrospectButton/RetrospectButton.tsx
+++ b/frontend/src/components/CompletedPairRoom/RetrospectButton/RetrospectButton.tsx
@@ -3,8 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import Button from '@/components/common/Button/Button';
 import RetrospectButtonDisabled from '@/components/CompletedPairRoom/RetrospectButton/RetroSpectButtonDisabled';
 
-import { getUserRetrospects } from '@/apis/retrospect';
-
 import { useGetUserIsInPairRoom } from '@/queries/CompletedPairRoom/useGetUserIsInPairRoom';
 import { useGetUserRetrospectExists } from '@/queries/CompletedPairRoom/useGetUserRetrospectExists';
 
@@ -24,9 +22,7 @@ const RetrospectButton = ({ accessCode }: RetrospectButtonProps) => {
 
   const handleRetrospectButtonClick = async () => {
     if (isUserRetrospectExist) {
-      const data = await getUserRetrospects();
-      const retrospectId = data.retrospects.find((retrospect) => retrospect.accessCode === accessCode)?.retrospectId;
-      navigate(`/retrospect/${retrospectId}`);
+      navigate(`/room/${accessCode}/retrospect`, { state: { valid: true } });
     } else {
       navigate(`/retrospect`, { state: { accessCode } });
     }

--- a/frontend/src/components/CompletedPairRoom/RetrospectButton/RetrospectButton.tsx
+++ b/frontend/src/components/CompletedPairRoom/RetrospectButton/RetrospectButton.tsx
@@ -24,7 +24,7 @@ const RetrospectButton = ({ accessCode }: RetrospectButtonProps) => {
     if (isUserRetrospectExist) {
       navigate(`/room/${accessCode}/retrospect`, { state: { valid: true } });
     } else {
-      navigate(`/retrospect`, { state: { accessCode } });
+      navigate(`/room/${accessCode}/retrospectForm`, { state: { valid: true } });
     }
   };
   return (

--- a/frontend/src/components/MyPage/PairRoomButton/RetrospectButton.tsx
+++ b/frontend/src/components/MyPage/PairRoomButton/RetrospectButton.tsx
@@ -10,12 +10,11 @@ import { useDeleteRetrospect } from '@/queries/Retrospect/useDeleteRetrospect';
 import * as S from './PairRoomButton.styles';
 
 interface RetrospectButtonProps {
-  retrospectId: string;
   answer: string;
   accessCode: string;
 }
 
-const RetrospectButton = ({ retrospectId, accessCode, answer }: RetrospectButtonProps) => {
+const RetrospectButton = ({ accessCode, answer }: RetrospectButtonProps) => {
   const { openModal, closeModal, isModalOpen } = useModal();
   const { mutate, isPending } = useDeleteRetrospect();
 
@@ -26,7 +25,7 @@ const RetrospectButton = ({ retrospectId, accessCode, answer }: RetrospectButton
   };
 
   const handleDeletePairRoom = async () => {
-    mutate({ retrospectId });
+    mutate({ accessCode });
     closeModal();
   };
 
@@ -36,7 +35,7 @@ const RetrospectButton = ({ retrospectId, accessCode, answer }: RetrospectButton
         <Spinner />
       ) : (
         <>
-          <S.LinkWrapper to={`/retrospect/${retrospectId}`}>
+          <S.LinkWrapper to={`room/${accessCode}/retrospect`} state={{ valid: true }}>
             <S.PairRoomButton $status="IN_PROGRESS">
               <S.RoleTextContainer>
                 <S.RoleText $status="IN_PROGRESS">

--- a/frontend/src/components/Retrospect/RetrospectForm/RetrospectForm.tsx
+++ b/frontend/src/components/Retrospect/RetrospectForm/RetrospectForm.tsx
@@ -1,5 +1,3 @@
-import { useLocation } from 'react-router-dom';
-
 import Button from '@/components/common/Button/Button';
 import Question from '@/components/Retrospect/Question/Question';
 import SkipModal from '@/components/Retrospect/RetrospectForm/SkipModal/SkipModal';
@@ -14,10 +12,10 @@ import { RETROSPECT_QUESTIONS } from '@/constants/retrospect';
 
 import * as S from './RetrospectForm.styles';
 
-const RetrospectForm = () => {
-  const location = useLocation();
-  const accessCode = location.state.accessCode;
-
+interface RetrospectFormProps {
+  accessCode: string;
+}
+const RetrospectForm = ({ accessCode }: RetrospectFormProps) => {
   const { answers, handleChange, handleSubmit } = useInputAnswer(accessCode);
 
   const { isModalOpen, openModal, closeModal } = useModal();

--- a/frontend/src/components/Retrospect/RetrospectView/RetrospectView.tsx
+++ b/frontend/src/components/Retrospect/RetrospectView/RetrospectView.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import Question from '@/components/Retrospect/Question/Question';
 import RetrospectHeader from '@/components/Retrospect/RetrospectHeader/RetrospectHeader';
@@ -9,15 +9,17 @@ import { RETROSPECT_QUESTIONS } from '@/constants/retrospect';
 
 import * as S from './RetrospectView.styles';
 
-const RetrospectView = () => {
+interface RetrospectViewProps {
+  accessCode: string;
+}
+const RetrospectView = ({ accessCode }: RetrospectViewProps) => {
   const navigate = useNavigate();
-  const { accessCode } = useParams();
   const answers = useGetRetrospectAnswer(accessCode || '');
 
   return (
     <>
       <RetrospectHeader
-        onClick={() => navigate(`/room/${accessCode}`, { replace: true })}
+        onClick={() => navigate(`/room/${accessCode}`, { state: { valid: true } })}
         readOnly={true}
         accessCode={accessCode || ''}
       />

--- a/frontend/src/components/Retrospect/RetrospectView/RetrospectView.tsx
+++ b/frontend/src/components/Retrospect/RetrospectView/RetrospectView.tsx
@@ -11,15 +11,15 @@ import * as S from './RetrospectView.styles';
 
 const RetrospectView = () => {
   const navigate = useNavigate();
-  const { retrospectId } = useParams();
-  const { accessCode, answers } = useGetRetrospectAnswer(retrospectId || '');
+  const { accessCode } = useParams();
+  const answers = useGetRetrospectAnswer(accessCode || '');
 
   return (
     <>
       <RetrospectHeader
         onClick={() => navigate(`/room/${accessCode}`, { replace: true })}
         readOnly={true}
-        accessCode={accessCode}
+        accessCode={accessCode || ''}
       />
       {RETROSPECT_QUESTIONS.map((question, index) => (
         <Question key={question.id} id={question.id} title={question.title} subtitle={question.subtitle}>

--- a/frontend/src/hooks/PairRoom/useTimer.ts
+++ b/frontend/src/hooks/PairRoom/useTimer.ts
@@ -54,7 +54,7 @@ const useTimer = (accessCode: string, defaultTime: number, defaultTimeleft: numb
 
     const handleStatus = (event: MessageEvent) => {
       if (event.data === 'complete') {
-        navigate(`/retrospect`, { state: { accessCode } });
+        navigate(`/room/${accessCode}/retrospectForm`, { state: { valid: true } });
         addToast({ status: 'WARNING', message: '페어룸이 종료되었습니다.' });
         return;
       }

--- a/frontend/src/pages/MyPage/MyPageContent/MyPageContent.tsx
+++ b/frontend/src/pages/MyPage/MyPageContent/MyPageContent.tsx
@@ -53,8 +53,7 @@ const MyPageContent = () => {
         >
           {myRetrospects?.map((retrospect) => (
             <RetrospectButton
-              key={retrospect.retrospectId}
-              retrospectId={retrospect.retrospectId}
+              key={retrospect.accessCode}
               answer={retrospect.answer}
               accessCode={retrospect.accessCode}
             />

--- a/frontend/src/pages/MyPage/MyPageContent/MyPageContent.tsx
+++ b/frontend/src/pages/MyPage/MyPageContent/MyPageContent.tsx
@@ -24,6 +24,7 @@ const MyPageContent = () => {
 
   const myPairRoomLength = myPairRoomList?.length || 0;
   const myRetrospectsLength = myRetrospects?.length || 0;
+
   return (
     <>
       <MyPageTab

--- a/frontend/src/pages/Retrospect/Retrospect.tsx
+++ b/frontend/src/pages/Retrospect/Retrospect.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react';
+import { useParams } from 'react-router-dom';
 
 import Loading from '@/pages/Loading/Loading';
 
@@ -12,15 +13,17 @@ interface RetrospectProps {
 }
 
 const Retrospect = ({ readOnly = true }: RetrospectProps) => {
+  const { accessCode } = useParams();
+
   return (
     <S.Layout>
       <S.Container>
         {readOnly ? (
           <Suspense fallback={<Loading />}>
-            <RetrospectView />
+            <RetrospectView accessCode={accessCode || ''} />
           </Suspense>
         ) : (
-          <RetrospectForm />
+          <RetrospectForm accessCode={accessCode || ''} />
         )}
       </S.Container>
     </S.Layout>

--- a/frontend/src/queries/PairRoom/useCompletePairRoom.ts
+++ b/frontend/src/queries/PairRoom/useCompletePairRoom.ts
@@ -13,7 +13,7 @@ const useCompletePairRoom = (accessCode: string) => {
     mutationFn: updatePairRoomStatus,
     onSuccess: () => {
       addToast({ status: 'SUCCESS', message: '페어 프로그래밍이 완료되었습니다.' });
-      navigate('/retrospect', { state: { accessCode } });
+      navigate(`room/${accessCode}/retrospectForm`, { state: { valid: true } });
     },
     onError: (error) => addToast({ status: 'ERROR', message: error.message }),
   });

--- a/frontend/src/queries/Retrospect/useGetRetrospectAnswer.ts
+++ b/frontend/src/queries/Retrospect/useGetRetrospectAnswer.ts
@@ -4,14 +4,14 @@ import { getRetrospectAnswer } from '@/apis/retrospect';
 
 import { QUERY_KEYS } from '@/constants/queryKeys';
 
-export const useGetRetrospectAnswer = (retrospectId: string) => {
+export const useGetRetrospectAnswer = (accessCode: string) => {
   const { data } = useSuspenseQuery({
     queryKey: [QUERY_KEYS.GET_RETROSPECT_ANSWER],
-    queryFn: () => getRetrospectAnswer({ retrospectId }),
+    queryFn: () => getRetrospectAnswer({ accessCode }),
     retry: false,
   });
 
-  const { accessCode, answers } = data;
+  const answers = data.answers;
 
-  return { accessCode, answers };
+  return answers;
 };


### PR DESCRIPTION
## 연관된 이슈

- closes: #869 

## 구현한 기능
- RetrospectId 삭제 및 회고 페이지 라우터 수정

## 상세 설명
- 회고 post, delete 에서 retrospectId 대신 accessCode 보내주도록 api 수정했습니다
- 회고 get 에서 retrospectId 제거했습니다
- 회고 페이지 라우팅을 `room/:accessCode/retrospect` 로 수정했습니다. 이제 회고페이지 접근하려면 {valid:true } 도 같이 보내줘야합니다.
- 마찬가지로 회고 페이지 작성 라우터를 `room/:accessCode/retrospectForm` 로 수정했습니다. 이제 accessCode 대신  {valid:true }  만 보내주면 돼요!
