### PR TITLE
[BE] 페어룸 종료 기능 추가

### DIFF
--- a/backend/src/main/java/site/coduo/pairroom/controller/PairRoomController.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/PairRoomController.java
@@ -9,7 +9,6 @@ import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -95,10 +94,18 @@ public class PairRoomController implements PairRoomDocs {
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/pair-room/{accessCode}")
+    @PatchMapping("/pair-room/{accessCode}/complete")
+    public ResponseEntity<Void> completePairRoom(@PathVariable("accessCode") final String accessCode) {
+        pairRoomService.completePairRoom(accessCode);
+        return ResponseEntity.noContent()
+                .build();
+    }
+
+    @PatchMapping("/pair-room/{accessCode}/delete")
     public ResponseEntity<Void> deletePairRoom(@PathVariable("accessCode") final String accessCode) {
         pairRoomService.deletePairRoom(accessCode);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.noContent()
+                .build();
     }
 
     @GetMapping("/member/{accessCode}/exists")

--- a/backend/src/main/java/site/coduo/pairroom/controller/PairRoomExceptionHandler.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/PairRoomExceptionHandler.java
@@ -12,11 +12,13 @@ import lombok.extern.slf4j.Slf4j;
 import site.coduo.common.controller.response.ApiErrorResponse;
 import site.coduo.pairroom.controller.error.PairRoomApiError;
 import site.coduo.pairroom.exception.DuplicatePairNameException;
+import site.coduo.pairroom.exception.InactivePairRoomException;
 import site.coduo.pairroom.exception.InvalidAccessCodeException;
 import site.coduo.pairroom.exception.InvalidNameFormatException;
-import site.coduo.pairroom.exception.PairRoomException;
-import site.coduo.pairroom.exception.PairRoomNotFoundException;
 import site.coduo.pairroom.exception.InvalidPairRoomStatusException;
+import site.coduo.pairroom.exception.PairRoomException;
+import site.coduo.pairroom.exception.PairRoomMemberNotFoundException;
+import site.coduo.pairroom.exception.PairRoomNotFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -29,6 +31,14 @@ public class PairRoomExceptionHandler {
 
         return ResponseEntity.status(PairRoomApiError.INVALID_PAIR_NAME.getHttpStatus())
                 .body(new ApiErrorResponse(PairRoomApiError.INVALID_PAIR_NAME.getMessage()));
+    }
+
+    @ExceptionHandler(InactivePairRoomException.class)
+    public ResponseEntity<ApiErrorResponse> handleInactivePairRoomException(final InactivePairRoomException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(PairRoomApiError.INACTIVE_PAIR_ROOM.getHttpStatus())
+                .body(new ApiErrorResponse(PairRoomApiError.INACTIVE_PAIR_ROOM.getMessage()));
     }
 
     @ExceptionHandler(InvalidAccessCodeException.class)
@@ -49,7 +59,8 @@ public class PairRoomExceptionHandler {
     }
 
     @ExceptionHandler(InvalidPairRoomStatusException.class)
-    public ResponseEntity<ApiErrorResponse> handlePairRoomStatusNotFoundException(final InvalidPairRoomStatusException e) {
+    public ResponseEntity<ApiErrorResponse> handlePairRoomStatusNotFoundException(
+            final InvalidPairRoomStatusException e) {
         log.warn(e.getMessage());
 
         return ResponseEntity.status(PairRoomApiError.INVALID_PROPERTIES_FORMAT.getHttpStatus())
@@ -62,6 +73,15 @@ public class PairRoomExceptionHandler {
 
         return ResponseEntity.status(PairRoomApiError.PAIR_ROOM_NOT_FOUND.getHttpStatus())
                 .body(new ApiErrorResponse(PairRoomApiError.PAIR_ROOM_NOT_FOUND.getMessage()));
+    }
+
+    @ExceptionHandler(PairRoomMemberNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handlePairRoomMemberNotFoundException(
+            final PairRoomMemberNotFoundException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(PairRoomApiError.PAIR_ROOM_MEMBER_NOT_FOUND.getHttpStatus())
+                .body(new ApiErrorResponse(PairRoomApiError.PAIR_ROOM_MEMBER_NOT_FOUND.getMessage()));
     }
 
     @ExceptionHandler(PairRoomException.class)

--- a/backend/src/main/java/site/coduo/pairroom/controller/docs/PairRoomDocs.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/docs/PairRoomDocs.java
@@ -83,6 +83,13 @@ public interface PairRoomDocs {
             String accessCode
     );
 
+    @Operation(summary = "페어룸을 종료한다.")
+    @ApiResponse(responseCode = "204", description = "페어룸 종료 성공")
+    ResponseEntity<Void> completePairRoom(
+            @Parameter(description = "페어룸 접근 코드", required = true)
+            String accessCode
+    );
+
     @Operation(summary = "특정 회원이 특정 페어룸에 존재하는지 여부를 조회한다.")
     @ApiResponse(responseCode = "200", description = "회원 페어룸 참여 여부 조회 성공", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
             schema = @Schema(implementation = ExistMemberInPairRoomResponse.class)))

--- a/backend/src/main/java/site/coduo/pairroom/controller/error/PairRoomApiError.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/error/PairRoomApiError.java
@@ -13,7 +13,9 @@ public enum PairRoomApiError {
     INVALID_PAIR_NAME(HttpStatus.BAD_REQUEST, "올바르지 않은 페어 이름입니다."),
     INVALID_ACCESS_CODE(HttpStatus.BAD_REQUEST, "올바르지 않은 접근 코드입니다."),
     PAIR_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "페어룸이 존재하지 않습니다."),
-    INVALID_PROPERTIES_FORMAT(HttpStatus.BAD_REQUEST, "올바르지 않은 데이터 형식입니다.");
+    PAIR_ROOM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "페어룸-멤버가 존재하지 않습니다."),
+    INVALID_PROPERTIES_FORMAT(HttpStatus.BAD_REQUEST, "올바르지 않은 데이터 형식입니다."),
+    INACTIVE_PAIR_ROOM(HttpStatus.BAD_REQUEST, "이미 종료되거나 삭제된 페어룸입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/site/coduo/pairroom/exception/DeletePairRoomException.java
+++ b/backend/src/main/java/site/coduo/pairroom/exception/DeletePairRoomException.java
@@ -1,8 +1,0 @@
-package site.coduo.pairroom.exception;
-
-public class DeletePairRoomException extends PairRoomException {
-
-    public DeletePairRoomException(final String message) {
-        super(message);
-    }
-}

--- a/backend/src/main/java/site/coduo/pairroom/exception/InactivePairRoomException.java
+++ b/backend/src/main/java/site/coduo/pairroom/exception/InactivePairRoomException.java
@@ -1,0 +1,8 @@
+package site.coduo.pairroom.exception;
+
+public class InactivePairRoomException extends PairRoomException {
+
+    public InactivePairRoomException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/site/coduo/pairroom/repository/PairRoomEntity.java
+++ b/backend/src/main/java/site/coduo/pairroom/repository/PairRoomEntity.java
@@ -102,7 +102,11 @@ public class PairRoomEntity extends BaseTimeEntity {
         this.driver = temp;
     }
 
-    public boolean isDelete() {
+    public boolean isActive() {
+        return status != PairRoomStatus.COMPLETED && status != PairRoomStatus.DELETED;
+    }
+
+    public boolean isDeleted() {
         return status == PairRoomStatus.DELETED;
     }
 

--- a/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
@@ -20,7 +20,7 @@ import site.coduo.pairroom.domain.accesscode.AccessCode;
 import site.coduo.pairroom.domain.accesscode.generator.AccessCodeGenerator;
 import site.coduo.pairroom.domain.accesscode.generator.EasyAccessCodeGenerator;
 import site.coduo.pairroom.domain.accesscode.generator.UUIDAccessCodeGenerator;
-import site.coduo.pairroom.exception.DeletePairRoomException;
+import site.coduo.pairroom.exception.InactivePairRoomException;
 import site.coduo.pairroom.repository.PairRoomEntity;
 import site.coduo.pairroom.repository.PairRoomMemberEntity;
 import site.coduo.pairroom.repository.PairRoomMemberRepository;
@@ -101,29 +101,29 @@ public class PairRoomService {
     @Transactional
     public void updateNavigatorWithDriver(final String accessCode) {
         final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCode);
-        checkDeletePairRoom(pairRoomEntity);
+        checkPairRoomIsActive(pairRoomEntity);
         pairRoomEntity.swapNavigatorWithDriver();
-    }
-
-    private void checkDeletePairRoom(final PairRoomEntity pairRoomEntity) {
-        if (pairRoomEntity.isDelete()) {
-            throw new DeletePairRoomException("삭제된 페어룸입니다.");
-        }
     }
 
     @Transactional
     public void updatePairRoomStatus(final String accessCode, final String statusName) {
         final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCode);
-        checkDeletePairRoom(pairRoomEntity);
+        checkPairRoomIsActive(pairRoomEntity);
         final PairRoomStatus status = PairRoomStatus.findByName(statusName);
         pairRoomEntity.updateStatus(status);
     }
 
     public PairRoomReadResponse findPairRoomAndTimer(final String accessCode) {
         final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCode);
-        checkDeletePairRoom(pairRoomEntity);
+        checkPairRoomIsDeleted(pairRoomEntity);
         final TimerEntity timerEntity = timerRepository.fetchTimerByPairRoomEntity(pairRoomEntity);
         return PairRoomReadResponse.of(pairRoomEntity.toDomain(), timerEntity.toDomain());
+    }
+
+    private void checkPairRoomIsActive(final PairRoomEntity pairRoomEntity) {
+        if (!pairRoomEntity.isActive()) {
+            throw new InactivePairRoomException("종료되거나 삭제된 페어룸을 조작할 수 없습니다.");
+        }
     }
 
     public List<PairRoomMemberResponse> findPairRooms(final String token) {
@@ -132,7 +132,7 @@ public class PairRoomService {
         final List<PairRoomMemberEntity> pairRooms = pairRoomMemberRepository.findByMember(member);
         final List<PairRoomEntity> pairRoomEntities = pairRooms.stream()
                 .map(PairRoomMemberEntity::getPairRoom)
-                .filter(pairRoomEntity -> !pairRoomEntity.isDelete())
+                .filter(pairRoomEntity -> !pairRoomEntity.isDeleted())
                 .toList();
 
         return pairRoomEntities.stream()
@@ -143,8 +143,21 @@ public class PairRoomService {
     @Transactional
     public void deletePairRoom(final String accessCode) {
         final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCode);
-        checkDeletePairRoom(pairRoomEntity);
+        checkPairRoomIsDeleted(pairRoomEntity);
         pairRoomEntity.updateStatus(PairRoomStatus.DELETED);
+    }
+
+    @Transactional
+    public void completePairRoom(final String accessCode) {
+        final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCode);
+        checkPairRoomIsActive(pairRoomEntity);
+        pairRoomEntity.updateStatus(PairRoomStatus.COMPLETED);
+    }
+
+    private void checkPairRoomIsDeleted(final PairRoomEntity pairRoomEntity) {
+        if (pairRoomEntity.isDeleted()) {
+            throw new InactivePairRoomException("삭제된 페어룸을 삭제할 수 없습니다.");
+        }
     }
 
     public boolean existMemberInPairRoom(final String credentialToken, final String pairRoomAccessCode) {

--- a/backend/src/main/java/site/coduo/referencelink/service/CategoryService.java
+++ b/backend/src/main/java/site/coduo/referencelink/service/CategoryService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import site.coduo.pairroom.domain.accesscode.AccessCode;
+import site.coduo.pairroom.exception.InactivePairRoomException;
 import site.coduo.pairroom.repository.PairRoomEntity;
 import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.referencelink.domain.Category;
@@ -41,6 +42,7 @@ public class CategoryService {
 
     public CategoryCreateResponse createCategory(final String accessCode, final CategoryCreateRequest request) {
         final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(new AccessCode(accessCode));
+        checkPairRoomIsActive(pairRoomEntity);
         validateDuplicated(request.value(), pairRoomEntity);
         final CategoryEntity categoryEntity = categoryRepository.save(
                 new CategoryEntity(pairRoomEntity, new Category(request.value())));
@@ -56,6 +58,7 @@ public class CategoryService {
 
     public CategoryUpdateResponse updateCategoryName(final String accessCode, final CategoryUpdateRequest request) {
         final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(new AccessCode(accessCode));
+        checkPairRoomIsActive(pairRoomEntity);
         validateDuplicated(request.updatedCategoryName(), pairRoomEntity);
         final CategoryEntity category = categoryRepository.fetchByPairRoomAndCategoryId(pairRoomEntity,
                 request.categoryId());
@@ -65,11 +68,18 @@ public class CategoryService {
 
     public void deleteCategory(final String accessCode, final Long categoryId) {
         final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(new AccessCode(accessCode));
+        checkPairRoomIsActive(pairRoomEntity);
         if (categoryRepository.existsByIdAndPairRoomEntity(categoryId, pairRoomEntity)) {
             final List<ReferenceLinkEntity> referenceLinks = referenceLinkService.findReferenceLinksEntityByCategory(
                     accessCode, categoryId);
             referenceLinks.forEach(ReferenceLinkEntity::updateCategoryToNull);
             categoryRepository.deleteCategoryByPairRoomEntityAndId(pairRoomEntity, categoryId);
+        }
+    }
+
+    private void checkPairRoomIsActive(final PairRoomEntity pairRoomEntity) {
+        if (!pairRoomEntity.isActive()) {
+            throw new InactivePairRoomException("이미 종료되었거나 삭제된 페어룸의 카테고리를 조작할 수 없습니다.");
         }
     }
 }

--- a/backend/src/main/java/site/coduo/referencelink/service/ReferenceLinkService.java
+++ b/backend/src/main/java/site/coduo/referencelink/service/ReferenceLinkService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import site.coduo.pairroom.domain.accesscode.AccessCode;
+import site.coduo.pairroom.exception.InactivePairRoomException;
 import site.coduo.pairroom.repository.PairRoomEntity;
 import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.referencelink.domain.Category;
@@ -34,10 +35,13 @@ public class ReferenceLinkService {
     private final CategoryRepository categoryRepository;
     private final OpenGraphService openGraphService;
 
-    public ReferenceLinkResponse createReferenceLink(final String accessCodeText,
-                                                     final ReferenceLinkCreateRequest request) {
+    public ReferenceLinkResponse createReferenceLink(
+            final String accessCodeText,
+            final ReferenceLinkCreateRequest request
+    ) {
         final AccessCode accessCode = new AccessCode(accessCodeText);
         final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCode);
+        checkPairRoomIsActive(pairRoomEntity);
         final URL url = makeUrl(request.url());
         final ReferenceLink referenceLink = new ReferenceLink(url, accessCode);
 
@@ -54,9 +58,10 @@ public class ReferenceLinkService {
         }
     }
 
-    private ReferenceLinkEntity saveReferenceLink(final ReferenceLinkCreateRequest request,
-                                                  final PairRoomEntity pairRoomEntity,
-                                                  final ReferenceLink referenceLink
+    private ReferenceLinkEntity saveReferenceLink(
+            final ReferenceLinkCreateRequest request,
+            final PairRoomEntity pairRoomEntity,
+            final ReferenceLink referenceLink
     ) {
         if (request.categoryId() == null) {
             return referenceLinkRepository.save(new ReferenceLinkEntity(referenceLink, pairRoomEntity));
@@ -118,10 +123,18 @@ public class ReferenceLinkService {
     }
 
     public void deleteReferenceLink(final String accessCodeText, final long id) {
+        final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCodeText);
+        checkPairRoomIsActive(pairRoomEntity);
         final ReferenceLinkEntity referenceLinkEntity = referenceLinkRepository.fetchById(id);
         if (referenceLinkEntity.isSameAccessCode(new AccessCode(accessCodeText))) {
             openGraphService.deleteByReferenceLink(referenceLinkEntity);
             referenceLinkRepository.delete(referenceLinkEntity);
+        }
+    }
+
+    private void checkPairRoomIsActive(final PairRoomEntity pairRoomEntity) {
+        if (!pairRoomEntity.isActive()) {
+            throw new InactivePairRoomException("이미 종료되었거나 삭제된 페어룸의 링크를 조작할 수 없습니다.");
         }
     }
 }

--- a/backend/src/main/java/site/coduo/todo/service/TodoService.java
+++ b/backend/src/main/java/site/coduo/todo/service/TodoService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
-import site.coduo.pairroom.exception.PairRoomNotFoundException;
+import site.coduo.pairroom.exception.InactivePairRoomException;
 import site.coduo.pairroom.repository.PairRoomEntity;
 import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.todo.domain.Todo;
@@ -29,9 +29,7 @@ public class TodoService {
 
     @Transactional(readOnly = true)
     public List<Todo> getAllOrderBySort(final String accessCode) {
-        final PairRoomEntity pairRoom = pairRoomRepository.findByAccessCode(accessCode)
-                .orElseThrow(() -> new PairRoomNotFoundException("해당 Access Code의 페어룸은 존재하지 않습니다. - " + accessCode));
-
+        final PairRoomEntity pairRoom = pairRoomRepository.fetchByAccessCode(accessCode);
         return todoRepository.findAllByPairRoomEntity(pairRoom)
                 .stream()
                 .map(TodoEntity::toDomain)
@@ -40,11 +38,11 @@ public class TodoService {
     }
 
     public void createTodo(final String accessCode, final String content) {
-        final PairRoomEntity pairRoom = pairRoomRepository.findByAccessCode(accessCode)
-                .orElseThrow(() -> new PairRoomNotFoundException("해당 Access Code의 페어룸은 존재하지 않습니다. - " + accessCode));
-        final TodoSort nextToLastSort = getLastTodoSort(pairRoom);
+        final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCode);
+        checkPairRoomIsActive(pairRoomEntity);
+        final TodoSort nextToLastSort = getLastTodoSort(pairRoomEntity);
         final Todo todo = new Todo(null, content, nextToLastSort.getSort(), INITIAL_TODO_CHECKED);
-        final TodoEntity todoEntity = new TodoEntity(todo, pairRoom);
+        final TodoEntity todoEntity = new TodoEntity(todo, pairRoomEntity);
 
         todoRepository.save(todoEntity);
     }
@@ -59,19 +57,20 @@ public class TodoService {
 
     public void updateTodoContent(final Long todoId, final String content) {
         final TodoEntity todoEntity = todoRepository.fetchById(todoId);
-
+        checkPairRoomIsActive(todoEntity.getPairRoomEntity());
         todoEntity.updateContent(content);
     }
 
     public void toggleTodoChecked(final Long todoId) {
         final TodoEntity todoEntity = todoRepository.fetchById(todoId);
-
+        checkPairRoomIsActive(todoEntity.getPairRoomEntity());
         todoEntity.toggleTodoChecked();
     }
 
     public void updateTodoSort(final Long targetTodoId, final int destinationSort) {
         final TodoEntity targetTodo = todoRepository.findById(targetTodoId)
                 .orElseThrow(() -> new TodoNotFoundException("존재하지 않은 todo id입니다." + targetTodoId));
+        checkPairRoomIsActive(targetTodo.getPairRoomEntity());
         final List<Todo> allByPairRoom = todoRepository
                 .findAllByPairRoomEntity(targetTodo.getPairRoomEntity())
                 .stream()
@@ -85,6 +84,15 @@ public class TodoService {
     }
 
     public void deleteTodo(final Long todoId) {
+        final TodoEntity todoEntity = todoRepository.findById(todoId)
+                .orElseThrow(() -> new TodoNotFoundException("존재하지 않은 todo id입니다." + todoId));
+        checkPairRoomIsActive(todoEntity.getPairRoomEntity());
         todoRepository.deleteById(todoId);
+    }
+
+    private void checkPairRoomIsActive(final PairRoomEntity pairRoomEntity) {
+        if (!pairRoomEntity.isActive()) {
+            throw new InactivePairRoomException("이미 종료되거나 삭제된 페어룸의 투두를 조작할 수 없습니다.");
+        }
     }
 }

--- a/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
@@ -40,8 +40,10 @@ class PairRoomAcceptanceTest extends AcceptanceFixture {
 
     @Autowired
     private JwtProvider jwtProvider;
+
     @Autowired
     private PairRoomRepository pairRoomRepository;
+
     @Autowired
     private PairRoomMemberRepository pairRoomMemberRepository;
 
@@ -193,7 +195,7 @@ class PairRoomAcceptanceTest extends AcceptanceFixture {
                 .all()
 
                 .when()
-                .delete("/api/pair-room/{access-code}", accessCode.accessCode())
+                .patch("/api/pair-room/{access-code}/complete", accessCode.accessCode())
 
                 .then()
                 .statusCode(204);

--- a/backend/src/test/java/site/coduo/acceptance/RetrospectAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/RetrospectAcceptanceTest.java
@@ -205,7 +205,6 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
                         .build()
         );
         final PairRoomEntity savedPairRoom = saveTestPairRoom();
-        pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, owner));
 
         // When
         final String otherMemberToken = jwtProvider.sign(other.getUserId());
@@ -220,7 +219,7 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
                 .delete("/api/retrospects/{accessCode}", savedPairRoom.getAccessCode())
 
                 .then()
-                .statusCode(400);
+                .statusCode(404);
     }
 
     @DisplayName("특정 회원이 특정 페어룸에 작성한 회고가 존재하는지 여부를 조회한다.")

--- a/backend/src/test/java/site/coduo/pairroom/domain/PairRoomEntityTest.java
+++ b/backend/src/test/java/site/coduo/pairroom/domain/PairRoomEntityTest.java
@@ -63,7 +63,7 @@ class PairRoomEntityTest {
         );
 
         // When
-        final boolean isDelete = sut.isDelete();
+        final boolean isDelete = sut.isDeleted();
 
         // Then
         assertThat(isDelete).isTrue();
@@ -82,7 +82,7 @@ class PairRoomEntityTest {
         );
 
         // When
-        final boolean isDelete = sut.isDelete();
+        final boolean isDelete = sut.isDeleted();
 
         // Then
         assertThat(isDelete).isFalse();

--- a/backend/src/test/java/site/coduo/pairroom/service/PairRoomServiceTest.java
+++ b/backend/src/test/java/site/coduo/pairroom/service/PairRoomServiceTest.java
@@ -27,7 +27,7 @@ import site.coduo.pairroom.domain.PairName;
 import site.coduo.pairroom.domain.PairRoom;
 import site.coduo.pairroom.domain.PairRoomStatus;
 import site.coduo.pairroom.domain.accesscode.AccessCode;
-import site.coduo.pairroom.exception.DeletePairRoomException;
+import site.coduo.pairroom.exception.InactivePairRoomException;
 import site.coduo.pairroom.exception.PairRoomNotFoundException;
 import site.coduo.pairroom.repository.PairRoomEntity;
 import site.coduo.pairroom.repository.PairRoomMemberEntity;
@@ -108,7 +108,7 @@ class PairRoomServiceTest {
 
         // when & then
         assertThatThrownBy(() -> pairRoomService.findPairRoomAndTimer(accessCode))
-                .isExactlyInstanceOf(DeletePairRoomException.class);
+                .isExactlyInstanceOf(InactivePairRoomException.class);
     }
 
     @Test
@@ -137,7 +137,7 @@ class PairRoomServiceTest {
 
         // when & then
         assertThatThrownBy(() -> pairRoomService.updatePairRoomStatus(accessCode, PairRoomStatus.COMPLETED.name()))
-                .isExactlyInstanceOf(DeletePairRoomException.class);
+                .isExactlyInstanceOf(InactivePairRoomException.class);
     }
 
     @Test
@@ -177,7 +177,7 @@ class PairRoomServiceTest {
 
         // when & then
         assertThatThrownBy(() -> pairRoomService.updateNavigatorWithDriver(entity.getAccessCode()))
-                .isExactlyInstanceOf(DeletePairRoomException.class);
+                .isExactlyInstanceOf(InactivePairRoomException.class);
     }
 
     @DisplayName("삭제되지 않은, 멤버의 방 목록을 가져온다.")

--- a/backend/src/test/java/site/coduo/referencelink/service/ReferenceLinkServiceTest.java
+++ b/backend/src/test/java/site/coduo/referencelink/service/ReferenceLinkServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import site.coduo.pairroom.domain.accesscode.AccessCode;
+import site.coduo.pairroom.exception.PairRoomNotFoundException;
 import site.coduo.pairroom.repository.PairRoomEntity;
 import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.referencelink.domain.Category;
@@ -138,20 +139,17 @@ class ReferenceLinkServiceTest extends CascadeCleaner {
 
     @DisplayName("액세스코드가 일치하지 않으면 삭제를 시도해도 삭제되지 않는다.")
     @Test
-    void cannot_delete_reference_link_and_open_graph_when_invalid_access_code() throws MalformedURLException {
+    void cannot_delete_reference_link_and_open_graph_when_invalid_access_code() {
         // given
         final ReferenceLinkCreateRequest request =
                 new ReferenceLinkCreateRequest(FakeServer.testUrl, springCategory.getId());
         final ReferenceLinkResponse referenceLink = referenceLinkService.createReferenceLink(
                 pairRoomEntity.getAccessCode(), request);
+        final String invalidAccessCode = "abcdef";
 
-        // when
-        referenceLinkService.deleteReferenceLink("abcdef", referenceLink.id());
-
-        assertAll(
-                () -> assertThat(referenceLinkRepository.findAll()).hasSize(1),
-                () -> assertThat(openGraphRepository.findAll()).hasSize(1)
-        );
+        // when & then
+        assertThatThrownBy(() -> referenceLinkService.deleteReferenceLink(invalidAccessCode, referenceLink.id()))
+                .isExactlyInstanceOf(PairRoomNotFoundException.class);
     }
 
     @Test

--- a/backend/src/test/java/site/coduo/todo/service/TodoServiceTest.java
+++ b/backend/src/test/java/site/coduo/todo/service/TodoServiceTest.java
@@ -98,7 +98,7 @@ class TodoServiceTest {
         // When & Then
         assertThatThrownBy(() -> todoService.createTodo("NOCODE", content))
                 .isInstanceOf(PairRoomNotFoundException.class)
-                .hasMessage("해당 Access Code의 페어룸은 존재하지 않습니다. - " + "NOCODE");
+                .hasMessage("존재하지 않는 페어룸 접근 코드입니다.");
     }
 
     @DisplayName("투두 id와 새로운 투두 내용이 입력되면 해당 투두를 저장소에서 가져와 내용을 변경한뒤 저장한다.")
@@ -215,9 +215,7 @@ class TodoServiceTest {
         final boolean isChecked = false;
         final Todo todo = new Todo(1L, content, sort, isChecked);
         final TodoEntity todoEntity = new TodoEntity(todo, pairRoomEntity);
-        todoRepository.save(todoEntity);
-
-        final Long todoId = 1L;
+        final Long todoId = todoRepository.save(todoEntity).getId();
 
         // When
         todoService.deleteTodo(todoId);
@@ -290,7 +288,7 @@ class TodoServiceTest {
         // When & Then
         assertThatThrownBy(() -> todoService.getAllOrderBySort(pairRoomAccessCode))
                 .isInstanceOf(PairRoomNotFoundException.class)
-                .hasMessage("해당 Access Code의 페어룸은 존재하지 않습니다. - " + pairRoomAccessCode);
+                .hasMessage("존재하지 않는 페어룸 접근 코드입니다.");
     }
 
     @DisplayName("대상 투두 아이디와 변경할 순서를 입력받으면 위치를 변경시킨다.")


### PR DESCRIPTION
## 연관된 이슈

- closes: #948 

## 구현한 기능
- 페어룸 종료 api 추가
- 페어룸 exception 중 핸들링 하지 않았던 것 핸들러에 추가
- 페어룸이 종료되었거나 삭제되었을 때, `페어룸&투두&링크&카테고리`의 `수정&생성&삭제` 방어 로직 추가
- 문서화 완료
## 상세 설명
