### PR TITLE
[BE] 핸들링 되고 있지 않은 커스텀 에러 핸들러 추가

### DIFF
--- a/backend/src/main/java/site/coduo/member/controller/MemberExceptionHandler.java
+++ b/backend/src/main/java/site/coduo/member/controller/MemberExceptionHandler.java
@@ -9,8 +9,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import lombok.extern.slf4j.Slf4j;
 import site.coduo.common.controller.response.ApiErrorResponse;
 import site.coduo.member.controller.error.MemberApiError;
+import site.coduo.member.exception.AuthenticationException;
 import site.coduo.member.exception.ExternalApiCallException;
 import site.coduo.member.exception.InvalidMemberAddException;
+import site.coduo.member.exception.MemberException;
 import site.coduo.member.exception.MemberNotFoundException;
 
 @Slf4j
@@ -40,5 +42,21 @@ public class MemberExceptionHandler {
 
         return ResponseEntity.status(MemberApiError.API_CALL_FAILURE_ERROR.getHttpStatus())
                 .body(new ApiErrorResponse(MemberApiError.MEMBER_NOT_FOUND_ERROR.getMessage()));
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ApiErrorResponse> handlerAuthenticationException(final AuthenticationException e) {
+        log.error(e.getMessage());
+
+        return ResponseEntity.status(MemberApiError.AUTHENTICATION_ERROR.getHttpStatus())
+                .body(new ApiErrorResponse(MemberApiError.AUTHENTICATION_ERROR.getMessage()));
+    }
+
+    @ExceptionHandler(MemberException.class)
+    public ResponseEntity<ApiErrorResponse> handlerMemberException(final MemberException e) {
+        log.error(e.getMessage());
+
+        return ResponseEntity.status(MemberApiError.INVALID_MEMBER_REQUEST.getHttpStatus())
+                .body(new ApiErrorResponse(MemberApiError.INVALID_MEMBER_REQUEST.getMessage()));
     }
 }

--- a/backend/src/main/java/site/coduo/member/controller/error/MemberApiError.java
+++ b/backend/src/main/java/site/coduo/member/controller/error/MemberApiError.java
@@ -12,7 +12,8 @@ public enum MemberApiError {
     AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, "인증되지 않은 접근입니다."),
     MEMBER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
     INVALID_ADD_MEMBER_ERROR(HttpStatus.BAD_REQUEST, "자신의 아이디로 페어 정보 연동을 할 수 없습니다."),
-    API_CALL_FAILURE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "외부 API와 상호작용 중 실패했습니다.");
+    API_CALL_FAILURE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "외부 API와 상호작용 중 실패했습니다."),
+    INVALID_MEMBER_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않은 사용자 관련 요청입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/site/coduo/pairroom/controller/PairRoomExceptionHandler.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/PairRoomExceptionHandler.java
@@ -88,7 +88,7 @@ public class PairRoomExceptionHandler {
     public ResponseEntity<ApiErrorResponse> handlePairRoomException(final PairRoomException e) {
         log.warn(e.getMessage());
 
-        return ResponseEntity.status(PairRoomApiError.INVALID_REQUEST.getHttpStatus())
-                .body(new ApiErrorResponse(PairRoomApiError.INVALID_REQUEST.getMessage()));
+        return ResponseEntity.status(PairRoomApiError.INVALID_PAIR_ROOM_REQUEST.getHttpStatus())
+                .body(new ApiErrorResponse(PairRoomApiError.INVALID_PAIR_ROOM_REQUEST.getMessage()));
     }
 }

--- a/backend/src/main/java/site/coduo/pairroom/controller/error/PairRoomApiError.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/error/PairRoomApiError.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PairRoomApiError {
 
-    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않은 요청입니다."),
+    INVALID_PAIR_ROOM_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않은 페어룸 관련 요청입니다."),
     INVALID_PAIR_NAME(HttpStatus.BAD_REQUEST, "올바르지 않은 페어 이름입니다."),
     INVALID_ACCESS_CODE(HttpStatus.BAD_REQUEST, "올바르지 않은 접근 코드입니다."),
     PAIR_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "페어룸이 존재하지 않습니다."),

--- a/backend/src/main/java/site/coduo/referencelink/controller/ReferenceLinkExceptionHandler.java
+++ b/backend/src/main/java/site/coduo/referencelink/controller/ReferenceLinkExceptionHandler.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import lombok.extern.slf4j.Slf4j;
 import site.coduo.common.controller.response.ApiErrorResponse;
 import site.coduo.referencelink.controller.error.ReferenceLinkApiError;
+import site.coduo.referencelink.exception.CategoryNotFoundException;
+import site.coduo.referencelink.exception.InvalidCategoryException;
 import site.coduo.referencelink.exception.InvalidUrlFormatException;
 import site.coduo.referencelink.exception.ReferenceLinkException;
 
