### PR TITLE
[BE] 멤버 도메인 미사용 컬럼 삭제 및 필드명 통일 

### DIFF
--- a/backend/src/main/java/site/coduo/member/client/dto/GithubUserResponse.java
+++ b/backend/src/main/java/site/coduo/member/client/dto/GithubUserResponse.java
@@ -12,12 +12,10 @@ public record GithubUserResponse(@JsonProperty(value = "id") String userId,
 
     public Member toDomain(final Bearer accessToken, final String username) {
         return Member.builder()
-                .profileImage(avatarUrl)
-                .userId(userId)
-                .loginId(longin)
+                .providerUserId(userId)
+                .providerLoginId(longin)
                 .username(username)
-                .accessToken(accessToken.getCredential())
+                .providerAccessToken(accessToken.getCredential())
                 .build();
     }
-
 }

--- a/backend/src/main/java/site/coduo/member/client/dto/GithubUserResponse.java
+++ b/backend/src/main/java/site/coduo/member/client/dto/GithubUserResponse.java
@@ -2,7 +2,7 @@ package site.coduo.member.client.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberEntity;
 import site.coduo.member.infrastructure.http.Bearer;
 
 public record GithubUserResponse(@JsonProperty(value = "id") String userId,
@@ -10,8 +10,8 @@ public record GithubUserResponse(@JsonProperty(value = "id") String userId,
                                  @JsonProperty(value = "avatar_url") String avatarUrl
 ) {
 
-    public Member toDomain(final Bearer accessToken, final String username) {
-        return Member.builder()
+    public MemberEntity toDomain(final Bearer accessToken, final String username) {
+        return MemberEntity.builder()
                 .providerUserId(userId)
                 .providerLoginId(longin)
                 .username(username)

--- a/backend/src/main/java/site/coduo/member/controller/MemberController.java
+++ b/backend/src/main/java/site/coduo/member/controller/MemberController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import site.coduo.member.controller.docs.MemberControllerDocs;
-import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberEntity;
 import site.coduo.member.service.MemberService;
 import site.coduo.member.service.dto.member.MemberNameResponse;
 import site.coduo.member.service.dto.member.MemberReadResponse;
@@ -35,8 +35,8 @@ public class MemberController implements MemberControllerDocs {
             @RequestParam("user_id") String userId
     ) {
 
-        final Member member = memberService.checkAndFindMember(token, userId);
-        final MemberNameResponse response = new MemberNameResponse(member.getUsername());
+        final MemberEntity memberEntity = memberService.checkAndFindMember(token, userId);
+        final MemberNameResponse response = new MemberNameResponse(memberEntity.getUsername());
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/site/coduo/member/domain/Member.java
+++ b/backend/src/main/java/site/coduo/member/domain/Member.java
@@ -29,17 +29,14 @@ public class Member extends BaseTimeEntity {
     @Column(name = "ID", nullable = false)
     private Long id;
 
-    @Column(name = "ACCESS_TOKEN", nullable = false, unique = true)
-    private String accessToken;
+    @Column(name = "PROVIDER_ACCESS_TOKEN", nullable = false, unique = true)
+    private String providerAccessToken;
 
     @Column(name = "PROVIDER_LOGIN_ID", nullable = false)
-    private String loginId;
+    private String providerLoginId;
 
     @Column(name = "PROVIDER_USER_ID", nullable = false, unique = true)
-    private String userId;
-
-    @Column(name = "PROFILE_IMAGE")
-    private String profileImage;
+    private String providerUserId;
 
     @Column(name = "USER_NAME")
     private String username;
@@ -49,21 +46,22 @@ public class Member extends BaseTimeEntity {
     private LocalDateTime deletedAt;
 
     @Builder
-    private Member(final String accessToken, final String loginId, final String userId, final String profileImage,
-                   final String username, final LocalDateTime deletedAt) {
-        this.accessToken = accessToken;
-        this.loginId = loginId;
-        this.userId = userId;
-        this.profileImage = profileImage;
+    private Member(final String providerAccessToken,
+                   final String providerLoginId,
+                   final String providerUserId,
+                   final String username,
+                   final LocalDateTime deletedAt) {
+        this.providerAccessToken = providerAccessToken;
+        this.providerLoginId = providerLoginId;
+        this.providerUserId = providerUserId;
         this.username = username;
         this.deletedAt = deletedAt;
     }
 
     public void update(final Member other) {
-        this.accessToken = other.accessToken;
-        this.loginId = other.loginId;
-        this.userId = other.userId;
-        this.profileImage = other.profileImage;
+        this.providerAccessToken = other.providerAccessToken;
+        this.providerLoginId = other.providerLoginId;
+        this.providerUserId = other.providerUserId;
         this.username = other.username;
         this.deletedAt = other.deletedAt;
     }
@@ -92,13 +90,12 @@ public class Member extends BaseTimeEntity {
     @Override
     public String toString() {
         return "Member{" +
-               "id=" + id +
-               ", accessToken='" + accessToken + '\'' +
-               ", loginId='" + loginId + '\'' +
-               ", userId='" + userId + '\'' +
-               ", profileImage='" + profileImage + '\'' +
-               ", username='" + username + '\'' +
-               ", deletedAt=" + deletedAt +
-               '}';
+                "id=" + id +
+                ", providerAccessToken='" + providerAccessToken + '\'' +
+                ", providerLoginId='" + providerLoginId + '\'' +
+                ", providerUserId='" + providerUserId + '\'' +
+                ", username='" + username + '\'' +
+                ", deletedAt=" + deletedAt +
+                '}';
     }
 }

--- a/backend/src/main/java/site/coduo/member/domain/Member.java
+++ b/backend/src/main/java/site/coduo/member/domain/Member.java
@@ -1,101 +1,23 @@
 package site.coduo.member.domain;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-
-import org.springframework.format.annotation.DateTimeFormat;
-
-import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import site.coduo.common.infrastructure.audit.entity.BaseTimeEntity;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "MEMBER")
-@Entity
-public class Member extends BaseTimeEntity {
+public class Member {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "ID", nullable = false)
-    private Long id;
-
-    @Column(name = "PROVIDER_ACCESS_TOKEN", nullable = false, unique = true)
-    private String providerAccessToken;
-
-    @Column(name = "PROVIDER_LOGIN_ID", nullable = false)
-    private String providerLoginId;
-
-    @Column(name = "PROVIDER_USER_ID", nullable = false, unique = true)
-    private String providerUserId;
-
-    @Column(name = "USER_NAME")
-    private String username;
-
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-    @Column(name = "DELETED_AT")
-    private LocalDateTime deletedAt;
+    private final String accessToken;
+    private final String loginId;
+    private final String username;
+    private final LocalDateTime deletedAt;
 
     @Builder
-    private Member(final String providerAccessToken,
-                   final String providerLoginId,
-                   final String providerUserId,
-                   final String username,
+    private Member(final String accessToken, final String loginId, final String username,
                    final LocalDateTime deletedAt) {
-        this.providerAccessToken = providerAccessToken;
-        this.providerLoginId = providerLoginId;
-        this.providerUserId = providerUserId;
+        this.accessToken = accessToken;
+        this.loginId = loginId;
         this.username = username;
         this.deletedAt = deletedAt;
     }
 
-    public void update(final Member other) {
-        this.providerAccessToken = other.providerAccessToken;
-        this.providerLoginId = other.providerLoginId;
-        this.providerUserId = other.providerUserId;
-        this.username = other.username;
-        this.deletedAt = other.deletedAt;
-    }
-
-    public void delete() {
-        this.deletedAt = LocalDateTime.now();
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        final Member member = (Member) o;
-        return Objects.equals(id, member.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id);
-    }
-
-    @Override
-    public String toString() {
-        return "Member{" +
-                "id=" + id +
-                ", providerAccessToken='" + providerAccessToken + '\'' +
-                ", providerLoginId='" + providerLoginId + '\'' +
-                ", providerUserId='" + providerUserId + '\'' +
-                ", username='" + username + '\'' +
-                ", deletedAt=" + deletedAt +
-                '}';
-    }
 }

--- a/backend/src/main/java/site/coduo/member/domain/MemberUpdate.java
+++ b/backend/src/main/java/site/coduo/member/domain/MemberUpdate.java
@@ -1,21 +1,22 @@
 package site.coduo.member.domain;
 
 import lombok.AllArgsConstructor;
+import site.coduo.member.domain.repository.MemberEntity;
 
 @AllArgsConstructor
 public class MemberUpdate {
 
-    private final Member member;
+    private final MemberEntity memberEntity;
 
     public void update(final String accessToken) {
-        final Member change = Member.builder()
-                .providerLoginId(member.getProviderLoginId())
-                .username(member.getUsername())
-                .providerUserId(member.getProviderUserId())
-                .deletedAt(member.getDeletedAt())
+        final MemberEntity change = MemberEntity.builder()
+                .providerLoginId(memberEntity.getProviderLoginId())
+                .username(memberEntity.getUsername())
+                .providerUserId(memberEntity.getProviderUserId())
+                .deletedAt(memberEntity.getDeletedAt())
                 .providerAccessToken(accessToken)
                 .build();
 
-        member.update(change);
+        memberEntity.update(change);
     }
 }

--- a/backend/src/main/java/site/coduo/member/domain/MemberUpdate.java
+++ b/backend/src/main/java/site/coduo/member/domain/MemberUpdate.java
@@ -9,12 +9,11 @@ public class MemberUpdate {
 
     public void update(final String accessToken) {
         final Member change = Member.builder()
-                .profileImage(member.getProfileImage())
-                .loginId(member.getLoginId())
+                .providerLoginId(member.getProviderLoginId())
                 .username(member.getUsername())
-                .userId(member.getUserId())
+                .providerUserId(member.getProviderUserId())
                 .deletedAt(member.getDeletedAt())
-                .accessToken(accessToken)
+                .providerAccessToken(accessToken)
                 .build();
 
         member.update(change);

--- a/backend/src/main/java/site/coduo/member/domain/repository/MemberEntity.java
+++ b/backend/src/main/java/site/coduo/member/domain/repository/MemberEntity.java
@@ -1,0 +1,101 @@
+package site.coduo.member.domain.repository;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.coduo.common.infrastructure.audit.entity.BaseTimeEntity;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "MEMBER")
+@Entity
+public class MemberEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ID", nullable = false)
+    private Long id;
+
+    @Column(name = "PROVIDER_ACCESS_TOKEN", nullable = false, unique = true)
+    private String providerAccessToken;
+
+    @Column(name = "PROVIDER_LOGIN_ID", nullable = false)
+    private String providerLoginId;
+
+    @Column(name = "PROVIDER_USER_ID", nullable = false, unique = true)
+    private String providerUserId;
+
+    @Column(name = "USER_NAME")
+    private String username;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @Column(name = "DELETED_AT")
+    private LocalDateTime deletedAt;
+
+    @Builder
+    private MemberEntity(final String providerAccessToken,
+                         final String providerLoginId,
+                         final String providerUserId,
+                         final String username,
+                         final LocalDateTime deletedAt) {
+        this.providerAccessToken = providerAccessToken;
+        this.providerLoginId = providerLoginId;
+        this.providerUserId = providerUserId;
+        this.username = username;
+        this.deletedAt = deletedAt;
+    }
+
+    public void update(final MemberEntity other) {
+        this.providerAccessToken = other.providerAccessToken;
+        this.providerLoginId = other.providerLoginId;
+        this.providerUserId = other.providerUserId;
+        this.username = other.username;
+        this.deletedAt = other.deletedAt;
+    }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final MemberEntity memberEntity = (MemberEntity) o;
+        return Objects.equals(id, memberEntity.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return "Member{" +
+                "id=" + id +
+                ", providerAccessToken='" + providerAccessToken + '\'' +
+                ", providerLoginId='" + providerLoginId + '\'' +
+                ", providerUserId='" + providerUserId + '\'' +
+                ", username='" + username + '\'' +
+                ", deletedAt=" + deletedAt +
+                '}';
+    }
+}

--- a/backend/src/main/java/site/coduo/member/domain/repository/MemberRepository.java
+++ b/backend/src/main/java/site/coduo/member/domain/repository/MemberRepository.java
@@ -10,9 +10,9 @@ import site.coduo.member.exception.MemberNotFoundException;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByUserIdAndDeletedAtIsNull(String userId);
+    Optional<Member> findByProviderUserIdAndDeletedAtIsNull(String userId);
 
-    Optional<Member> findByLoginIdAndDeletedAtIsNull(String loginId);
+    Optional<Member> findByProviderLoginIdAndDeletedAtIsNull(String loginId);
 
     List<Member> findByDeletedAtIsNull();
 
@@ -23,15 +23,14 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     default Member fetchByUserId(final String userId) {
 
-        return findByUserIdAndDeletedAtIsNull(userId)
+        return findByProviderUserIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new MemberNotFoundException(String.format("%s는(은) 찾을 수 없는 회원 아이디입니다.", userId)));
     }
 
-    default Member fetchByLoginId(final String loginId) {
-
-        return findByLoginIdAndDeletedAtIsNull(loginId)
+    default Member fetchByProviderLoginId(final String loginId) {
+        return findByProviderLoginIdAndDeletedAtIsNull(loginId)
                 .orElseThrow(() -> new MemberNotFoundException(String.format("%s는(은) 찾을 수 없는 회원입니다.", loginId)));
     }
 
-    boolean existsByUserIdAndDeletedAtIsNull(String userId);
+    boolean existsByProviderUserIdAndDeletedAtIsNull(String userId);
 }

--- a/backend/src/main/java/site/coduo/member/domain/repository/MemberRepository.java
+++ b/backend/src/main/java/site/coduo/member/domain/repository/MemberRepository.java
@@ -5,29 +5,28 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import site.coduo.member.domain.Member;
 import site.coduo.member.exception.MemberNotFoundException;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
-    Optional<Member> findByProviderUserIdAndDeletedAtIsNull(String userId);
+    Optional<MemberEntity> findByProviderUserIdAndDeletedAtIsNull(String userId);
 
-    Optional<Member> findByProviderLoginIdAndDeletedAtIsNull(String loginId);
+    Optional<MemberEntity> findByProviderLoginIdAndDeletedAtIsNull(String loginId);
 
-    List<Member> findByDeletedAtIsNull();
+    List<MemberEntity> findByDeletedAtIsNull();
 
     @Override
-    default List<Member> findAll() {
+    default List<MemberEntity> findAll() {
         return findByDeletedAtIsNull();
     }
 
-    default Member fetchByUserId(final String userId) {
+    default MemberEntity fetchByUserId(final String userId) {
 
         return findByProviderUserIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new MemberNotFoundException(String.format("%s는(은) 찾을 수 없는 회원 아이디입니다.", userId)));
     }
 
-    default Member fetchByProviderLoginId(final String loginId) {
+    default MemberEntity fetchByProviderLoginId(final String loginId) {
         return findByProviderLoginIdAndDeletedAtIsNull(loginId)
                 .orElseThrow(() -> new MemberNotFoundException(String.format("%s는(은) 찾을 수 없는 회원입니다.", loginId)));
     }

--- a/backend/src/main/java/site/coduo/member/service/AuthService.java
+++ b/backend/src/main/java/site/coduo/member/service/AuthService.java
@@ -26,11 +26,11 @@ public class AuthService {
         final String accessToken = jwtProvider.extractSubject(encryptedAccessToken);
         final GithubUserResponse userResponse = githubApiClient.getUser(new GithubUserRequest(accessToken));
 
-        memberRepository.findByUserIdAndDeletedAtIsNull(userResponse.userId())
+        memberRepository.findByProviderUserIdAndDeletedAtIsNull(userResponse.userId())
                 .ifPresent(member -> new MemberUpdate(member).update(accessToken));
         final String signInToken = jwtProvider.sign(userResponse.userId());
 
-        return new SignInServiceResponse(memberRepository.existsByUserIdAndDeletedAtIsNull(userResponse.userId()), signInToken);
+        return new SignInServiceResponse(memberRepository.existsByProviderUserIdAndDeletedAtIsNull(userResponse.userId()), signInToken);
     }
 
     public boolean isSignedIn(final String signInToken) {

--- a/backend/src/main/java/site/coduo/member/service/MemberService.java
+++ b/backend/src/main/java/site/coduo/member/service/MemberService.java
@@ -47,10 +47,6 @@ public class MemberService {
         return memberRepository.fetchByUserId(userId);
     }
 
-    public Member findMember(final String loginId) {
-        return memberRepository.fetchByLoginId(loginId);
-    }
-
     @Transactional
     public void deleteMember(final String token) {
         final String userId = jwtProvider.extractSubject(token);
@@ -59,9 +55,9 @@ public class MemberService {
         member.delete();
     }
 
-    public Member checkAndFindMember(final String token, final String userId) {
+    public Member checkAndFindMember(final String token, final String loginId) {
         final Member loginedMember = findMemberByCredential(token);
-        final Member pairMember = findMember(userId);
+        final Member pairMember = memberRepository.fetchByProviderLoginId(loginId);
 
         if (loginedMember.equals(pairMember)) {
             throw new InvalidMemberAddException("자신의 아이디로 페어 정보 연동을 할 수 없습니다.");

--- a/backend/src/main/java/site/coduo/member/service/MemberService.java
+++ b/backend/src/main/java/site/coduo/member/service/MemberService.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import site.coduo.member.client.GithubApiClient;
 import site.coduo.member.client.dto.GithubUserRequest;
 import site.coduo.member.client.dto.GithubUserResponse;
-import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberEntity;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.exception.InvalidMemberAddException;
 import site.coduo.member.infrastructure.http.Bearer;
@@ -30,18 +30,18 @@ public class MemberService {
         final String accessToken = jwtProvider.extractSubject(encryptedAccessToken);
         final Bearer bearer = new Bearer(accessToken);
         final GithubUserResponse userResponse = githubClient.getUser(new GithubUserRequest(bearer));
-        final Member member = userResponse.toDomain(bearer, username);
-        memberRepository.save(member);
+        final MemberEntity memberEntity = userResponse.toDomain(bearer, username);
+        memberRepository.save(memberEntity);
     }
 
     public MemberReadResponse findMemberNameByCredential(final String token) {
         final String userId = jwtProvider.extractSubject(token);
-        final Member member = memberRepository.fetchByUserId(userId);
+        final MemberEntity memberEntity = memberRepository.fetchByUserId(userId);
 
-        return new MemberReadResponse(member.getUsername());
+        return new MemberReadResponse(memberEntity.getUsername());
     }
 
-    public Member findMemberByCredential(final String token) {
+    public MemberEntity findMemberByCredential(final String token) {
         final String userId = jwtProvider.extractSubject(token);
 
         return memberRepository.fetchByUserId(userId);
@@ -50,19 +50,19 @@ public class MemberService {
     @Transactional
     public void deleteMember(final String token) {
         final String userId = jwtProvider.extractSubject(token);
-        final Member member = memberRepository.fetchByUserId(userId);
+        final MemberEntity memberEntity = memberRepository.fetchByUserId(userId);
 
-        member.delete();
+        memberEntity.delete();
     }
 
-    public Member checkAndFindMember(final String token, final String loginId) {
-        final Member loginedMember = findMemberByCredential(token);
-        final Member pairMember = memberRepository.fetchByProviderLoginId(loginId);
+    public MemberEntity checkAndFindMember(final String token, final String loginId) {
+        final MemberEntity loginedMemberEntity = findMemberByCredential(token);
+        final MemberEntity pairMemberEntity = memberRepository.fetchByProviderLoginId(loginId);
 
-        if (loginedMember.equals(pairMember)) {
+        if (loginedMemberEntity.equals(pairMemberEntity)) {
             throw new InvalidMemberAddException("자신의 아이디로 페어 정보 연동을 할 수 없습니다.");
         }
 
-        return pairMember;
+        return pairMemberEntity;
     }
 }

--- a/backend/src/main/java/site/coduo/pairroom/repository/PairRoomMember.java
+++ b/backend/src/main/java/site/coduo/pairroom/repository/PairRoomMember.java
@@ -14,13 +14,13 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.coduo.common.infrastructure.audit.entity.BaseTimeEntity;
-import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberEntity;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "PAIR_ROOM_MEMBER")
 @Entity
-public class PairRoomMemberEntity extends BaseTimeEntity {
+public class PairRoomMember extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,15 +28,15 @@ public class PairRoomMemberEntity extends BaseTimeEntity {
 
     @ManyToOne
     @JoinColumn(name = "PAIR_ROOM_ID")
-    private PairRoomEntity pairRoom;
+    private PairRoomEntity pairRoomEntity;
 
     @ManyToOne
     @JoinColumn(name = "MEMBER_ID")
-    private Member member;
+    private MemberEntity memberEntity;
 
-    public PairRoomMemberEntity(final PairRoomEntity pairRoom, final Member member) {
-        this.pairRoom = pairRoom;
-        this.member = member;
+    public PairRoomMember(final PairRoomEntity pairRoomEntity, final MemberEntity memberEntity) {
+        this.pairRoomEntity = pairRoomEntity;
+        this.memberEntity = memberEntity;
     }
 
     @Override
@@ -44,7 +44,7 @@ public class PairRoomMemberEntity extends BaseTimeEntity {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof final PairRoomMemberEntity that)) {
+        if (!(o instanceof final PairRoomMember that)) {
             return false;
         }
         return Objects.equals(getId(), that.getId());
@@ -57,10 +57,10 @@ public class PairRoomMemberEntity extends BaseTimeEntity {
 
     @Override
     public String toString() {
-        return "PairRoomMemberEntity{" +
+        return "PairRoomMember{" +
                 "id=" + id +
-                ", pairRoom=" + pairRoom +
-                ", member=" + member +
+                ", pairRoomEntity=" + pairRoomEntity +
+                ", memberEntity=" + memberEntity +
                 '}';
     }
 }

--- a/backend/src/main/java/site/coduo/pairroom/repository/PairRoomMemberRepository.java
+++ b/backend/src/main/java/site/coduo/pairroom/repository/PairRoomMemberRepository.java
@@ -5,20 +5,20 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberEntity;
 import site.coduo.pairroom.exception.PairRoomMemberNotFoundException;
 
-public interface PairRoomMemberRepository extends JpaRepository<PairRoomMemberEntity, Long> {
+public interface PairRoomMemberRepository extends JpaRepository<PairRoomMember, Long> {
 
-    List<PairRoomMemberEntity> findByMember(Member member);
+    List<PairRoomMember> findByMemberEntity(MemberEntity memberEntity);
 
-    Optional<PairRoomMemberEntity> findByPairRoomAndMember(PairRoomEntity pairRoom, Member member);
+    Optional<PairRoomMember> findByPairRoomEntityAndMemberEntity(PairRoomEntity pairRoom, MemberEntity memberEntity);
 
-    default PairRoomMemberEntity fetchByPairRoomAndMember(PairRoomEntity pairRoom, Member member) {
-        return findByPairRoomAndMember(pairRoom, member)
+    default PairRoomMember fetchByPairRoomAndMember(PairRoomEntity pairRoom, MemberEntity memberEntity) {
+        return findByPairRoomEntityAndMemberEntity(pairRoom, memberEntity)
                 .orElseThrow(() -> new PairRoomMemberNotFoundException(String.format("멤버로 생성된 페어룸이 존재하지 않습니다. %s",
-                        member.getId())));
+                        memberEntity.getId())));
     }
 
-    boolean existsByPairRoomAndMember(PairRoomEntity pairRoom, Member member);
+    boolean existsByPairRoomEntityAndMemberEntity(PairRoomEntity pairRoom, MemberEntity memberEntity);
 }

--- a/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.service.MemberService;
 import site.coduo.pairroom.domain.MissionUrl;
 import site.coduo.pairroom.domain.Pair;
@@ -42,6 +43,7 @@ public class PairRoomService {
     private final TimerRepository timerRepository;
     private final PairRoomMemberRepository pairRoomMemberRepository;
     private final MemberService memberService;
+    private final MemberRepository memberRepository;
     private final UUIDAccessCodeGenerator uuidAccessCodeGenerator;
 
     @Transactional
@@ -57,7 +59,7 @@ public class PairRoomService {
             pairRoomMemberRepository.save(new PairRoomMemberEntity(pairRoomEntity, member));
         }
         if (isRegisteredMember(request.pairId())) {
-            final Member member = memberService.findMember(request.pairId());
+            final Member member = memberRepository.fetchByProviderLoginId(request.pairId());
             pairRoomMemberRepository.save(new PairRoomMemberEntity(pairRoomEntity, member));
         }
         return pairRoom.getAccessCodeText();

--- a/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
@@ -9,7 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberEntity;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.service.MemberService;
 import site.coduo.pairroom.domain.MissionUrl;
@@ -23,7 +23,7 @@ import site.coduo.pairroom.domain.accesscode.generator.EasyAccessCodeGenerator;
 import site.coduo.pairroom.domain.accesscode.generator.UUIDAccessCodeGenerator;
 import site.coduo.pairroom.exception.DeletePairRoomException;
 import site.coduo.pairroom.repository.PairRoomEntity;
-import site.coduo.pairroom.repository.PairRoomMemberEntity;
+import site.coduo.pairroom.repository.PairRoomMember;
 import site.coduo.pairroom.repository.PairRoomMemberRepository;
 import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.pairroom.service.dto.PairRoomCreateRequest;
@@ -55,12 +55,12 @@ public class PairRoomService {
         timerRepository.save(new TimerEntity(timer, pairRoomEntity));
 
         if (isRegisteredMember(loginToken)) {
-            final Member member = memberService.findMemberByCredential(loginToken);
-            pairRoomMemberRepository.save(new PairRoomMemberEntity(pairRoomEntity, member));
+            final MemberEntity memberEntity = memberService.findMemberByCredential(loginToken);
+            pairRoomMemberRepository.save(new PairRoomMember(pairRoomEntity, memberEntity));
         }
         if (isRegisteredMember(request.pairId())) {
-            final Member member = memberRepository.fetchByProviderLoginId(request.pairId());
-            pairRoomMemberRepository.save(new PairRoomMemberEntity(pairRoomEntity, member));
+            final MemberEntity memberEntity = memberRepository.fetchByProviderLoginId(request.pairId());
+            pairRoomMemberRepository.save(new PairRoomMember(pairRoomEntity, memberEntity));
         }
         return pairRoom.getAccessCodeText();
     }
@@ -129,11 +129,11 @@ public class PairRoomService {
     }
 
     public List<PairRoomMemberResponse> findPairRooms(final String token) {
-        final Member member = memberService.findMemberByCredential(token);
+        final MemberEntity memberEntity = memberService.findMemberByCredential(token);
 
-        final List<PairRoomMemberEntity> pairRooms = pairRoomMemberRepository.findByMember(member);
+        final List<PairRoomMember> pairRooms = pairRoomMemberRepository.findByMemberEntity(memberEntity);
         final List<PairRoomEntity> pairRoomEntities = pairRooms.stream()
-                .map(PairRoomMemberEntity::getPairRoom)
+                .map(PairRoomMember::getPairRoomEntity)
                 .filter(pairRoomEntity -> !pairRoomEntity.isDelete())
                 .toList();
 
@@ -151,7 +151,7 @@ public class PairRoomService {
 
     public boolean existMemberInPairRoom(final String credentialToken, final String pairRoomAccessCode) {
         final PairRoomEntity pairRoom = pairRoomRepository.fetchByAccessCode(pairRoomAccessCode);
-        final Member member = memberService.findMemberByCredential(credentialToken);
-        return pairRoomMemberRepository.existsByPairRoomAndMember(pairRoom, member);
+        final MemberEntity memberEntity = memberService.findMemberByCredential(credentialToken);
+        return pairRoomMemberRepository.existsByPairRoomEntityAndMemberEntity(pairRoom, memberEntity);
     }
 }

--- a/backend/src/main/java/site/coduo/referencelink/controller/ReferenceLinkController.java
+++ b/backend/src/main/java/site/coduo/referencelink/controller/ReferenceLinkController.java
@@ -33,8 +33,7 @@ public class ReferenceLinkController implements ReferenceLinkDocs {
             @PathVariable("accessCode") final String accessCodeText,
             @Valid @RequestBody final ReferenceLinkCreateRequest request
     ) {
-        final ReferenceLinkResponse response = referenceLinkService.createReferenceLink(
-                accessCodeText, request);
+        final ReferenceLinkResponse response = referenceLinkService.createReferenceLink(accessCodeText, request);
 
         return ResponseEntity.created(URI.create("/"))
                 .body(response);

--- a/backend/src/main/java/site/coduo/referencelink/service/HtmlParser.java
+++ b/backend/src/main/java/site/coduo/referencelink/service/HtmlParser.java
@@ -1,0 +1,10 @@
+package site.coduo.referencelink.service;
+
+import java.net.URL;
+
+import site.coduo.referencelink.domain.OpenGraph;
+
+public interface HtmlParser {
+
+    OpenGraph getOpenGraph(final URL url);
+}

--- a/backend/src/main/java/site/coduo/referencelink/service/JsoupHtmlParser.java
+++ b/backend/src/main/java/site/coduo/referencelink/service/JsoupHtmlParser.java
@@ -1,0 +1,36 @@
+package site.coduo.referencelink.service;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Component;
+
+import site.coduo.referencelink.domain.OpenGraph;
+
+@Component
+public class JsoupHtmlParser implements HtmlParser {
+
+    @Override
+    public OpenGraph getOpenGraph(final URL url) {
+        final Connection connect = Jsoup.connect(url.toExternalForm());
+        final Document document;
+        try {
+            document = connect.get();
+            if (hasNotTitle(document)) {
+                return OpenGraph.of(document, url);
+            }
+            return OpenGraph.from(document);
+        } catch (IOException e) {
+            return OpenGraph.from(url);
+        }
+    }
+
+    private boolean hasNotTitle(final Document document) {
+        final Element element = document.selectFirst(String.format(OpenGraph.OPEN_GRAPH_META_TAG_SELECTOR, "title"));
+        return document.title().isEmpty() && element == null;
+    }
+}

--- a/backend/src/main/java/site/coduo/referencelink/service/OpenGraphService.java
+++ b/backend/src/main/java/site/coduo/referencelink/service/OpenGraphService.java
@@ -1,18 +1,13 @@
 package site.coduo.referencelink.service;
 
-import java.io.IOException;
 import java.net.URL;
 import java.util.Optional;
 
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import site.coduo.referencelink.domain.OpenGraph;
-import site.coduo.referencelink.exception.DocumentAccessException;
 import site.coduo.referencelink.repository.OpenGraphEntity;
 import site.coduo.referencelink.repository.OpenGraphRepository;
 import site.coduo.referencelink.repository.ReferenceLinkEntity;
@@ -23,41 +18,13 @@ import site.coduo.referencelink.repository.ReferenceLinkEntity;
 public class OpenGraphService {
 
     private final OpenGraphRepository openGraphRepository;
+    private final HtmlParser htmlParser;
 
     public OpenGraph createOpenGraph(final ReferenceLinkEntity referenceLinkEntity, final URL url) {
-        final OpenGraph openGraph = getOpenGraph(url);
+        final OpenGraph openGraph = htmlParser.getOpenGraph(url);
         final OpenGraphEntity openGraphEntity = new OpenGraphEntity(openGraph, referenceLinkEntity);
         return openGraphRepository.save(openGraphEntity)
                 .toDomain();
-    }
-
-    private OpenGraph getOpenGraph(final URL url) {
-        try {
-            final Document document = getDocumentFromUrl(url);
-            return getOpenGraphFromDocument(document, url);
-        } catch (final DocumentAccessException e) {
-            return OpenGraph.from(url);
-        }
-    }
-
-    private Document getDocumentFromUrl(final URL url) {
-        try {
-            return Jsoup.connect(url.toExternalForm()).get();
-        } catch (final IOException e) {
-            throw new DocumentAccessException("URL에 대한 Document를 불러올 수 없습니다.");
-        }
-    }
-
-    private OpenGraph getOpenGraphFromDocument(final Document document, final URL url) {
-        if (hasNoTitle(document)) {
-            return OpenGraph.of(document, url);
-        }
-        return OpenGraph.from(document);
-    }
-
-    private boolean hasNoTitle(final Document document) {
-        final Element element = document.selectFirst(String.format(OpenGraph.OPEN_GRAPH_META_TAG_SELECTOR, "title"));
-        return document.title().isEmpty() && element == null;
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/site/coduo/retrospect/repository/RetrospectEntity.java
+++ b/backend/src/main/java/site/coduo/retrospect/repository/RetrospectEntity.java
@@ -16,7 +16,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.coduo.common.infrastructure.audit.entity.BaseTimeEntity;
-import site.coduo.pairroom.repository.PairRoomMemberEntity;
+import site.coduo.pairroom.repository.PairRoomMember;
 import site.coduo.retrospect.domain.RetrospectAnswer;
 import site.coduo.retrospect.domain.RetrospectContent;
 import site.coduo.retrospect.domain.RetrospectQuestionType;
@@ -33,7 +33,7 @@ public class RetrospectEntity extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "PAIR_ROOM_MEMBER_ID")
-    private PairRoomMemberEntity pairRoomMember;
+    private PairRoomMember pairRoomMember;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "QUESTION_TYPE", nullable = false)
@@ -42,7 +42,7 @@ public class RetrospectEntity extends BaseTimeEntity {
     @Column(name = "CONTENT", length = 1000)
     private String content;
 
-    public RetrospectEntity(final PairRoomMemberEntity pairRoomMember,
+    public RetrospectEntity(final PairRoomMember pairRoomMember,
                             final RetrospectQuestionType questionType,
                             final String content) {
         this.pairRoomMember = pairRoomMember;

--- a/backend/src/main/java/site/coduo/retrospect/repository/RetrospectRepository.java
+++ b/backend/src/main/java/site/coduo/retrospect/repository/RetrospectRepository.java
@@ -4,14 +4,13 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import site.coduo.pairroom.repository.PairRoomEntity;
-import site.coduo.pairroom.repository.PairRoomMemberEntity;
+import site.coduo.pairroom.repository.PairRoomMember;
 
 public interface RetrospectRepository extends JpaRepository<RetrospectEntity, Long> {
 
-    List<RetrospectEntity> findAllByPairRoomMember(PairRoomMemberEntity pairRoomMember);
+    List<RetrospectEntity> findAllByPairRoomMember(PairRoomMember pairRoomMember);
 
-    void deleteAllByPairRoomMember(PairRoomMemberEntity pairRoomMember);
+    void deleteAllByPairRoomMember(PairRoomMember pairRoomMember);
 
-    boolean existsRetrospectEntityByPairRoomMember(PairRoomMemberEntity pairRoomMember);
+    boolean existsRetrospectEntityByPairRoomMember(PairRoomMember pairRoomMember);
 }

--- a/backend/src/main/java/site/coduo/retrospect/service/RetrospectService.java
+++ b/backend/src/main/java/site/coduo/retrospect/service/RetrospectService.java
@@ -7,10 +7,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberEntity;
 import site.coduo.member.service.MemberService;
 import site.coduo.pairroom.repository.PairRoomEntity;
-import site.coduo.pairroom.repository.PairRoomMemberEntity;
+import site.coduo.pairroom.repository.PairRoomMember;
 import site.coduo.pairroom.repository.PairRoomMemberRepository;
 import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.retrospect.controller.response.FindRetrospectResponse;
@@ -41,8 +41,9 @@ public class RetrospectService {
             final List<String> answers
     ) {
         final PairRoomEntity pairRoom = pairRoomRepository.fetchByAccessCode(pairRoomAccessCode);
-        final Member member = memberService.findMemberByCredential(credentialToken);
-        final PairRoomMemberEntity pairRoomMember = pairRoomMemberRepository.fetchByPairRoomAndMember(pairRoom, member);
+        final MemberEntity memberEntity = memberService.findMemberByCredential(credentialToken);
+        final PairRoomMember pairRoomMember = pairRoomMemberRepository.fetchByPairRoomAndMember(pairRoom,
+                memberEntity);
         if (retrospectRepository.existsRetrospectEntityByPairRoomMember(pairRoomMember)) {
             throw new DuplicateRetrospectException("해당 페어룸에 대한 사용자의 회고가 이미 존재합니다.");
         }
@@ -57,8 +58,8 @@ public class RetrospectService {
     }
 
     public FindRetrospectsResponse findAllRetrospectsByMember(final String credentialToken) {
-        final Member member = memberService.findMemberByCredential(credentialToken);
-        final List<PairRoomMemberEntity> byMember = pairRoomMemberRepository.findByMember(member);
+        final MemberEntity memberEntity = memberService.findMemberByCredential(credentialToken);
+        final List<PairRoomMember> byMember = pairRoomMemberRepository.findByMemberEntity(memberEntity);
 
         final List<FindRetrospectResponse> findRetrospects = byMember.stream()
                 .filter(this::existsAnyRetrospect)
@@ -68,7 +69,7 @@ public class RetrospectService {
         return new FindRetrospectsResponse(findRetrospects);
     }
 
-    private FindRetrospectResponse convertRetrospect(final PairRoomMemberEntity pairRoomMember) {
+    private FindRetrospectResponse convertRetrospect(final PairRoomMember pairRoomMember) {
         final List<RetrospectContent> retrospectContents = retrospectRepository
                 .findAllByPairRoomMember(pairRoomMember)
                 .stream()
@@ -76,15 +77,15 @@ public class RetrospectService {
                 .toList();
 
         final Retrospect retrospect = new Retrospect(new RetrospectContents(retrospectContents));
-        return new FindRetrospectResponse(pairRoomMember.getPairRoom().getAccessCode(),
+        return new FindRetrospectResponse(pairRoomMember.getPairRoomEntity().getAccessCode(),
                 retrospect.getContents().getFirst().getAnswer().getValue());
     }
 
     public Retrospect findRetrospectByAccessCode(final String credentialToken, final String accessCode) {
-        final Member member = memberService.findMemberByCredential(credentialToken);
+        final MemberEntity memberEntity = memberService.findMemberByCredential(credentialToken);
         final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCode);
-        final PairRoomMemberEntity pairRoomMember = pairRoomMemberRepository.fetchByPairRoomAndMember(
-                pairRoomEntity, member);
+        final PairRoomMember pairRoomMember = pairRoomMemberRepository.fetchByPairRoomAndMember(
+                pairRoomEntity, memberEntity);
 
         final List<RetrospectEntity> allByPairRoomMember = retrospectRepository.findAllByPairRoomMember(
                 pairRoomMember);
@@ -98,32 +99,33 @@ public class RetrospectService {
 
     @Transactional
     public void deleteRetrospect(final String credentialToken, final String accessCode) {
-        final Member member = memberService.findMemberByCredential(credentialToken);
+        final MemberEntity memberEntity = memberService.findMemberByCredential(credentialToken);
         final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCode);
-        final PairRoomMemberEntity pairRoomMember = pairRoomMemberRepository
-                .fetchByPairRoomAndMember(pairRoomEntity, member);
-        checkRetrospectOwner(pairRoomMember, member);
+        final PairRoomMember pairRoomMember = pairRoomMemberRepository
+                .fetchByPairRoomAndMember(pairRoomEntity, memberEntity);
+        checkRetrospectOwner(pairRoomMember, memberEntity);
         retrospectRepository.deleteAllByPairRoomMember(pairRoomMember);
     }
 
-    private void checkRetrospectOwner(final PairRoomMemberEntity pairRoomMember, final Member member) {
-        if (pairRoomMember.getMember().equals(member)) {
+    private void checkRetrospectOwner(final PairRoomMember pairRoomMember, final MemberEntity memberEntity) {
+        if (pairRoomMember.getMemberEntity().equals(memberEntity)) {
             return;
         }
         throw new NotRetrospectOwnerAccessException("본인 소유가 아닌 회고는 삭제할 수 없습니다.");
     }
 
     public boolean existRetrospectWithPairRoom(final String credentialToken, final String pairRoomAccessCode) {
-        final Member member = memberService.findMemberByCredential(credentialToken);
+        final MemberEntity memberEntity = memberService.findMemberByCredential(credentialToken);
         final PairRoomEntity pairRoom = pairRoomRepository.fetchByAccessCode(pairRoomAccessCode);
-        if (!pairRoomMemberRepository.existsByPairRoomAndMember(pairRoom, member)) {
+        if (!pairRoomMemberRepository.existsByPairRoomEntityAndMemberEntity(pairRoom, memberEntity)) {
             return false;
         }
-        final PairRoomMemberEntity pairRoomMember = pairRoomMemberRepository.fetchByPairRoomAndMember(pairRoom, member);
+        final PairRoomMember pairRoomMember = pairRoomMemberRepository.fetchByPairRoomAndMember(pairRoom,
+                memberEntity);
         return existsAnyRetrospect(pairRoomMember);
     }
 
-    private boolean existsAnyRetrospect(final PairRoomMemberEntity pairRoomMember) {
+    private boolean existsAnyRetrospect(final PairRoomMember pairRoomMember) {
         final List<RetrospectEntity> retrospects = retrospectRepository.findAllByPairRoomMember(pairRoomMember);
 
         return retrospects.stream()

--- a/backend/src/test/java/site/coduo/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/AuthAcceptanceTest.java
@@ -17,7 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import site.coduo.fake.FakeGithubOAuthClient;
-import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberEntity;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
 import site.coduo.fixture.MemberDummy;
@@ -34,9 +34,9 @@ class AuthAcceptanceTest extends AcceptanceFixture {
     @DisplayName("로그인 검증 & 로그인 토큰을 발급한다.")
     void verify_login_and_publish_login_token() {
         final String cookie = GithubAcceptanceTest.createAccessTokenCookie();
-        final Member member = MemberDummy.createDummy("test user", ACCESS_TOKEN.getCredential(), USER_ID, LOGIN_ID);
+        final MemberEntity memberEntity = MemberDummy.createDummy("test user", ACCESS_TOKEN.getCredential(), USER_ID, LOGIN_ID);
 
-        memberRepository.save(member);
+        memberRepository.save(memberEntity);
 
         // when
         RestAssured

--- a/backend/src/test/java/site/coduo/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/AuthAcceptanceTest.java
@@ -3,6 +3,9 @@ package site.coduo.acceptance;
 import static org.hamcrest.Matchers.is;
 
 import static site.coduo.common.config.web.filter.AccessTokenCookieFilter.TEMPORARY_ACCESS_TOKEN_COOKIE_NAME;
+import static site.coduo.fake.FakeGithubApiClient.LOGIN_ID;
+import static site.coduo.fake.FakeGithubApiClient.USER_ID;
+import static site.coduo.fake.FakeGithubOAuthClient.ACCESS_TOKEN;
 
 import java.util.Map;
 
@@ -18,6 +21,7 @@ import site.coduo.fake.FakeGithubOAuthClient;
 import site.coduo.member.domain.Member;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
+import site.coduo.member.support.MemberDummy;
 
 class AuthAcceptanceTest extends AcceptanceFixture {
 
@@ -31,7 +35,7 @@ class AuthAcceptanceTest extends AcceptanceFixture {
     @DisplayName("로그인 검증 & 로그인 토큰을 발급한다.")
     void verify_login_and_publish_login_token() {
         final String cookie = GithubAcceptanceTest.createAccessTokenCookie();
-        final Member member = createMember();
+        final Member member = MemberDummy.createDummy("test user", ACCESS_TOKEN.getCredential(), USER_ID, LOGIN_ID);
 
         memberRepository.save(member);
 
@@ -139,15 +143,4 @@ class AuthAcceptanceTest extends AcceptanceFixture {
                 .then().log().all()
                 .statusCode(HttpStatus.SC_UNAUTHORIZED);
     }
-
-    private Member createMember() {
-        return Member.builder()
-                .username("test user")
-                .userId(FakeGithubApiClient.USER_ID)
-                .loginId(FakeGithubApiClient.LOGIN_ID)
-                .accessToken(FakeGithubOAuthClient.ACCESS_TOKEN.getCredential())
-                .profileImage(FakeGithubApiClient.PROFILE_IMAGE)
-                .build();
-    }
-
 }

--- a/backend/src/test/java/site/coduo/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/AuthAcceptanceTest.java
@@ -16,12 +16,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import site.coduo.fake.FakeGithubApiClient;
 import site.coduo.fake.FakeGithubOAuthClient;
 import site.coduo.member.domain.Member;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
-import site.coduo.member.support.MemberDummy;
+import site.coduo.fixture.MemberDummy;
 
 class AuthAcceptanceTest extends AcceptanceFixture {
 

--- a/backend/src/test/java/site/coduo/acceptance/GithubAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/GithubAcceptanceTest.java
@@ -17,7 +17,7 @@ import org.springframework.http.HttpHeaders;
 
 import io.restassured.RestAssured;
 import site.coduo.fake.FixedNonceProvider;
-import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberEntity;
 import site.coduo.fixture.MemberDummy;
 
 class GithubAcceptanceTest extends AcceptanceFixture {
@@ -100,12 +100,12 @@ class GithubAcceptanceTest extends AcceptanceFixture {
     @DisplayName("callback 엔드 포인트가 호출되면 리디렉션을 통해 로그인이 시도된다.")
     void try_login_when_call_callback_end_point() {
         // given
-        final Member member = MemberDummy.createDummy("test user", ACCESS_TOKEN.getCredential(), USER_ID, LOGIN_ID);
+        final MemberEntity memberEntity = MemberDummy.createDummy("test user", ACCESS_TOKEN.getCredential(), USER_ID, LOGIN_ID);
 
         final Map<String, String> query = Map.of("code", "authorization code",
                 "state", FixedNonceProvider.FIXED_VALUE);
 
-        memberRepository.save(member);
+        memberRepository.save(memberEntity);
 
         // when & then
         RestAssured

--- a/backend/src/test/java/site/coduo/acceptance/GithubAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/GithubAcceptanceTest.java
@@ -16,11 +16,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 
 import io.restassured.RestAssured;
-import site.coduo.fake.FakeGithubApiClient;
-import site.coduo.fake.FakeGithubOAuthClient;
 import site.coduo.fake.FixedNonceProvider;
 import site.coduo.member.domain.Member;
-import site.coduo.member.support.MemberDummy;
+import site.coduo.fixture.MemberDummy;
 
 class GithubAcceptanceTest extends AcceptanceFixture {
 

--- a/backend/src/test/java/site/coduo/acceptance/GithubAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/GithubAcceptanceTest.java
@@ -4,6 +4,9 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 import static site.coduo.common.config.web.filter.AccessTokenCookieFilter.TEMPORARY_ACCESS_TOKEN_COOKIE_NAME;
+import static site.coduo.fake.FakeGithubApiClient.LOGIN_ID;
+import static site.coduo.fake.FakeGithubApiClient.USER_ID;
+import static site.coduo.fake.FakeGithubOAuthClient.ACCESS_TOKEN;
 
 import java.util.Map;
 
@@ -17,6 +20,7 @@ import site.coduo.fake.FakeGithubApiClient;
 import site.coduo.fake.FakeGithubOAuthClient;
 import site.coduo.fake.FixedNonceProvider;
 import site.coduo.member.domain.Member;
+import site.coduo.member.support.MemberDummy;
 
 class GithubAcceptanceTest extends AcceptanceFixture {
 
@@ -98,13 +102,8 @@ class GithubAcceptanceTest extends AcceptanceFixture {
     @DisplayName("callback 엔드 포인트가 호출되면 리디렉션을 통해 로그인이 시도된다.")
     void try_login_when_call_callback_end_point() {
         // given
-        final Member member = Member.builder()
-                .username("test user")
-                .userId(FakeGithubApiClient.USER_ID)
-                .loginId(FakeGithubApiClient.LOGIN_ID)
-                .accessToken(FakeGithubOAuthClient.ACCESS_TOKEN.getCredential())
-                .profileImage(FakeGithubApiClient.PROFILE_IMAGE)
-                .build();
+        final Member member = MemberDummy.createDummy("test user", ACCESS_TOKEN.getCredential(), USER_ID, LOGIN_ID);
+
         final Map<String, String> query = Map.of("code", "authorization code",
                 "state", FixedNonceProvider.FIXED_VALUE);
 

--- a/backend/src/test/java/site/coduo/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/MemberAcceptanceTest.java
@@ -13,7 +13,7 @@ import io.restassured.RestAssured;
 import site.coduo.member.domain.Member;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
-import site.coduo.member.support.MemberDummy;
+import site.coduo.fixture.MemberDummy;
 
 class MemberAcceptanceTest extends AcceptanceFixture {
 

--- a/backend/src/test/java/site/coduo/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/MemberAcceptanceTest.java
@@ -13,6 +13,7 @@ import io.restassured.RestAssured;
 import site.coduo.member.domain.Member;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
+import site.coduo.member.support.MemberDummy;
 
 class MemberAcceptanceTest extends AcceptanceFixture {
 
@@ -26,15 +27,9 @@ class MemberAcceptanceTest extends AcceptanceFixture {
     @DisplayName("회원의 정보를 조회한다.")
     void search_member_info() {
         // given
-        final Member member = Member.builder()
-                .userId("123")
-                .accessToken("access")
-                .loginId("login")
-                .username("username")
-                .profileImage("some image")
-                .build();
+        final Member member = MemberDummy.createDummy();
 
-        final String loginToken = jwtProvider.sign(member.getUserId());
+        final String loginToken = jwtProvider.sign(member.getProviderUserId());
         memberRepository.save(member);
 
         // when & then
@@ -54,15 +49,9 @@ class MemberAcceptanceTest extends AcceptanceFixture {
     @DisplayName("회원을 삭제한다.")
     void delete_member() {
         //given
-        final Member member = Member.builder()
-                .userId("123")
-                .accessToken("access")
-                .loginId("login")
-                .username("username")
-                .profileImage("some image")
-                .build();
+        final Member member = MemberDummy.createDummy();
 
-        final String loginToken = jwtProvider.sign(member.getUserId());
+        final String loginToken = jwtProvider.sign(member.getProviderUserId());
         memberRepository.save(member);
 
         //when && then
@@ -81,15 +70,8 @@ class MemberAcceptanceTest extends AcceptanceFixture {
     @DisplayName("존재하지 않는 회원을 삭제한다.")
     void delete_not_member() {
         //given
-        final Member member = Member.builder()
-                .userId("123")
-                .accessToken("access")
-                .loginId("login")
-                .username("username")
-                .profileImage("some image")
-                .build();
-
-        final String loginToken = jwtProvider.sign(member.getUserId());
+        final Member member = MemberDummy.createDummy();
+        final String loginToken = jwtProvider.sign(member.getProviderUserId());
         memberRepository.save(member);
 
         //when && then

--- a/backend/src/test/java/site/coduo/acceptance/MemberEntityAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/MemberEntityAcceptanceTest.java
@@ -10,12 +10,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import io.restassured.RestAssured;
-import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberEntity;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
 import site.coduo.fixture.MemberDummy;
 
-class MemberAcceptanceTest extends AcceptanceFixture {
+class MemberEntityAcceptanceTest extends AcceptanceFixture {
 
     @Autowired
     private JwtProvider jwtProvider;
@@ -27,10 +27,10 @@ class MemberAcceptanceTest extends AcceptanceFixture {
     @DisplayName("회원의 정보를 조회한다.")
     void search_member_info() {
         // given
-        final Member member = MemberDummy.createDummy();
+        final MemberEntity memberEntity = MemberDummy.createDummy();
 
-        final String loginToken = jwtProvider.sign(member.getProviderUserId());
-        memberRepository.save(member);
+        final String loginToken = jwtProvider.sign(memberEntity.getProviderUserId());
+        memberRepository.save(memberEntity);
 
         // when & then
         RestAssured
@@ -42,17 +42,17 @@ class MemberAcceptanceTest extends AcceptanceFixture {
 
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body("username", is(member.getUsername()));
+                .body("username", is(memberEntity.getUsername()));
     }
 
     @Test
     @DisplayName("회원을 삭제한다.")
     void delete_member() {
         //given
-        final Member member = MemberDummy.createDummy();
+        final MemberEntity memberEntity = MemberDummy.createDummy();
 
-        final String loginToken = jwtProvider.sign(member.getProviderUserId());
-        memberRepository.save(member);
+        final String loginToken = jwtProvider.sign(memberEntity.getProviderUserId());
+        memberRepository.save(memberEntity);
 
         //when && then
         RestAssured
@@ -70,9 +70,9 @@ class MemberAcceptanceTest extends AcceptanceFixture {
     @DisplayName("존재하지 않는 회원을 삭제한다.")
     void delete_not_member() {
         //given
-        final Member member = MemberDummy.createDummy();
-        final String loginToken = jwtProvider.sign(member.getProviderUserId());
-        memberRepository.save(member);
+        final MemberEntity memberEntity = MemberDummy.createDummy();
+        final String loginToken = jwtProvider.sign(memberEntity.getProviderUserId());
+        memberRepository.save(memberEntity);
 
         //when && then
         RestAssured

--- a/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
@@ -22,7 +22,7 @@ import io.restassured.response.Response;
 import site.coduo.fixture.PairRoomCreateRequestFixture;
 import site.coduo.member.domain.Member;
 import site.coduo.member.infrastructure.security.JwtProvider;
-import site.coduo.member.support.MemberDummy;
+import site.coduo.fixture.MemberDummy;
 import site.coduo.pairroom.domain.MissionUrl;
 import site.coduo.pairroom.domain.Pair;
 import site.coduo.pairroom.domain.PairName;

--- a/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
@@ -19,10 +19,10 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import site.coduo.fixture.PairRoomCreateRequestFixture;
-import site.coduo.member.domain.Member;
-import site.coduo.member.infrastructure.security.JwtProvider;
 import site.coduo.fixture.MemberDummy;
+import site.coduo.fixture.PairRoomCreateRequestFixture;
+import site.coduo.member.domain.repository.MemberEntity;
+import site.coduo.member.infrastructure.security.JwtProvider;
 import site.coduo.pairroom.domain.MissionUrl;
 import site.coduo.pairroom.domain.Pair;
 import site.coduo.pairroom.domain.PairName;
@@ -30,7 +30,7 @@ import site.coduo.pairroom.domain.PairRoom;
 import site.coduo.pairroom.domain.PairRoomStatus;
 import site.coduo.pairroom.domain.accesscode.AccessCode;
 import site.coduo.pairroom.repository.PairRoomEntity;
-import site.coduo.pairroom.repository.PairRoomMemberEntity;
+import site.coduo.pairroom.repository.PairRoomMember;
 import site.coduo.pairroom.repository.PairRoomMemberRepository;
 import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.pairroom.service.dto.PairRoomCreateRequest;
@@ -204,13 +204,15 @@ class PairRoomAcceptanceTest extends AcceptanceFixture {
     @DisplayName("깃허브 id로 추가된 사용자가 자신의 페어룸 목록에서 페어룸을 확인할 수 있다.")
     void add_pair_and_find_my_pair_room() {
         //given
-        final Member pairRoomCreator = MemberDummy.createDummy("redddy", jwtProvider.sign("idA"), "idA", "loginAA");
+        final MemberEntity pairRoomCreator = MemberDummy.createDummy("redddy", jwtProvider.sign("idA"), "idA",
+                "loginAA");
 
-        final Member addPair = MemberDummy.createDummy("hash", jwtProvider.sign("idB"), "idB", "loginBB") ;
+        final MemberEntity addPair = MemberDummy.createDummy("hash", jwtProvider.sign("idB"), "idB", "loginBB");
         memberRepository.save(pairRoomCreator);
         memberRepository.save(addPair);
 
-        final PairRoomCreateRequest request = new PairRoomCreateRequest("navi", "dri", addPair.getProviderLoginId(), 60000L,
+        final PairRoomCreateRequest request = new PairRoomCreateRequest("navi", "dri", addPair.getProviderLoginId(),
+                60000L,
                 60000L, "");
 
         RestAssured
@@ -245,7 +247,7 @@ class PairRoomAcceptanceTest extends AcceptanceFixture {
     @Test
     void existMemberInPairRoom() {
         // Given
-        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
+        final MemberEntity savedMemberEntity = memberRepository.save(MemberDummy.createDummy());
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -253,10 +255,10 @@ class PairRoomAcceptanceTest extends AcceptanceFixture {
                         new AccessCode("ac"),
                         EASY_ACCESS_CODE_INK_REDDY)
         ));
-        pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember));
+        pairRoomMemberRepository.save(new PairRoomMember(savedPairRoom, savedMemberEntity));
 
         // When
-        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
+        final String credentialToken = jwtProvider.sign(savedMemberEntity.getProviderUserId());
         final ExtractableResponse<Response> response = RestAssured
                 .given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/PairRoomAcceptanceTest.java
@@ -22,6 +22,7 @@ import io.restassured.response.Response;
 import site.coduo.fixture.PairRoomCreateRequestFixture;
 import site.coduo.member.domain.Member;
 import site.coduo.member.infrastructure.security.JwtProvider;
+import site.coduo.member.support.MemberDummy;
 import site.coduo.pairroom.domain.MissionUrl;
 import site.coduo.pairroom.domain.Pair;
 import site.coduo.pairroom.domain.PairName;
@@ -203,31 +204,18 @@ class PairRoomAcceptanceTest extends AcceptanceFixture {
     @DisplayName("깃허브 id로 추가된 사용자가 자신의 페어룸 목록에서 페어룸을 확인할 수 있다.")
     void add_pair_and_find_my_pair_room() {
         //given
-        final Member pairRoomCreator = Member.builder()
-                .userId("idA")
-                .accessToken(jwtProvider.sign("idA"))
-                .loginId("loginAA")
-                .username("redddy")
-                .profileImage("some image")
-                .build();
+        final Member pairRoomCreator = MemberDummy.createDummy("redddy", jwtProvider.sign("idA"), "idA", "loginAA");
 
-        final Member addPair = Member.builder()
-                .userId("idB")
-                .accessToken(jwtProvider.sign("idB"))
-                .loginId("loginBB")
-                .username("hash")
-                .profileImage("some image")
-                .build();
-
+        final Member addPair = MemberDummy.createDummy("hash", jwtProvider.sign("idB"), "idB", "loginBB") ;
         memberRepository.save(pairRoomCreator);
         memberRepository.save(addPair);
 
-        final PairRoomCreateRequest request = new PairRoomCreateRequest("navi", "dri", addPair.getLoginId(), 60000L,
+        final PairRoomCreateRequest request = new PairRoomCreateRequest("navi", "dri", addPair.getProviderLoginId(), 60000L,
                 60000L, "");
 
         RestAssured
                 .given()
-                .cookie(SIGN_IN_COOKIE_NAME, pairRoomCreator.getAccessToken())
+                .cookie(SIGN_IN_COOKIE_NAME, pairRoomCreator.getProviderAccessToken())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .body(request)
@@ -241,7 +229,7 @@ class PairRoomAcceptanceTest extends AcceptanceFixture {
         //when && then
         RestAssured
                 .given()
-                .cookie(SIGN_IN_COOKIE_NAME, addPair.getAccessToken())
+                .cookie(SIGN_IN_COOKIE_NAME, addPair.getProviderAccessToken())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
 
@@ -257,15 +245,7 @@ class PairRoomAcceptanceTest extends AcceptanceFixture {
     @Test
     void existMemberInPairRoom() {
         // Given
-        final Member savedMember = memberRepository.save(
-                Member.builder()
-                        .userId("userid")
-                        .accessToken("access")
-                        .loginId("login")
-                        .username("username")
-                        .profileImage("some image")
-                        .build()
-        );
+        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -276,7 +256,7 @@ class PairRoomAcceptanceTest extends AcceptanceFixture {
         pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember));
 
         // When
-        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
         final ExtractableResponse<Response> response = RestAssured
                 .given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/backend/src/test/java/site/coduo/acceptance/RetrospectAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/RetrospectAcceptanceTest.java
@@ -16,7 +16,7 @@ import site.coduo.fixture.RetrospectCreateRequestFixture;
 import site.coduo.member.domain.Member;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
-import site.coduo.member.support.MemberDummy;
+import site.coduo.fixture.MemberDummy;
 import site.coduo.pairroom.domain.MissionUrl;
 import site.coduo.pairroom.domain.Pair;
 import site.coduo.pairroom.domain.PairName;

--- a/backend/src/test/java/site/coduo/acceptance/RetrospectAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/RetrospectAcceptanceTest.java
@@ -16,6 +16,7 @@ import site.coduo.fixture.RetrospectCreateRequestFixture;
 import site.coduo.member.domain.Member;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
+import site.coduo.member.support.MemberDummy;
 import site.coduo.pairroom.domain.MissionUrl;
 import site.coduo.pairroom.domain.Pair;
 import site.coduo.pairroom.domain.PairName;
@@ -57,10 +58,10 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
     void createRetrospect() {
         // Given
         final PairRoomEntity savedPairRoom = saveTestPairRoom();
-        final Member savedMember = saveTestMember();
+        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
         pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember));
 
-        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
         final CreateRetrospectRequest request = RetrospectCreateRequestFixture.setCreateRequest();
 
         // When && Then
@@ -83,13 +84,13 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
     void findRetrospects() {
         // Given
         final PairRoomEntity savedPairRoom = saveTestPairRoom();
-        final Member savedMember = saveTestMember();
+        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
         final PairRoomMemberEntity pairRoomMember = pairRoomMemberRepository.save(
                 new PairRoomMemberEntity(savedPairRoom, savedMember));
 
         saveRetrospectContents(pairRoomMember);
 
-        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
 
         // When
         final FindRetrospectsResponse response = RestAssured
@@ -117,10 +118,10 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
     void findRetrospectById() {
         // Given
         final PairRoomEntity savedPairRoom = saveTestPairRoom();
-        final Member savedMember = saveTestMember();
+        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
         final PairRoomMemberEntity pairRoomMember = pairRoomMemberRepository.save(
                 new PairRoomMemberEntity(savedPairRoom, savedMember));
-        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
 
         saveRetrospectContents(pairRoomMember);
 
@@ -149,8 +150,8 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
     @DisplayName("존재하지 않은 회고를 조회하려하면 404를 반환받는다.")
     @Test
     void findNotExistRetrospect() {
-        final Member savedMember = saveTestMember();
-        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final Member savedMember = MemberDummy.createDummy();
+        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
 
         RestAssured
                 .given()
@@ -170,12 +171,12 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
     void deleteRetrospect() {
         // Given
         final PairRoomEntity savedPairRoom = saveTestPairRoom();
-        final Member savedMember = saveTestMember();
+        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
         pairRoomMemberRepository.save(
                 new PairRoomMemberEntity(savedPairRoom, savedMember));
 
         // When && Then
-        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
         RestAssured
                 .given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -194,21 +195,13 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
     @Test
     void notOwnerAccessFail() {
         // Given
-        final Member owner = saveTestMember();
-        final Member other = memberRepository.save(
-                Member.builder()
-                        .userId("userid2")
-                        .accessToken("access2")
-                        .loginId("login2")
-                        .username("username2")
-                        .profileImage("some image2")
-                        .build()
-        );
+        final Member owner = memberRepository.save(MemberDummy.createDummy());
+        final Member other = memberRepository.save(MemberDummy.createDummy("username2", "accesss2", "userid2", "login2"));
         final PairRoomEntity savedPairRoom = saveTestPairRoom();
         pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, owner));
 
         // When
-        final String otherMemberToken = jwtProvider.sign(other.getUserId());
+        final String otherMemberToken = jwtProvider.sign(other.getProviderUserId());
 
         RestAssured
                 .given()
@@ -228,14 +221,15 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
     void existRetrospectWithPairRoom() {
         // Given
         final PairRoomEntity savedPairRoom = saveTestPairRoom();
-        final Member savedMember = saveTestMember();
+        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
+
         final PairRoomMemberEntity pairRoomMember = pairRoomMemberRepository.save(
                 new PairRoomMemberEntity(savedPairRoom, savedMember));
 
         saveRetrospectContents(pairRoomMember);
 
         // When
-        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
         final ExistRetrospectWithPairRoomResponse response = RestAssured
                 .given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -252,18 +246,6 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
 
         // Then
         assertThat(response.existRetrospect()).isTrue();
-    }
-
-    private Member saveTestMember() {
-        return memberRepository.save(
-                Member.builder()
-                        .userId("userid")
-                        .accessToken("access")
-                        .loginId("login")
-                        .username("username")
-                        .profileImage("some image")
-                        .build()
-        );
     }
 
     private PairRoomEntity saveTestPairRoom() {

--- a/backend/src/test/java/site/coduo/acceptance/RetrospectAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/RetrospectAcceptanceTest.java
@@ -12,11 +12,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 import io.restassured.RestAssured;
+import site.coduo.fixture.MemberDummy;
 import site.coduo.fixture.RetrospectCreateRequestFixture;
-import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberEntity;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
-import site.coduo.fixture.MemberDummy;
 import site.coduo.pairroom.domain.MissionUrl;
 import site.coduo.pairroom.domain.Pair;
 import site.coduo.pairroom.domain.PairName;
@@ -24,7 +24,7 @@ import site.coduo.pairroom.domain.PairRoom;
 import site.coduo.pairroom.domain.PairRoomStatus;
 import site.coduo.pairroom.domain.accesscode.AccessCode;
 import site.coduo.pairroom.repository.PairRoomEntity;
-import site.coduo.pairroom.repository.PairRoomMemberEntity;
+import site.coduo.pairroom.repository.PairRoomMember;
 import site.coduo.pairroom.repository.PairRoomMemberRepository;
 import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.retrospect.controller.request.CreateRetrospectRequest;
@@ -58,10 +58,10 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
     void createRetrospect() {
         // Given
         final PairRoomEntity savedPairRoom = saveTestPairRoom();
-        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
-        pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember));
+        final MemberEntity savedMemberEntity = memberRepository.save(MemberDummy.createDummy());
+        pairRoomMemberRepository.save(new PairRoomMember(savedPairRoom, savedMemberEntity));
 
-        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
+        final String credentialToken = jwtProvider.sign(savedMemberEntity.getProviderUserId());
         final CreateRetrospectRequest request = RetrospectCreateRequestFixture.setCreateRequest();
 
         // When && Then
@@ -84,13 +84,13 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
     void findRetrospects() {
         // Given
         final PairRoomEntity savedPairRoom = saveTestPairRoom();
-        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
-        final PairRoomMemberEntity pairRoomMember = pairRoomMemberRepository.save(
-                new PairRoomMemberEntity(savedPairRoom, savedMember));
+        final MemberEntity savedMemberEntity = memberRepository.save(MemberDummy.createDummy());
+        final PairRoomMember pairRoomMember = pairRoomMemberRepository.save(
+                new PairRoomMember(savedPairRoom, savedMemberEntity));
 
         saveRetrospectContents(pairRoomMember);
 
-        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
+        final String credentialToken = jwtProvider.sign(savedMemberEntity.getProviderUserId());
 
         // When
         final FindRetrospectsResponse response = RestAssured
@@ -118,10 +118,10 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
     void findRetrospectById() {
         // Given
         final PairRoomEntity savedPairRoom = saveTestPairRoom();
-        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
-        final PairRoomMemberEntity pairRoomMember = pairRoomMemberRepository.save(
-                new PairRoomMemberEntity(savedPairRoom, savedMember));
-        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
+        final MemberEntity savedMemberEntity = memberRepository.save(MemberDummy.createDummy());
+        final PairRoomMember pairRoomMember = pairRoomMemberRepository.save(
+                new PairRoomMember(savedPairRoom, savedMemberEntity));
+        final String credentialToken = jwtProvider.sign(savedMemberEntity.getProviderUserId());
 
         saveRetrospectContents(pairRoomMember);
 
@@ -150,8 +150,8 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
     @DisplayName("존재하지 않은 회고를 조회하려하면 404를 반환받는다.")
     @Test
     void findNotExistRetrospect() {
-        final Member savedMember = MemberDummy.createDummy();
-        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
+        final MemberEntity savedMemberEntity = MemberDummy.createDummy();
+        final String credentialToken = jwtProvider.sign(savedMemberEntity.getProviderUserId());
 
         RestAssured
                 .given()
@@ -171,12 +171,12 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
     void deleteRetrospect() {
         // Given
         final PairRoomEntity savedPairRoom = saveTestPairRoom();
-        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
+        final MemberEntity savedMemberEntity = memberRepository.save(MemberDummy.createDummy());
         pairRoomMemberRepository.save(
-                new PairRoomMemberEntity(savedPairRoom, savedMember));
+                new PairRoomMember(savedPairRoom, savedMemberEntity));
 
         // When && Then
-        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
+        final String credentialToken = jwtProvider.sign(savedMemberEntity.getProviderUserId());
         RestAssured
                 .given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -195,10 +195,11 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
     @Test
     void notOwnerAccessFail() {
         // Given
-        final Member owner = memberRepository.save(MemberDummy.createDummy());
-        final Member other = memberRepository.save(MemberDummy.createDummy("username2", "accesss2", "userid2", "login2"));
+        final MemberEntity owner = memberRepository.save(MemberDummy.createDummy());
+        final MemberEntity other = memberRepository.save(
+                MemberDummy.createDummy("username2", "accesss2", "userid2", "login2"));
         final PairRoomEntity savedPairRoom = saveTestPairRoom();
-        pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, owner));
+        pairRoomMemberRepository.save(new PairRoomMember(savedPairRoom, owner));
 
         // When
         final String otherMemberToken = jwtProvider.sign(other.getProviderUserId());
@@ -221,15 +222,15 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
     void existRetrospectWithPairRoom() {
         // Given
         final PairRoomEntity savedPairRoom = saveTestPairRoom();
-        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
+        final MemberEntity savedMemberEntity = memberRepository.save(MemberDummy.createDummy());
 
-        final PairRoomMemberEntity pairRoomMember = pairRoomMemberRepository.save(
-                new PairRoomMemberEntity(savedPairRoom, savedMember));
+        final PairRoomMember pairRoomMember = pairRoomMemberRepository.save(
+                new PairRoomMember(savedPairRoom, savedMemberEntity));
 
         saveRetrospectContents(pairRoomMember);
 
         // When
-        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
+        final String credentialToken = jwtProvider.sign(savedMemberEntity.getProviderUserId());
         final ExistRetrospectWithPairRoomResponse response = RestAssured
                 .given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -260,7 +261,7 @@ class RetrospectAcceptanceTest extends AcceptanceFixture {
         ));
     }
 
-    private void saveRetrospectContents(final PairRoomMemberEntity pairRoomMember) {
+    private void saveRetrospectContents(final PairRoomMember pairRoomMember) {
         final List<RetrospectEntity> retrospectContentEntities = List.of(
                 new RetrospectEntity(pairRoomMember, RetrospectQuestionType.FIRST, "답변1"),
                 new RetrospectEntity(pairRoomMember, RetrospectQuestionType.SECOND, "답변2"),

--- a/backend/src/test/java/site/coduo/acceptance/TimerAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/TimerAcceptanceTest.java
@@ -67,6 +67,7 @@ class TimerAcceptanceTest extends AcceptanceFixture {
         final String accessCode = createPairRoom(PairRoomCreateRequestFixture.PAIR_ROOM_CREATE_REQUEST);
         final TimerUpdateRequest request = new TimerUpdateRequest(20000L, 3000L);
         createConnect(accessCode);
+        
         // when & then
         RestAssured
                 .given()

--- a/backend/src/test/java/site/coduo/config/TestConfig.java
+++ b/backend/src/test/java/site/coduo/config/TestConfig.java
@@ -8,14 +8,22 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import site.coduo.fake.FakeEventStreamRegistry;
 import site.coduo.fake.FakeGithubApiClient;
 import site.coduo.fake.FakeGithubOAuthClient;
+import site.coduo.fake.FakeHtmlParser;
 import site.coduo.fake.FixedNonceProvider;
 import site.coduo.member.client.GithubApiClient;
 import site.coduo.member.client.GithubOAuthClient;
 import site.coduo.member.infrastructure.security.NonceProvider;
+import site.coduo.referencelink.service.HtmlParser;
 import site.coduo.sync.service.EventStreamsRegistry;
 
 @TestConfiguration
 public class TestConfig {
+
+    @Bean
+    @Primary
+    public HtmlParser fakeHtmlParser() {
+        return new FakeHtmlParser();
+    }
 
     @Bean
     @Primary

--- a/backend/src/test/java/site/coduo/fake/FakeEvenStream.java
+++ b/backend/src/test/java/site/coduo/fake/FakeEvenStream.java
@@ -8,7 +8,7 @@ import site.coduo.sync.service.EventStream;
 
 public class FakeEvenStream implements EventStream {
 
-    private static final long CONNECTION_TIME_OUT_MILLISECONDS = Duration.ofMillis(500).toMillis();
+    private static final long CONNECTION_TIME_OUT_MILLISECONDS = Duration.ofMillis(1).toMillis();
 
     private final SseEmitter sseEmitter;
 

--- a/backend/src/test/java/site/coduo/fake/FakeHtmlParser.java
+++ b/backend/src/test/java/site/coduo/fake/FakeHtmlParser.java
@@ -1,0 +1,14 @@
+package site.coduo.fake;
+
+import java.net.URL;
+
+import site.coduo.referencelink.domain.OpenGraph;
+import site.coduo.referencelink.service.HtmlParser;
+
+public class FakeHtmlParser implements HtmlParser {
+
+    @Override
+    public OpenGraph getOpenGraph(final URL url) {
+        return OpenGraph.from(url);
+    }
+}

--- a/backend/src/test/java/site/coduo/fixture/MemberDummy.java
+++ b/backend/src/test/java/site/coduo/fixture/MemberDummy.java
@@ -1,4 +1,4 @@
-package site.coduo.member.support;
+package site.coduo.fixture;
 
 import site.coduo.member.domain.Member;
 

--- a/backend/src/test/java/site/coduo/fixture/MemberDummy.java
+++ b/backend/src/test/java/site/coduo/fixture/MemberDummy.java
@@ -1,11 +1,11 @@
 package site.coduo.fixture;
 
-import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberEntity;
 
 public abstract class MemberDummy {
 
-    public static Member createDummy() {
-        return Member.builder()
+    public static MemberEntity createDummy() {
+        return MemberEntity.builder()
                 .providerUserId("userId")
                 .providerAccessToken("access")
                 .providerLoginId("loginId")
@@ -13,8 +13,8 @@ public abstract class MemberDummy {
                 .build();
     }
 
-    public static Member createDummy(final String userId) {
-        return Member.builder()
+    public static MemberEntity createDummy(final String userId) {
+        return MemberEntity.builder()
                 .providerUserId(userId)
                 .providerAccessToken("access")
                 .providerLoginId("loginId")
@@ -22,8 +22,8 @@ public abstract class MemberDummy {
                 .build();
     }
 
-    public static Member createDummy(final String username, final String accessToken, final String userId) {
-        return Member.builder()
+    public static MemberEntity createDummy(final String username, final String accessToken, final String userId) {
+        return MemberEntity.builder()
                 .providerUserId(userId)
                 .providerAccessToken(accessToken)
                 .username(username)
@@ -31,8 +31,8 @@ public abstract class MemberDummy {
                 .build();
     }
 
-    public static Member createDummy(final String username, final String accessToken, final String userId, final String loginId) {
-        return Member.builder()
+    public static MemberEntity createDummy(final String username, final String accessToken, final String userId, final String loginId) {
+        return MemberEntity.builder()
                 .providerUserId(userId)
                 .providerAccessToken(accessToken)
                 .username(username)

--- a/backend/src/test/java/site/coduo/member/domain/MemberEntityTest.java
+++ b/backend/src/test/java/site/coduo/member/domain/MemberEntityTest.java
@@ -6,15 +6,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import site.coduo.fixture.MemberDummy;
+import site.coduo.member.domain.repository.MemberEntity;
 
-class MemberTest {
+class MemberEntityTest {
 
     @Test
     @DisplayName("회원 정보를 수정한다.")
     void update() {
         // given
-        final Member origin = MemberDummy.createDummy("origin", "origin", "origin");
-        final Member change = MemberDummy.createDummy("change", "change", "change");
+        final MemberEntity origin = MemberDummy.createDummy("origin", "origin", "origin");
+        final MemberEntity change = MemberDummy.createDummy("change", "change", "change");
 
         // when
         origin.update(change);

--- a/backend/src/test/java/site/coduo/member/domain/MemberTest.java
+++ b/backend/src/test/java/site/coduo/member/domain/MemberTest.java
@@ -5,35 +5,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import site.coduo.member.support.MemberDummy;
+
 class MemberTest {
 
     @Test
     @DisplayName("회원 정보를 수정한다.")
     void update() {
         // given
-        final Member origin = Member.builder()
-                .userId("origin")
-                .loginId("origin")
-                .username("origin")
-                .profileImage("origin")
-                .accessToken("origin")
-                .build();
-
-        final Member change = Member.builder()
-                .userId("change")
-                .loginId("change")
-                .username("change")
-                .accessToken("change")
-                .profileImage("change")
-                .build();
+        final Member origin = MemberDummy.createDummy("origin", "origin", "origin");
+        final Member change = MemberDummy.createDummy("change", "change", "change");
 
         // when
         origin.update(change);
 
         // then
         assertThat(origin)
-                .extracting("userId", "loginId", "username", "accessToken", "profileImage")
-                .contains(change.getUserId(), change.getLoginId(), change.getUsername(), change.getAccessToken(),
-                        change.getProfileImage());
+                .extracting("providerUserId", "providerLoginId", "username", "providerAccessToken")
+                .contains(change.getProviderUserId(), change.getProviderLoginId(), change.getUsername(), change.getProviderAccessToken());
     }
 }

--- a/backend/src/test/java/site/coduo/member/domain/MemberTest.java
+++ b/backend/src/test/java/site/coduo/member/domain/MemberTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import site.coduo.member.support.MemberDummy;
+import site.coduo.fixture.MemberDummy;
 
 class MemberTest {
 

--- a/backend/src/test/java/site/coduo/member/domain/repository/MemberEntityRepositoryTest.java
+++ b/backend/src/test/java/site/coduo/member/domain/repository/MemberEntityRepositoryTest.java
@@ -10,11 +10,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import site.coduo.member.domain.Member;
 import site.coduo.fixture.MemberDummy;
 
 @SpringBootTest
-class MemberRepositoryTest {
+class MemberEntityRepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;
@@ -30,14 +29,14 @@ class MemberRepositoryTest {
         // given
         final String identifier = "some id";
 
-        final Member member = MemberDummy.createDummy(identifier);
-        memberRepository.save(member);
+        final MemberEntity memberEntity = MemberDummy.createDummy(identifier);
+        memberRepository.save(memberEntity);
 
         // when
-        final Optional<Member> find = memberRepository.findByProviderUserIdAndDeletedAtIsNull(identifier);
+        final Optional<MemberEntity> find = memberRepository.findByProviderUserIdAndDeletedAtIsNull(identifier);
 
         // then
-        assertThat(find).hasValue(member);
+        assertThat(find).hasValue(memberEntity);
     }
 
 }

--- a/backend/src/test/java/site/coduo/member/domain/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/site/coduo/member/domain/repository/MemberRepositoryTest.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import site.coduo.member.domain.Member;
-import site.coduo.member.support.MemberDummy;
+import site.coduo.fixture.MemberDummy;
 
 @SpringBootTest
 class MemberRepositoryTest {

--- a/backend/src/test/java/site/coduo/member/domain/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/site/coduo/member/domain/repository/MemberRepositoryTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import site.coduo.member.domain.Member;
+import site.coduo.member.support.MemberDummy;
 
 @SpringBootTest
 class MemberRepositoryTest {
@@ -29,17 +30,11 @@ class MemberRepositoryTest {
         // given
         final String identifier = "some id";
 
-        final Member member = Member.builder()
-                .loginId("loginId")
-                .userId(identifier)
-                .profileImage("some photo")
-                .accessToken("some accessCode")
-                .username("some username")
-                .build();
+        final Member member = MemberDummy.createDummy(identifier);
         memberRepository.save(member);
 
         // when
-        final Optional<Member> find = memberRepository.findByUserIdAndDeletedAtIsNull(identifier);
+        final Optional<Member> find = memberRepository.findByProviderUserIdAndDeletedAtIsNull(identifier);
 
         // then
         assertThat(find).hasValue(member);

--- a/backend/src/test/java/site/coduo/member/service/AuthServiceTest.java
+++ b/backend/src/test/java/site/coduo/member/service/AuthServiceTest.java
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.Import;
 
 import site.coduo.config.TestConfig;
 import site.coduo.fake.FakeGithubApiClient;
-import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberEntity;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
 import site.coduo.member.service.dto.SignInServiceResponse;
@@ -39,8 +39,8 @@ class AuthServiceTest {
     @DisplayName("JWT로 감싸진 엑세스 토큰으로 회원을 조회한다.")
     void search_member_by_access_token() {
         // given
-        final Member member = createMember("username", FakeGithubApiClient.ACCESS_TOKEN, FakeGithubApiClient.USER_ID);
-        final String sign = jwtProvider.sign(member.getProviderAccessToken());
+        final MemberEntity memberEntity = createMember("username", FakeGithubApiClient.ACCESS_TOKEN, FakeGithubApiClient.USER_ID);
+        final String sign = jwtProvider.sign(memberEntity.getProviderAccessToken());
 
         // when
         final SignInServiceResponse signInToken = authService.createSignInToken(sign);
@@ -63,23 +63,23 @@ class AuthServiceTest {
         assertThat(signInToken.token()).isEmpty();
     }
 
-    private Member createMember(final String username, final String accessToken, final String userId) {
-        final Member member = MemberDummy.createDummy(username, accessToken, userId);
-        return memberRepository.save(member);
+    private MemberEntity createMember(final String username, final String accessToken, final String userId) {
+        final MemberEntity memberEntity = MemberDummy.createDummy(username, accessToken, userId);
+        return memberRepository.save(memberEntity);
     }
 
     @Test
     @DisplayName("로그인 토큰을 생성할 때 회원이 엑세스 토큰을 갱신한다.")
     void renewal_member_access_token_when_create_sign_in_token() {
         // given
-        final Member member = createMember("username", "origin", FakeGithubApiClient.USER_ID);
+        final MemberEntity memberEntity = createMember("username", "origin", FakeGithubApiClient.USER_ID);
         final String sign = jwtProvider.sign("change");
 
         // when
         authService.createSignInToken(sign);
 
         // then
-        assertThat(memberRepository.findById(member.getId()).orElseThrow())
+        assertThat(memberRepository.findById(memberEntity.getId()).orElseThrow())
                 .extracting("providerAccessToken")
                 .isEqualTo("change");
     }

--- a/backend/src/test/java/site/coduo/member/service/AuthServiceTest.java
+++ b/backend/src/test/java/site/coduo/member/service/AuthServiceTest.java
@@ -15,7 +15,7 @@ import site.coduo.member.domain.Member;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
 import site.coduo.member.service.dto.SignInServiceResponse;
-import site.coduo.member.support.MemberDummy;
+import site.coduo.fixture.MemberDummy;
 
 @SpringBootTest
 @Import(TestConfig.class)

--- a/backend/src/test/java/site/coduo/member/service/AuthServiceTest.java
+++ b/backend/src/test/java/site/coduo/member/service/AuthServiceTest.java
@@ -15,6 +15,7 @@ import site.coduo.member.domain.Member;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
 import site.coduo.member.service.dto.SignInServiceResponse;
+import site.coduo.member.support.MemberDummy;
 
 @SpringBootTest
 @Import(TestConfig.class)
@@ -39,7 +40,7 @@ class AuthServiceTest {
     void search_member_by_access_token() {
         // given
         final Member member = createMember("username", FakeGithubApiClient.ACCESS_TOKEN, FakeGithubApiClient.USER_ID);
-        final String sign = jwtProvider.sign(member.getAccessToken());
+        final String sign = jwtProvider.sign(member.getProviderAccessToken());
 
         // when
         final SignInServiceResponse signInToken = authService.createSignInToken(sign);
@@ -63,14 +64,7 @@ class AuthServiceTest {
     }
 
     private Member createMember(final String username, final String accessToken, final String userId) {
-        final Member member = Member.builder()
-                .username(username)
-                .accessToken(accessToken)
-                .loginId("")
-                .userId(userId)
-                .profileImage("")
-                .build();
-
+        final Member member = MemberDummy.createDummy(username, accessToken, userId);
         return memberRepository.save(member);
     }
 
@@ -86,7 +80,7 @@ class AuthServiceTest {
 
         // then
         assertThat(memberRepository.findById(member.getId()).orElseThrow())
-                .extracting("accessToken")
+                .extracting("providerAccessToken")
                 .isEqualTo("change");
     }
 

--- a/backend/src/test/java/site/coduo/member/service/MemberEntityServiceTest.java
+++ b/backend/src/test/java/site/coduo/member/service/MemberEntityServiceTest.java
@@ -12,7 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 
 import site.coduo.config.TestConfig;
-import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberEntity;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
 import site.coduo.member.service.dto.member.MemberReadResponse;
@@ -20,7 +20,7 @@ import site.coduo.fixture.MemberDummy;
 
 @SpringBootTest
 @Import(TestConfig.class)
-class MemberServiceTest {
+class MemberEntityServiceTest {
 
     @Autowired
     private MemberService memberService;
@@ -55,47 +55,47 @@ class MemberServiceTest {
     @DisplayName("로그인 토큰을 바탕으로 회원이름을 조회한다.")
     void search_username_by_login_token() {
         // given
-        final Member member = MemberDummy.createDummy();
-        final String sign = jwtProvider.sign(member.getProviderUserId());
-        memberRepository.save(member);
+        final MemberEntity memberEntity = MemberDummy.createDummy();
+        final String sign = jwtProvider.sign(memberEntity.getProviderUserId());
+        memberRepository.save(memberEntity);
 
         // when
         final MemberReadResponse response = memberService.findMemberNameByCredential(sign);
 
         // then
-        assertThat(response.username()).isEqualTo(member.getUsername());
+        assertThat(response.username()).isEqualTo(memberEntity.getUsername());
     }
 
     @Test
     @DisplayName("로그인 토큰을 바탕으로 회원 엔티티를 조회한다.")
     void search_member_by_login_token() {
         // given
-        final Member member = MemberDummy.createDummy();
-        final String sign = jwtProvider.sign(member.getProviderUserId());
-        memberRepository.save(member);
+        final MemberEntity memberEntity = MemberDummy.createDummy();
+        final String sign = jwtProvider.sign(memberEntity.getProviderUserId());
+        memberRepository.save(memberEntity);
 
         // when
-        final Member findMember = memberService.findMemberByCredential(sign);
+        final MemberEntity findMemberEntity = memberService.findMemberByCredential(sign);
 
         // then
-        assertThat(findMember.getUsername()).isEqualTo(member.getUsername());
+        assertThat(findMemberEntity.getUsername()).isEqualTo(memberEntity.getUsername());
     }
 
     @Test
     @DisplayName("회원을 삭제한다.")
     void delete_member() {
         // given
-        final Member member = MemberDummy.createDummy();
-        final String token = jwtProvider.sign(member.getProviderUserId());
+        final MemberEntity memberEntity = MemberDummy.createDummy();
+        final String token = jwtProvider.sign(memberEntity.getProviderUserId());
 
-        memberRepository.save(member);
-        final List<Member> beforeDelete = memberRepository.findAll();
+        memberRepository.save(memberEntity);
+        final List<MemberEntity> beforeDelete = memberRepository.findAll();
 
         // when
         memberService.deleteMember(token);
 
         //then
-        final List<Member> afterDelete = memberRepository.findAll();
+        final List<MemberEntity> afterDelete = memberRepository.findAll();
         assertThat(afterDelete).hasSize(beforeDelete.size() - 1);
     }
 }

--- a/backend/src/test/java/site/coduo/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/site/coduo/member/service/MemberServiceTest.java
@@ -16,7 +16,7 @@ import site.coduo.member.domain.Member;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
 import site.coduo.member.service.dto.member.MemberReadResponse;
-import site.coduo.member.support.MemberDummy;
+import site.coduo.fixture.MemberDummy;
 
 @SpringBootTest
 @Import(TestConfig.class)

--- a/backend/src/test/java/site/coduo/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/site/coduo/member/service/MemberServiceTest.java
@@ -16,6 +16,7 @@ import site.coduo.member.domain.Member;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
 import site.coduo.member.service.dto.member.MemberReadResponse;
+import site.coduo.member.support.MemberDummy;
 
 @SpringBootTest
 @Import(TestConfig.class)
@@ -54,14 +55,8 @@ class MemberServiceTest {
     @DisplayName("로그인 토큰을 바탕으로 회원이름을 조회한다.")
     void search_username_by_login_token() {
         // given
-        final Member member = Member.builder()
-                .userId("userid")
-                .accessToken("access")
-                .loginId("login")
-                .username("username")
-                .profileImage("some image")
-                .build();
-        final String sign = jwtProvider.sign(member.getUserId());
+        final Member member = MemberDummy.createDummy();
+        final String sign = jwtProvider.sign(member.getProviderUserId());
         memberRepository.save(member);
 
         // when
@@ -75,14 +70,8 @@ class MemberServiceTest {
     @DisplayName("로그인 토큰을 바탕으로 회원 엔티티를 조회한다.")
     void search_member_by_login_token() {
         // given
-        final Member member = Member.builder()
-                .userId("userid")
-                .accessToken("access")
-                .loginId("login")
-                .username("username")
-                .profileImage("some image")
-                .build();
-        final String sign = jwtProvider.sign(member.getUserId());
+        final Member member = MemberDummy.createDummy();
+        final String sign = jwtProvider.sign(member.getProviderUserId());
         memberRepository.save(member);
 
         // when
@@ -96,14 +85,8 @@ class MemberServiceTest {
     @DisplayName("회원을 삭제한다.")
     void delete_member() {
         // given
-        final Member member = Member.builder()
-                .userId("userid")
-                .accessToken("access")
-                .loginId("login")
-                .username("username")
-                .profileImage("some image")
-                .build();
-        final String token = jwtProvider.sign(member.getUserId());
+        final Member member = MemberDummy.createDummy();
+        final String token = jwtProvider.sign(member.getProviderUserId());
 
         memberRepository.save(member);
         final List<Member> beforeDelete = memberRepository.findAll();
@@ -114,26 +97,5 @@ class MemberServiceTest {
         //then
         final List<Member> afterDelete = memberRepository.findAll();
         assertThat(afterDelete).hasSize(beforeDelete.size() - 1);
-    }
-
-    @Test
-    @DisplayName("user id로 회원을 조회한다.")
-    void find_by_user_id() {
-        //given
-        final Member member = Member.builder()
-                .userId("targetUserId")
-                .accessToken("access")
-                .loginId("login")
-                .username("username")
-                .profileImage("some image")
-                .build();
-
-        final Member saved = memberRepository.save(member);
-
-        //when
-        final Member find = memberService.findMember(member.getLoginId());
-
-        //then
-        assertThat(find).isEqualTo(saved);
     }
 }

--- a/backend/src/test/java/site/coduo/member/support/MemberDummy.java
+++ b/backend/src/test/java/site/coduo/member/support/MemberDummy.java
@@ -1,0 +1,42 @@
+package site.coduo.member.support;
+
+import site.coduo.member.domain.Member;
+
+public abstract class MemberDummy {
+
+    public static Member createDummy() {
+        return Member.builder()
+                .providerUserId("userId")
+                .providerAccessToken("access")
+                .providerLoginId("loginId")
+                .username("username")
+                .build();
+    }
+
+    public static Member createDummy(final String userId) {
+        return Member.builder()
+                .providerUserId(userId)
+                .providerAccessToken("access")
+                .providerLoginId("loginId")
+                .username("username")
+                .build();
+    }
+
+    public static Member createDummy(final String username, final String accessToken, final String userId) {
+        return Member.builder()
+                .providerUserId(userId)
+                .providerAccessToken(accessToken)
+                .username(username)
+                .providerLoginId("")
+                .build();
+    }
+
+    public static Member createDummy(final String username, final String accessToken, final String userId, final String loginId) {
+        return Member.builder()
+                .providerUserId(userId)
+                .providerAccessToken(accessToken)
+                .username(username)
+                .providerLoginId(loginId)
+                .build();
+    }
+}

--- a/backend/src/test/java/site/coduo/pairroom/service/PairRoomServiceTest.java
+++ b/backend/src/test/java/site/coduo/pairroom/service/PairRoomServiceTest.java
@@ -21,7 +21,7 @@ import site.coduo.fixture.PairRoomCreateRequestFixture;
 import site.coduo.member.domain.Member;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
-import site.coduo.member.support.MemberDummy;
+import site.coduo.fixture.MemberDummy;
 import site.coduo.pairroom.domain.MissionUrl;
 import site.coduo.pairroom.domain.Pair;
 import site.coduo.pairroom.domain.PairName;

--- a/backend/src/test/java/site/coduo/pairroom/service/PairRoomServiceTest.java
+++ b/backend/src/test/java/site/coduo/pairroom/service/PairRoomServiceTest.java
@@ -17,11 +17,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import site.coduo.fixture.MemberDummy;
 import site.coduo.fixture.PairRoomCreateRequestFixture;
-import site.coduo.member.domain.Member;
+import site.coduo.member.domain.repository.MemberEntity;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
-import site.coduo.fixture.MemberDummy;
 import site.coduo.pairroom.domain.MissionUrl;
 import site.coduo.pairroom.domain.Pair;
 import site.coduo.pairroom.domain.PairName;
@@ -31,7 +31,7 @@ import site.coduo.pairroom.domain.accesscode.AccessCode;
 import site.coduo.pairroom.exception.DeletePairRoomException;
 import site.coduo.pairroom.exception.PairRoomNotFoundException;
 import site.coduo.pairroom.repository.PairRoomEntity;
-import site.coduo.pairroom.repository.PairRoomMemberEntity;
+import site.coduo.pairroom.repository.PairRoomMember;
 import site.coduo.pairroom.repository.PairRoomMemberRepository;
 import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.pairroom.service.dto.PairRoomCreateRequest;
@@ -185,20 +185,26 @@ class PairRoomServiceTest {
     @Test
     void find_rooms_by_member() {
         //given
-        final Member memberA = createMember("reddevilmidzy");
-        final Member memberB = createMember("test");
+        final MemberEntity memberEntityA = createMember("reddevilmidzy");
+        final MemberEntity memberEntityB = createMember("test");
 
         final PairRoomCreateRequest pairRoomCreateRequest = PairRoomCreateRequestFixture.PAIR_ROOM_CREATE_REQUEST;
 
-        final String accessCodeA_1 = pairRoomService.savePairRoom(pairRoomCreateRequest, memberA.getProviderAccessToken());
-        final String accessCodeA_2 = pairRoomService.savePairRoom(pairRoomCreateRequest, memberA.getProviderAccessToken());
-        final String accessCodeB_1 = pairRoomService.savePairRoom(pairRoomCreateRequest, memberB.getProviderAccessToken());
+        final String accessCodeA_1 = pairRoomService.savePairRoom(pairRoomCreateRequest,
+                memberEntityA.getProviderAccessToken());
+        final String accessCodeA_2 = pairRoomService.savePairRoom(pairRoomCreateRequest,
+                memberEntityA.getProviderAccessToken());
+        final String accessCodeB_1 = pairRoomService.savePairRoom(pairRoomCreateRequest,
+                memberEntityB.getProviderAccessToken());
         pairRoomService.savePairRoom(pairRoomCreateRequest, null);
 
         final PairRoomCreateRequest deletePairRoomCreateRequest = PairRoomCreateRequestFixture.PAIR_ROOM_CREATE_REQUEST;
-        final String accessToken1 = pairRoomService.savePairRoom(deletePairRoomCreateRequest, memberA.getProviderAccessToken());
-        final String accessToken2 = pairRoomService.savePairRoom(deletePairRoomCreateRequest, memberA.getProviderAccessToken());
-        final String accessToken3 = pairRoomService.savePairRoom(deletePairRoomCreateRequest, memberA.getProviderAccessToken());
+        final String accessToken1 = pairRoomService.savePairRoom(deletePairRoomCreateRequest,
+                memberEntityA.getProviderAccessToken());
+        final String accessToken2 = pairRoomService.savePairRoom(deletePairRoomCreateRequest,
+                memberEntityA.getProviderAccessToken());
+        final String accessToken3 = pairRoomService.savePairRoom(deletePairRoomCreateRequest,
+                memberEntityA.getProviderAccessToken());
 
         pairRoomRepository.fetchByAccessCode(accessToken1).updateStatus(PairRoomStatus.DELETED);
         pairRoomRepository.fetchByAccessCode(accessToken2).updateStatus(PairRoomStatus.DELETED);
@@ -208,11 +214,13 @@ class PairRoomServiceTest {
         final List<String> memberBExpected = List.of(accessCodeB_1);
 
         //when
-        final List<String> findAccessCodesForMemberA = pairRoomService.findPairRooms(memberA.getProviderAccessToken())
+        final List<String> findAccessCodesForMemberA = pairRoomService.findPairRooms(
+                        memberEntityA.getProviderAccessToken())
                 .stream()
                 .map(PairRoomMemberResponse::accessCode)
                 .toList();
-        final List<String> findAccessCodesForMemberB = pairRoomService.findPairRooms(memberB.getProviderAccessToken())
+        final List<String> findAccessCodesForMemberB = pairRoomService.findPairRooms(
+                        memberEntityB.getProviderAccessToken())
                 .stream()
                 .map(PairRoomMemberResponse::accessCode)
                 .toList();
@@ -224,10 +232,10 @@ class PairRoomServiceTest {
                 .containsAll(memberBExpected);
     }
 
-    private Member createMember(final String userId) {
+    private MemberEntity createMember(final String userId) {
         final String token = jwtProvider.sign(userId);
-        final Member member = MemberDummy.createDummy("hello" + new Random().nextInt(), token, userId);
-        return memberRepository.save(member);
+        final MemberEntity memberEntity = MemberDummy.createDummy("hello" + new Random().nextInt(), token, userId);
+        return memberRepository.save(memberEntity);
     }
 
     @Test
@@ -286,7 +294,7 @@ class PairRoomServiceTest {
     @Test
     void existMemberInPairRoom() {
         // Given
-        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
+        final MemberEntity savedMemberEntity = memberRepository.save(MemberDummy.createDummy());
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -294,10 +302,10 @@ class PairRoomServiceTest {
                         new AccessCode("123456"),
                         EASY_ACCESS_CODE_INK_REDDY)
         ));
-        pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember));
+        pairRoomMemberRepository.save(new PairRoomMember(savedPairRoom, savedMemberEntity));
 
         // When
-        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
+        final String credentialToken = jwtProvider.sign(savedMemberEntity.getProviderUserId());
         final boolean existMemberInPairRoom = pairRoomService.existMemberInPairRoom(credentialToken, "123456");
 
         // Then
@@ -308,10 +316,10 @@ class PairRoomServiceTest {
     @Test
     void existMemberInPairRoomWithNotExistRoomCode() {
         // Given
-        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
+        final MemberEntity savedMemberEntity = memberRepository.save(MemberDummy.createDummy());
 
         // When & Then
-        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
+        final String credentialToken = jwtProvider.sign(savedMemberEntity.getProviderUserId());
         assertThatThrownBy(() -> pairRoomService.existMemberInPairRoom(credentialToken, "no-code"))
                 .isInstanceOf(PairRoomNotFoundException.class);
     }
@@ -320,10 +328,10 @@ class PairRoomServiceTest {
     @DisplayName("페어가 회원가입한 유저인 경우 페어의 나의 페이지에서도 조회가 가능하다.")
     void createPairRoomRegisteredPair() {
         //given
-        final Member me = MemberDummy.createDummy("pairNameA",jwtProvider.sign("pairA"), "pairA","loginIdA");
+        final MemberEntity me = MemberDummy.createDummy("pairNameA", jwtProvider.sign("pairA"), "pairA", "loginIdA");
         memberRepository.save(me);
 
-        final Member pair =MemberDummy.createDummy("pairNameB",jwtProvider.sign("pairB"), "pairB", "loginIdB");
+        final MemberEntity pair = MemberDummy.createDummy("pairNameB", jwtProvider.sign("pairB"), "pairB", "loginIdB");
         memberRepository.save(pair);
 
         final PairRoomCreateRequest request = new PairRoomCreateRequest("navi", "dri", pair.getProviderLoginId(),
@@ -333,8 +341,8 @@ class PairRoomServiceTest {
         pairRoomService.savePairRoom(request, me.getProviderAccessToken());
 
         //then
-        final List<PairRoomMemberEntity> mine = pairRoomMemberRepository.findByMember(me);
-        final List<PairRoomMemberEntity> pairsList = pairRoomMemberRepository.findByMember(pair);
+        final List<PairRoomMember> mine = pairRoomMemberRepository.findByMemberEntity(me);
+        final List<PairRoomMember> pairsList = pairRoomMemberRepository.findByMemberEntity(pair);
         assertThat(mine).hasSize(1);
         assertThat(pairsList).hasSize(1);
     }

--- a/backend/src/test/java/site/coduo/pairroom/service/PairRoomServiceTest.java
+++ b/backend/src/test/java/site/coduo/pairroom/service/PairRoomServiceTest.java
@@ -21,6 +21,7 @@ import site.coduo.fixture.PairRoomCreateRequestFixture;
 import site.coduo.member.domain.Member;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
+import site.coduo.member.support.MemberDummy;
 import site.coduo.pairroom.domain.MissionUrl;
 import site.coduo.pairroom.domain.Pair;
 import site.coduo.pairroom.domain.PairName;
@@ -40,8 +41,8 @@ import site.coduo.timer.domain.Timer;
 import site.coduo.timer.repository.TimerEntity;
 import site.coduo.timer.repository.TimerRepository;
 
-@Transactional
 @SpringBootTest
+@Transactional
 class PairRoomServiceTest {
 
     @Autowired
@@ -189,15 +190,15 @@ class PairRoomServiceTest {
 
         final PairRoomCreateRequest pairRoomCreateRequest = PairRoomCreateRequestFixture.PAIR_ROOM_CREATE_REQUEST;
 
-        final String accessCodeA_1 = pairRoomService.savePairRoom(pairRoomCreateRequest, memberA.getAccessToken());
-        final String accessCodeA_2 = pairRoomService.savePairRoom(pairRoomCreateRequest, memberA.getAccessToken());
-        final String accessCodeB_1 = pairRoomService.savePairRoom(pairRoomCreateRequest, memberB.getAccessToken());
+        final String accessCodeA_1 = pairRoomService.savePairRoom(pairRoomCreateRequest, memberA.getProviderAccessToken());
+        final String accessCodeA_2 = pairRoomService.savePairRoom(pairRoomCreateRequest, memberA.getProviderAccessToken());
+        final String accessCodeB_1 = pairRoomService.savePairRoom(pairRoomCreateRequest, memberB.getProviderAccessToken());
         pairRoomService.savePairRoom(pairRoomCreateRequest, null);
 
         final PairRoomCreateRequest deletePairRoomCreateRequest = PairRoomCreateRequestFixture.PAIR_ROOM_CREATE_REQUEST;
-        final String accessToken1 = pairRoomService.savePairRoom(deletePairRoomCreateRequest, memberA.getAccessToken());
-        final String accessToken2 = pairRoomService.savePairRoom(deletePairRoomCreateRequest, memberA.getAccessToken());
-        final String accessToken3 = pairRoomService.savePairRoom(deletePairRoomCreateRequest, memberA.getAccessToken());
+        final String accessToken1 = pairRoomService.savePairRoom(deletePairRoomCreateRequest, memberA.getProviderAccessToken());
+        final String accessToken2 = pairRoomService.savePairRoom(deletePairRoomCreateRequest, memberA.getProviderAccessToken());
+        final String accessToken3 = pairRoomService.savePairRoom(deletePairRoomCreateRequest, memberA.getProviderAccessToken());
 
         pairRoomRepository.fetchByAccessCode(accessToken1).updateStatus(PairRoomStatus.DELETED);
         pairRoomRepository.fetchByAccessCode(accessToken2).updateStatus(PairRoomStatus.DELETED);
@@ -207,11 +208,11 @@ class PairRoomServiceTest {
         final List<String> memberBExpected = List.of(accessCodeB_1);
 
         //when
-        final List<String> findAccessCodesForMemberA = pairRoomService.findPairRooms(memberA.getAccessToken())
+        final List<String> findAccessCodesForMemberA = pairRoomService.findPairRooms(memberA.getProviderAccessToken())
                 .stream()
                 .map(PairRoomMemberResponse::accessCode)
                 .toList();
-        final List<String> findAccessCodesForMemberB = pairRoomService.findPairRooms(memberB.getAccessToken())
+        final List<String> findAccessCodesForMemberB = pairRoomService.findPairRooms(memberB.getProviderAccessToken())
                 .stream()
                 .map(PairRoomMemberResponse::accessCode)
                 .toList();
@@ -225,13 +226,7 @@ class PairRoomServiceTest {
 
     private Member createMember(final String userId) {
         final String token = jwtProvider.sign(userId);
-        final Member member = Member.builder()
-                .accessToken(token)
-                .loginId("login id")
-                .profileImage("profile image")
-                .username("hello" + new Random().nextInt())
-                .userId(userId)
-                .build();
+        final Member member = MemberDummy.createDummy("hello" + new Random().nextInt(), token, userId);
         return memberRepository.save(member);
     }
 
@@ -291,15 +286,7 @@ class PairRoomServiceTest {
     @Test
     void existMemberInPairRoom() {
         // Given
-        final Member savedMember = memberRepository.save(
-                Member.builder()
-                        .userId("userid")
-                        .accessToken("access")
-                        .loginId("login")
-                        .username("username")
-                        .profileImage("some image")
-                        .build()
-        );
+        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -310,7 +297,7 @@ class PairRoomServiceTest {
         pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember));
 
         // When
-        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
         final boolean existMemberInPairRoom = pairRoomService.existMemberInPairRoom(credentialToken, "123456");
 
         // Then
@@ -321,18 +308,10 @@ class PairRoomServiceTest {
     @Test
     void existMemberInPairRoomWithNotExistRoomCode() {
         // Given
-        final Member savedMember = memberRepository.save(
-                Member.builder()
-                        .userId("userid")
-                        .accessToken("access")
-                        .loginId("login")
-                        .username("username")
-                        .profileImage("some image")
-                        .build()
-        );
+        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
 
         // When & Then
-        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
         assertThatThrownBy(() -> pairRoomService.existMemberInPairRoom(credentialToken, "no-code"))
                 .isInstanceOf(PairRoomNotFoundException.class);
     }
@@ -341,31 +320,17 @@ class PairRoomServiceTest {
     @DisplayName("페어가 회원가입한 유저인 경우 페어의 나의 페이지에서도 조회가 가능하다.")
     void createPairRoomRegisteredPair() {
         //given
-        final Member me = memberRepository.save(
-                Member.builder()
-                        .userId("pairA")
-                        .accessToken(jwtProvider.sign("pairA"))
-                        .loginId("pairA")
-                        .username("pairNameA")
-                        .profileImage("some image")
-                        .build()
-        );
+        final Member me = MemberDummy.createDummy("pairNameA",jwtProvider.sign("pairA"), "pairA","loginIdA");
+        memberRepository.save(me);
 
-        final Member pair = memberRepository.save(
-                Member.builder()
-                        .userId("pairB")
-                        .accessToken(jwtProvider.sign("pairB"))
-                        .loginId("pairB")
-                        .username("pairNameB")
-                        .profileImage("some image")
-                        .build()
-        );
+        final Member pair =MemberDummy.createDummy("pairNameB",jwtProvider.sign("pairB"), "pairB", "loginIdB");
+        memberRepository.save(pair);
 
-        final PairRoomCreateRequest request = new PairRoomCreateRequest("navi", "dri", pair.getUserId(),
+        final PairRoomCreateRequest request = new PairRoomCreateRequest("navi", "dri", pair.getProviderLoginId(),
                 60000L, 60000L, "");
 
         //when
-        pairRoomService.savePairRoom(request, me.getAccessToken());
+        pairRoomService.savePairRoom(request, me.getProviderAccessToken());
 
         //then
         final List<PairRoomMemberEntity> mine = pairRoomMemberRepository.findByMember(me);

--- a/backend/src/test/java/site/coduo/retrospect/service/RetrospectServiceTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/service/RetrospectServiceTest.java
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import site.coduo.member.domain.Member;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
-import site.coduo.member.support.MemberDummy;
+import site.coduo.fixture.MemberDummy;
 import site.coduo.pairroom.domain.MissionUrl;
 import site.coduo.pairroom.domain.Pair;
 import site.coduo.pairroom.domain.PairName;

--- a/backend/src/test/java/site/coduo/retrospect/service/RetrospectServiceTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/service/RetrospectServiceTest.java
@@ -14,10 +14,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import site.coduo.member.domain.Member;
+import site.coduo.fixture.MemberDummy;
+import site.coduo.member.domain.repository.MemberEntity;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
-import site.coduo.fixture.MemberDummy;
 import site.coduo.pairroom.domain.MissionUrl;
 import site.coduo.pairroom.domain.Pair;
 import site.coduo.pairroom.domain.PairName;
@@ -27,7 +27,7 @@ import site.coduo.pairroom.domain.accesscode.AccessCode;
 import site.coduo.pairroom.exception.PairRoomMemberNotFoundException;
 import site.coduo.pairroom.exception.PairRoomNotFoundException;
 import site.coduo.pairroom.repository.PairRoomEntity;
-import site.coduo.pairroom.repository.PairRoomMemberEntity;
+import site.coduo.pairroom.repository.PairRoomMember;
 import site.coduo.pairroom.repository.PairRoomMemberRepository;
 import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.referencelink.repository.CategoryRepository;
@@ -72,7 +72,7 @@ class RetrospectServiceTest {
     @Test
     void createRetrospect() {
         // Given
-        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
+        final MemberEntity savedMemberEntity = memberRepository.save(MemberDummy.createDummy());
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -80,10 +80,10 @@ class RetrospectServiceTest {
                         new AccessCode("123456"),
                         EASY_ACCESS_CODE_INK_REDDY)
         ));
-        final PairRoomMemberEntity pairRoomMember = pairRoomMemberRepository.save(
-                new PairRoomMemberEntity(savedPairRoom, savedMember));
+        final PairRoomMember pairRoomMember = pairRoomMemberRepository.save(
+                new PairRoomMember(savedPairRoom, savedMemberEntity));
 
-        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
+        final String credentialToken = jwtProvider.sign(savedMemberEntity.getProviderUserId());
         final String pairRoomAccessCode = "123456";
         final List<String> answers = List.of("답변1", "답변2", "답변3", "답변4", "답변5", "답변6");
 
@@ -102,7 +102,7 @@ class RetrospectServiceTest {
     @Test
     void createTwiceRetrospect() {
         // Given
-        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
+        final MemberEntity savedMemberEntity = memberRepository.save(MemberDummy.createDummy());
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -110,9 +110,9 @@ class RetrospectServiceTest {
                         new AccessCode("123456"),
                         EASY_ACCESS_CODE_INK_REDDY)
         ));
-        pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember));
+        pairRoomMemberRepository.save(new PairRoomMember(savedPairRoom, savedMemberEntity));
 
-        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
+        final String credentialToken = jwtProvider.sign(savedMemberEntity.getProviderUserId());
         final List<String> answers = List.of("답변1", "답변2", "답변3", "답변4", "답변5", "답변6");
         retrospectService.createRetrospect(credentialToken, savedPairRoom.getAccessCode(), answers);
 
@@ -128,9 +128,9 @@ class RetrospectServiceTest {
     @Test
     void notExistPairRoomByAccessCode() {
         // Given
-        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
+        final MemberEntity savedMemberEntity = memberRepository.save(MemberDummy.createDummy());
 
-        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
+        final String credentialToken = jwtProvider.sign(savedMemberEntity.getProviderUserId());
         final String pairRoomAccessCode = "kelly-code";
         final List<String> answers = List.of("답변1", "답변2", "답변3", "답변4", "답변5", "답변6", "답변7");
 
@@ -143,11 +143,11 @@ class RetrospectServiceTest {
     @Test
     void notJoinPairRoomAndMember() {
         // Given
-        final Member dummy1 = MemberDummy.createDummy("username1", "access1", "userid1", "login1");
-        final Member dummy2 = MemberDummy.createDummy("username2", "access2", "userid2", "login2");
+        final MemberEntity dummy1 = MemberDummy.createDummy("username1", "access1", "userid1", "login1");
+        final MemberEntity dummy2 = MemberDummy.createDummy("username2", "access2", "userid2", "login2");
 
-        final Member savedMember1 = memberRepository.save(dummy1);
-        final Member savedMember2 = memberRepository.save(dummy2);
+        final MemberEntity savedMember1Entity = memberRepository.save(dummy1);
+        final MemberEntity savedMember2Entity = memberRepository.save(dummy2);
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -155,9 +155,9 @@ class RetrospectServiceTest {
                         new AccessCode("123456"),
                         EASY_ACCESS_CODE_INK_REDDY)
         ));
-        pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember1));
+        pairRoomMemberRepository.save(new PairRoomMember(savedPairRoom, savedMember1Entity));
 
-        final String credentialToken = jwtProvider.sign(savedMember2.getProviderUserId());
+        final String credentialToken = jwtProvider.sign(savedMember2Entity.getProviderUserId());
         final String pairRoomAccessCode = "123456";
         final List<String> answers = List.of("답변1", "답변2", "답변3", "답변4", "답변5", "답변6", "답변7");
 
@@ -170,7 +170,7 @@ class RetrospectServiceTest {
     @Test
     void findAllRetrospectsByMember() {
         // Given
-        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
+        final MemberEntity savedMemberEntity = memberRepository.save(MemberDummy.createDummy());
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -179,8 +179,8 @@ class RetrospectServiceTest {
                         EASY_ACCESS_CODE_INK_REDDY)
         ));
         pairRoomMemberRepository.save(
-                new PairRoomMemberEntity(savedPairRoom, savedMember));
-        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
+                new PairRoomMember(savedPairRoom, savedMemberEntity));
+        final String credentialToken = jwtProvider.sign(savedMemberEntity.getProviderUserId());
         final String pairRoomAccessCode = "123456";
         final List<String> answers = List.of("답변1", "답변2", "답변3", "답변4", "답변5", "답변6");
         retrospectService.createRetrospect(credentialToken, pairRoomAccessCode, answers);
@@ -197,11 +197,11 @@ class RetrospectServiceTest {
     @Test
     void deleteRetrospectWhoNotOwner() {
         // Given
-        final Member dummy1 = MemberDummy.createDummy("username1", "access1", "userid1", "login1");
-        final Member dummy2 = MemberDummy.createDummy("username2", "access2", "userid2", "login2");
+        final MemberEntity dummy1 = MemberDummy.createDummy("username1", "access1", "userid1", "login1");
+        final MemberEntity dummy2 = MemberDummy.createDummy("username2", "access2", "userid2", "login2");
 
-        final Member owner = memberRepository.save(dummy1);
-        final Member other = memberRepository.save(dummy2);
+        final MemberEntity owner = memberRepository.save(dummy1);
+        final MemberEntity other = memberRepository.save(dummy2);
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -209,7 +209,7 @@ class RetrospectServiceTest {
                         new AccessCode("123456"),
                         EASY_ACCESS_CODE_INK_REDDY)
         ));
-        pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, owner));
+        pairRoomMemberRepository.save(new PairRoomMember(savedPairRoom, owner));
         final String ownerCredentialToken = jwtProvider.sign(owner.getProviderUserId());
         final String otherCredentialToken = jwtProvider.sign(other.getProviderUserId());
 
@@ -226,7 +226,7 @@ class RetrospectServiceTest {
     @DisplayName("입력된 페어룸, 회원 정보를 가진 회고가 DB에 존재하는지 여부를 반환한다.")
     @Test
     void existRetrospectWithPairRoom() {
-        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
+        final MemberEntity savedMemberEntity = memberRepository.save(MemberDummy.createDummy());
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -234,8 +234,8 @@ class RetrospectServiceTest {
                         new AccessCode("123456"),
                         EASY_ACCESS_CODE_INK_REDDY)
         ));
-        pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember));
-        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
+        pairRoomMemberRepository.save(new PairRoomMember(savedPairRoom, savedMemberEntity));
+        final String credentialToken = jwtProvider.sign(savedMemberEntity.getProviderUserId());
         final String pairRoomAccessCode = "123456";
         final List<String> answers = List.of("답변1", "답변2", "답변3", "답변4", "답변5", "답변6");
         retrospectService.createRetrospect(credentialToken, pairRoomAccessCode, answers);
@@ -250,7 +250,7 @@ class RetrospectServiceTest {
     @DisplayName("회고를 입력하지 않은 경우 false를 반환한다.")
     @Test
     void notExistRetrospectWithPairRoom() {
-        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
+        final MemberEntity savedMemberEntity = memberRepository.save(MemberDummy.createDummy());
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -258,8 +258,8 @@ class RetrospectServiceTest {
                         new AccessCode("123456"),
                         EASY_ACCESS_CODE_INK_REDDY)
         ));
-        pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember));
-        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
+        pairRoomMemberRepository.save(new PairRoomMember(savedPairRoom, savedMemberEntity));
+        final String credentialToken = jwtProvider.sign(savedMemberEntity.getProviderUserId());
 
         // When
         retrospectService.createRetrospect(credentialToken, savedPairRoom.getAccessCode(),
@@ -275,7 +275,7 @@ class RetrospectServiceTest {
     @DisplayName("회고를 하나 이상 입력한 경우 true를 반환한다.")
     @Test
     void oneExistRetrospectWithPairRoom() {
-        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
+        final MemberEntity savedMemberEntity = memberRepository.save(MemberDummy.createDummy());
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -283,8 +283,8 @@ class RetrospectServiceTest {
                         new AccessCode("123456"),
                         EASY_ACCESS_CODE_INK_REDDY)
         ));
-        pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember));
-        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
+        pairRoomMemberRepository.save(new PairRoomMember(savedPairRoom, savedMemberEntity));
+        final String credentialToken = jwtProvider.sign(savedMemberEntity.getProviderUserId());
 
         retrospectService.createRetrospect(credentialToken, savedPairRoom.getAccessCode(),
                 List.of("답변!", "", "", "", "", ""));

--- a/backend/src/test/java/site/coduo/retrospect/service/RetrospectServiceTest.java
+++ b/backend/src/test/java/site/coduo/retrospect/service/RetrospectServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import site.coduo.member.domain.Member;
 import site.coduo.member.domain.repository.MemberRepository;
 import site.coduo.member.infrastructure.security.JwtProvider;
+import site.coduo.member.support.MemberDummy;
 import site.coduo.pairroom.domain.MissionUrl;
 import site.coduo.pairroom.domain.Pair;
 import site.coduo.pairroom.domain.PairName;
@@ -71,15 +72,7 @@ class RetrospectServiceTest {
     @Test
     void createRetrospect() {
         // Given
-        final Member savedMember = memberRepository.save(
-                Member.builder()
-                        .userId("userid")
-                        .accessToken("access")
-                        .loginId("login")
-                        .username("username")
-                        .profileImage("some image")
-                        .build()
-        );
+        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -90,7 +83,7 @@ class RetrospectServiceTest {
         final PairRoomMemberEntity pairRoomMember = pairRoomMemberRepository.save(
                 new PairRoomMemberEntity(savedPairRoom, savedMember));
 
-        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
         final String pairRoomAccessCode = "123456";
         final List<String> answers = List.of("답변1", "답변2", "답변3", "답변4", "답변5", "답변6");
 
@@ -109,15 +102,7 @@ class RetrospectServiceTest {
     @Test
     void createTwiceRetrospect() {
         // Given
-        final Member savedMember = memberRepository.save(
-                Member.builder()
-                        .userId("userid")
-                        .accessToken("access")
-                        .loginId("login")
-                        .username("username")
-                        .profileImage("some image")
-                        .build()
-        );
+        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -127,7 +112,7 @@ class RetrospectServiceTest {
         ));
         pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember));
 
-        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
         final List<String> answers = List.of("답변1", "답변2", "답변3", "답변4", "답변5", "답변6");
         retrospectService.createRetrospect(credentialToken, savedPairRoom.getAccessCode(), answers);
 
@@ -143,17 +128,9 @@ class RetrospectServiceTest {
     @Test
     void notExistPairRoomByAccessCode() {
         // Given
-        final Member savedMember = memberRepository.save(
-                Member.builder()
-                        .userId("userid")
-                        .accessToken("access")
-                        .loginId("login")
-                        .username("username")
-                        .profileImage("some image")
-                        .build()
-        );
+        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
 
-        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
         final String pairRoomAccessCode = "kelly-code";
         final List<String> answers = List.of("답변1", "답변2", "답변3", "답변4", "답변5", "답변6", "답변7");
 
@@ -166,24 +143,11 @@ class RetrospectServiceTest {
     @Test
     void notJoinPairRoomAndMember() {
         // Given
-        final Member savedMember1 = memberRepository.save(
-                Member.builder()
-                        .userId("userid1")
-                        .accessToken("access1")
-                        .loginId("login1")
-                        .username("username1")
-                        .profileImage("some image")
-                        .build()
-        );
-        final Member savedMember2 = memberRepository.save(
-                Member.builder()
-                        .userId("userid2")
-                        .accessToken("access2")
-                        .loginId("login2")
-                        .username("username2")
-                        .profileImage("some image")
-                        .build()
-        );
+        final Member dummy1 = MemberDummy.createDummy("username1", "access1", "userid1", "login1");
+        final Member dummy2 = MemberDummy.createDummy("username2", "access2", "userid2", "login2");
+
+        final Member savedMember1 = memberRepository.save(dummy1);
+        final Member savedMember2 = memberRepository.save(dummy2);
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -193,7 +157,7 @@ class RetrospectServiceTest {
         ));
         pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember1));
 
-        final String credentialToken = jwtProvider.sign(savedMember2.getUserId());
+        final String credentialToken = jwtProvider.sign(savedMember2.getProviderUserId());
         final String pairRoomAccessCode = "123456";
         final List<String> answers = List.of("답변1", "답변2", "답변3", "답변4", "답변5", "답변6", "답변7");
 
@@ -206,15 +170,7 @@ class RetrospectServiceTest {
     @Test
     void findAllRetrospectsByMember() {
         // Given
-        final Member savedMember = memberRepository.save(
-                Member.builder()
-                        .userId("userid")
-                        .accessToken("access")
-                        .loginId("login")
-                        .username("username")
-                        .profileImage("some image")
-                        .build()
-        );
+        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -224,7 +180,7 @@ class RetrospectServiceTest {
         ));
         pairRoomMemberRepository.save(
                 new PairRoomMemberEntity(savedPairRoom, savedMember));
-        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
         final String pairRoomAccessCode = "123456";
         final List<String> answers = List.of("답변1", "답변2", "답변3", "답변4", "답변5", "답변6");
         retrospectService.createRetrospect(credentialToken, pairRoomAccessCode, answers);
@@ -241,24 +197,11 @@ class RetrospectServiceTest {
     @Test
     void deleteRetrospectWhoNotOwner() {
         // Given
-        final Member owner = memberRepository.save(
-                Member.builder()
-                        .userId("userid1")
-                        .accessToken("access1")
-                        .loginId("login1")
-                        .username("username1")
-                        .profileImage("some image1")
-                        .build()
-        );
-        final Member other = memberRepository.save(
-                Member.builder()
-                        .userId("userid2")
-                        .accessToken("access2")
-                        .loginId("login2")
-                        .username("username3")
-                        .profileImage("some image2")
-                        .build()
-        );
+        final Member dummy1 = MemberDummy.createDummy("username1", "access1", "userid1", "login1");
+        final Member dummy2 = MemberDummy.createDummy("username2", "access2", "userid2", "login2");
+
+        final Member owner = memberRepository.save(dummy1);
+        final Member other = memberRepository.save(dummy2);
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -267,8 +210,8 @@ class RetrospectServiceTest {
                         EASY_ACCESS_CODE_INK_REDDY)
         ));
         pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, owner));
-        final String ownerCredentialToken = jwtProvider.sign(owner.getUserId());
-        final String otherCredentialToken = jwtProvider.sign(other.getUserId());
+        final String ownerCredentialToken = jwtProvider.sign(owner.getProviderUserId());
+        final String otherCredentialToken = jwtProvider.sign(other.getProviderUserId());
 
         final String pairRoomAccessCode = "123456";
         final List<String> answers = List.of("답변1", "답변2", "답변3", "답변4", "답변5", "답변6");
@@ -283,15 +226,7 @@ class RetrospectServiceTest {
     @DisplayName("입력된 페어룸, 회원 정보를 가진 회고가 DB에 존재하는지 여부를 반환한다.")
     @Test
     void existRetrospectWithPairRoom() {
-        final Member savedMember = memberRepository.save(
-                Member.builder()
-                        .userId("userid")
-                        .accessToken("access")
-                        .loginId("login")
-                        .username("username")
-                        .profileImage("some image")
-                        .build()
-        );
+        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -300,7 +235,7 @@ class RetrospectServiceTest {
                         EASY_ACCESS_CODE_INK_REDDY)
         ));
         pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember));
-        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
         final String pairRoomAccessCode = "123456";
         final List<String> answers = List.of("답변1", "답변2", "답변3", "답변4", "답변5", "답변6");
         retrospectService.createRetrospect(credentialToken, pairRoomAccessCode, answers);
@@ -315,15 +250,7 @@ class RetrospectServiceTest {
     @DisplayName("회고를 입력하지 않은 경우 false를 반환한다.")
     @Test
     void notExistRetrospectWithPairRoom() {
-        final Member savedMember = memberRepository.save(
-                Member.builder()
-                        .userId("userid")
-                        .accessToken("access")
-                        .loginId("login")
-                        .username("username")
-                        .profileImage("some image")
-                        .build()
-        );
+        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -332,7 +259,7 @@ class RetrospectServiceTest {
                         EASY_ACCESS_CODE_INK_REDDY)
         ));
         pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember));
-        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
 
         // When
         retrospectService.createRetrospect(credentialToken, savedPairRoom.getAccessCode(),
@@ -348,15 +275,7 @@ class RetrospectServiceTest {
     @DisplayName("회고를 하나 이상 입력한 경우 true를 반환한다.")
     @Test
     void oneExistRetrospectWithPairRoom() {
-        final Member savedMember = memberRepository.save(
-                Member.builder()
-                        .userId("userid")
-                        .accessToken("access")
-                        .loginId("login")
-                        .username("username")
-                        .profileImage("some image")
-                        .build()
-        );
+        final Member savedMember = memberRepository.save(MemberDummy.createDummy());
         final PairRoomEntity savedPairRoom = pairRoomRepository.save(PairRoomEntity.from(
                 new PairRoom(PairRoomStatus.IN_PROGRESS,
                         new Pair(new PairName("레디"), new PairName("파슬리")),
@@ -365,7 +284,7 @@ class RetrospectServiceTest {
                         EASY_ACCESS_CODE_INK_REDDY)
         ));
         pairRoomMemberRepository.save(new PairRoomMemberEntity(savedPairRoom, savedMember));
-        final String credentialToken = jwtProvider.sign(savedMember.getUserId());
+        final String credentialToken = jwtProvider.sign(savedMember.getProviderUserId());
 
         retrospectService.createRetrospect(credentialToken, savedPairRoom.getAccessCode(),
                 List.of("답변!", "", "", "", "", ""));


### PR DESCRIPTION
## 연관된 이슈

- closes: #952 

## 구현한 기능
1. 미사용 profileImage 컬럼 삭제
2. 깃허브 측에서 받는 데이터는 Provider 접두사 붙힘
3. Member 도메인 테스트 더미 값 test/java/src/~~/ member/support 패키지에 묵어둠  

## 상세 설명
테스트 총 실행 시간: 13초 388
<img width="1595" alt="image" src="https://github.com/user-attachments/assets/bbe832be-f4fd-42b7-8314-183ea909e91d">
에서 
<img width="1309" alt="image" src="https://github.com/user-attachments/assets/ee67cc30-2f05-41de-aa69-cde3faf09077">
7초 536으로 개선

1. 레퍼런스 생성 시 Jsoup으로 실제 Html 호출을 Fake객체로 테스팅 시 호출 막음. 5초 가량 개선
2.SSE (이젠 안쓰이겠지만.. ) Fake 객체 Timeout Duration 500ms -> 1ms으로 변경. 2초가량 개선 