@@ -23,6 +25,22 @@ public class ReferenceLinkExceptionHandler {
 
         return ResponseEntity.status(ReferenceLinkApiError.INVALID_URL_FORMAT.getHttpStatus())
                 .body(new ApiErrorResponse(ReferenceLinkApiError.INVALID_URL_FORMAT.getMessage()));
+    }
+
+    @ExceptionHandler(CategoryNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleCategoryNotFoundException(final CategoryNotFoundException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(ReferenceLinkApiError.CATEGORY_NOT_FOUND.getHttpStatus())
+                .body(new ApiErrorResponse(ReferenceLinkApiError.CATEGORY_NOT_FOUND.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidCategoryException.class)
+    public ResponseEntity<ApiErrorResponse> handleInvalidCategoryException(final InvalidCategoryException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(ReferenceLinkApiError.INVALID_CATEGORY_FORMAT.getHttpStatus())
+                .body(new ApiErrorResponse(ReferenceLinkApiError.INVALID_CATEGORY_FORMAT.getMessage()));
     }
 
     @ExceptionHandler(ReferenceLinkException.class)

--- a/backend/src/main/java/site/coduo/referencelink/controller/error/ReferenceLinkApiError.java
+++ b/backend/src/main/java/site/coduo/referencelink/controller/error/ReferenceLinkApiError.java
@@ -11,7 +11,9 @@ public enum ReferenceLinkApiError {
 
     INVALID_URL_FORMAT(HttpStatus.BAD_REQUEST, "올바르지 않은 URL 형식입니다."),
     REFERENCE_LINK_NOT_FOUND(HttpStatus.NOT_FOUND, "링크 정보가 존재하지 않습니다."),
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않은 요청입니다.");
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
+    INVALID_CATEGORY_FORMAT(HttpStatus.BAD_REQUEST, "올바르지 않은 카테고리 형식입니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않은 카테고리 혹은 레퍼런스 링크 요청입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/site/coduo/retrospect/exception/RetrospectException.java
+++ b/backend/src/main/java/site/coduo/retrospect/exception/RetrospectException.java
@@ -5,8 +5,4 @@ public class RetrospectException extends RuntimeException {
     public RetrospectException(final String message) {
         super(message);
     }
-
-    public RetrospectException(final String message, final Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/backend/src/main/java/site/coduo/timer/exception/NegativeTimeException.java
+++ b/backend/src/main/java/site/coduo/timer/exception/NegativeTimeException.java
@@ -1,8 +1,0 @@
-package site.coduo.timer.exception;
-
-public class NegativeTimeException extends TimerException{
-
-    public NegativeTimeException(final String message) {
-        super(message);
-    }
-}

--- a/backend/src/main/java/site/coduo/todo/controller/TodoExceptionHandler.java
+++ b/backend/src/main/java/site/coduo/todo/controller/TodoExceptionHandler.java
@@ -9,18 +9,46 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import lombok.extern.slf4j.Slf4j;
 import site.coduo.common.controller.response.ApiErrorResponse;
 import site.coduo.todo.controller.error.TodoApiError;
+import site.coduo.todo.exception.InvalidTodoContentException;
+import site.coduo.todo.exception.InvalidUpdatedTodoSortException;
 import site.coduo.todo.exception.TodoException;
+import site.coduo.todo.exception.TodoNotFoundException;
 
 @Slf4j
 @RestControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class TodoExceptionHandler {
 
+    @ExceptionHandler(InvalidTodoContentException.class)
+    public ResponseEntity<ApiErrorResponse> handleInvalidTodoContentException(final InvalidTodoContentException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(TodoApiError.INVALID_TODO_CONTENT_FORMAT.getHttpStatus())
+                .body(new ApiErrorResponse(TodoApiError.INVALID_TODO_CONTENT_FORMAT.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidUpdatedTodoSortException.class)
+    public ResponseEntity<ApiErrorResponse> handleInvalidUpdatedTodoSortException(
+            final InvalidUpdatedTodoSortException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(TodoApiError.INVALID_TODO_SORT.getHttpStatus())
+                .body(new ApiErrorResponse(TodoApiError.INVALID_TODO_SORT.getMessage()));
+    }
+
+    @ExceptionHandler(TodoNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleTodoNotFoundException(final TodoNotFoundException e) {
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(TodoApiError.TODO_NOT_FOUND.getHttpStatus())
+                .body(new ApiErrorResponse(TodoApiError.TODO_NOT_FOUND.getMessage()));
+    }
+
     @ExceptionHandler(TodoException.class)
     public ResponseEntity<ApiErrorResponse> handleTodoException(final TodoException e) {
         log.warn(e.getMessage());
 
         return ResponseEntity.status(TodoApiError.INVALID_TODO_REQUEST.getHttpStatus())
-                .body(new ApiErrorResponse(e.getMessage()));
+                .body(new ApiErrorResponse(TodoApiError.INVALID_TODO_REQUEST.getMessage()));
     }
 }

--- a/backend/src/main/java/site/coduo/todo/controller/error/TodoApiError.java
+++ b/backend/src/main/java/site/coduo/todo/controller/error/TodoApiError.java
@@ -9,6 +9,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum TodoApiError {
 
+    TODO_NOT_FOUND(HttpStatus.NOT_FOUND, "투두를 찾을 수 없습니다."),
+    INVALID_TODO_SORT(HttpStatus.BAD_REQUEST, "유효하지 않은 투두 순서입니다."),
+    INVALID_TODO_CONTENT_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 투두 내용 형식입니다."),
     INVALID_TODO_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않은 TODO 요청입니다.");
 
     private final HttpStatus httpStatus;

--- a/backend/src/main/java/site/coduo/todo/exception/InvalidTodoArgumentException.java
+++ b/backend/src/main/java/site/coduo/todo/exception/InvalidTodoArgumentException.java
@@ -1,8 +1,0 @@
-package site.coduo.todo.exception;
-
-public class InvalidTodoArgumentException extends TodoException {
-
-    public InvalidTodoArgumentException(final String message) {
-        super(message);
-    }
-}


### PR DESCRIPTION
## 연관된 이슈

- closes: #958 

## 구현한 기능
- 핸들링 되고 있지 않은 예외 핸들러에 추가
- 사용되고 있지 않은 예외 삭제

## 상세 설명
- 레퍼런스 링크의 `DocumentAccessException`는 예외 발생 시 catch 하여 외부로 나가지 않는 예외이기 때문에 핸들러에 추가하지 않았습니다.