### PR TITLE
[FE] TextButton 공통 컴포넌트 구현

### DIFF
--- a/frontend/src/components/PairRoomOnboarding/PairNameInput/PairNameInput.styles.ts
+++ b/frontend/src/components/PairRoomOnboarding/PairNameInput/PairNameInput.styles.ts
@@ -32,18 +32,6 @@ export const InputWrapper = styled.div`
   gap: 2rem;
 `;
 
-export const TextButton = styled.button`
-  color: ${({ theme }) => theme.color.black[600]};
-  font-size: ${({ theme }) => theme.fontSize.sm};
-  text-decoration: underline;
-
-  transition: all 0.2s;
-
-  &:hover {
-    color: ${({ theme }) => theme.color.black[600]};
-  }
-`;
-
 export const AddButton = styled.button`
   display: flex;
   align-items: center;

--- a/frontend/src/components/PairRoomOnboarding/PairNameInput/PairNameInput.tsx
+++ b/frontend/src/components/PairRoomOnboarding/PairNameInput/PairNameInput.tsx
@@ -6,6 +6,7 @@ import { LogoIcon } from '@/assets';
 import Button from '@/components/_common/Button/Button';
 import { InputField } from '@/components/_common/InputField';
 import { InputType } from '@/components/_common/InputField/Input.type';
+import TextButton from '@/components/_common/TextButton/TextButton';
 
 import { theme } from '@/styles/theme';
 
@@ -89,7 +90,13 @@ const PairNameInput = ({
               </div>
               <p>페어 정보 연동하기</p>
             </S.AddButton>
-            <S.TextButton onClick={() => setIsInputOpen(true)}>연동 없이 시작하기</S.TextButton>
+            <TextButton
+              text="연동 없이 시작하기"
+              onClick={() => setIsInputOpen(true)}
+              underline={true}
+              color={theme.color.black[600]}
+              size="sm"
+            />
           </>
         )}
       </InputField>

--- a/frontend/src/components/PairRoomOnboarding/PairNameInput/PairNameInput.tsx
+++ b/frontend/src/components/PairRoomOnboarding/PairNameInput/PairNameInput.tsx
@@ -94,8 +94,9 @@ const PairNameInput = ({
               text="연동 없이 시작하기"
               onClick={() => setIsInputOpen(true)}
               underline={true}
-              color={theme.color.black[600]}
+              color={theme.color.black[400]}
               size="sm"
+              hoverType="DARK"
             />
           </>
         )}

--- a/frontend/src/components/_common/Header/Header.styles.ts
+++ b/frontend/src/components/_common/Header/Header.styles.ts
@@ -22,26 +22,6 @@ export const Layout = styled.div`
 
   border-bottom: 0.1rem solid ${({ theme }) => theme.color.black[300]};
 
-  a,
-  button {
-    justify-content: center;
-    align-items: center;
-
-    transition: all 0.1s;
-
-    cursor: pointer;
-
-    &:hover {
-      opacity: 0.7;
-      text-decoration: underline;
-    }
-
-    &:active {
-      opacity: 0.5;
-      text-decoration: underline;
-    }
-  }
-
   @media (max-width: ${({ theme }) => theme.deviceWidth.mobile}) {
     padding: 0 8vw;
   }
@@ -50,6 +30,16 @@ export const Layout = styled.div`
 export const Logo = styled.img`
   width: 3.6rem;
   height: 3.6rem;
+
+  transition: all 0.1s;
+
+  &:hover {
+    opacity: 0.7;
+  }
+
+  &:active {
+    opacity: 0.5;
+  }
 `;
 
 export const LinkContainer = styled.div`
@@ -72,16 +62,5 @@ export const ResponsiveIcon = styled.div`
 
   @media (max-width: ${({ theme }) => theme.deviceWidth.mobile}) {
     display: inline;
-  }
-`;
-
-export const HowToPairIcon = styled.div`
-  display: none;
-
-  color: ${({ theme }) => theme.color.primary[900]};
-
-  @media (max-width: ${({ theme }) => theme.deviceWidth.mobile}) {
-    display: flex;
-    align-items: center;
   }
 `;

--- a/frontend/src/components/_common/Header/Header.tsx
+++ b/frontend/src/components/_common/Header/Header.tsx
@@ -29,7 +29,7 @@ const Header = () => {
       </Link>
       <S.LinkContainer>
         <S.ResponsiveLink to="/coduo-docs" aria-label="코딩해듀오 시작하기로 이동">
-          <TextButton text="코딩해듀오 시작하기" opacity={true} />
+          <TextButton text="코딩해듀오 시작하기" />
         </S.ResponsiveLink>
         <S.ResponsiveIcon>
           <Link to="/coduo-docs" aria-label="코딩해듀오 시작하기로 이동">
@@ -38,13 +38,13 @@ const Header = () => {
         </S.ResponsiveIcon>
         {userStatus === 'SIGNED_IN' ? (
           <>
-            <TextButton text="로그아웃" onClick={handleSignOut} opacity={true} />
+            <TextButton text="로그아웃" onClick={handleSignOut} />
             <Link to="/my-page" aria-label={`${username}의 마이페이지로 이동`}>
               <span aria-hidden="true">{username}</span>
             </Link>
           </>
         ) : (
-          <TextButton text="Github로 로그인" onClick={handleSignInGithub} opacity={true} />
+          <TextButton text="Github로 로그인" onClick={handleSignInGithub} />
         )}
       </S.LinkContainer>
     </S.Layout>

--- a/frontend/src/components/_common/Header/Header.tsx
+++ b/frontend/src/components/_common/Header/Header.tsx
@@ -4,6 +4,9 @@ import { FaBook } from 'react-icons/fa';
 
 import { LogoIcon } from '@/assets';
 
+import IconButton from '@/components/_common/IconButton/IconButton';
+import TextButton from '@/components/_common/TextButton/TextButton';
+
 import useUserStore from '@/stores/userStore';
 
 import useSignInHandler from '@/hooks/_common/member/useSignInHandler';
@@ -26,22 +29,22 @@ const Header = () => {
       </Link>
       <S.LinkContainer>
         <S.ResponsiveLink to="/coduo-docs" aria-label="코딩해듀오 시작하기로 이동">
-          <span aria-hidden="true">코딩해듀오 시작하기</span>
+          <TextButton text="코딩해듀오 시작하기" opacity={true} />
         </S.ResponsiveLink>
         <S.ResponsiveIcon>
           <Link to="/coduo-docs" aria-label="코딩해듀오 시작하기로 이동">
-            <FaBook size={theme.iconSize.sm} aria-hidden="true" />
+            <IconButton icon={<FaBook size={theme.iconSize.sm} aria-hidden="true" />} size="sm" />
           </Link>
         </S.ResponsiveIcon>
         {userStatus === 'SIGNED_IN' ? (
           <>
-            <button onClick={handleSignOut}>로그아웃</button>
+            <TextButton text="로그아웃" onClick={handleSignOut} opacity={true} />
             <Link to="/my-page" aria-label={`${username}의 마이페이지로 이동`}>
               <span aria-hidden="true">{username}</span>
             </Link>
           </>
         ) : (
-          <button onClick={handleSignInGithub}>Github로 로그인</button>
+          <TextButton text="Github로 로그인" onClick={handleSignInGithub} opacity={true} />
         )}
       </S.LinkContainer>
     </S.Layout>

--- a/frontend/src/components/_common/IconButton/IconButton.tsx
+++ b/frontend/src/components/_common/IconButton/IconButton.tsx
@@ -12,32 +12,19 @@ interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> 
   color?: string;
   backgroundColor?: string;
   disabled?: boolean;
-  onClick?: () => void;
 }
 
 const IconButton = ({
   icon,
   size = 'md',
   $css,
-  onClick,
   color = '#000000',
   backgroundColor = '#FFFFFF',
   disabled = false,
   ...props
 }: IconButtonProps) => {
   return (
-    <S.Layout
-      $css={$css}
-      $size={size}
-      $color={color}
-      $backgroundColor={backgroundColor}
-      disabled={disabled}
-      onClick={(event) => {
-        event.stopPropagation();
-        onClick?.();
-      }}
-      {...props}
-    >
+    <S.Layout $css={$css} $size={size} $color={color} $backgroundColor={backgroundColor} disabled={disabled} {...props}>
       {icon}
     </S.Layout>
   );

--- a/frontend/src/components/_common/TextButton/TextButton.stories.tsx
+++ b/frontend/src/components/_common/TextButton/TextButton.stories.tsx
@@ -33,5 +33,5 @@ CustomButton.args = {
   size: 'md',
   color: '#a21321',
   underline: true,
-  opacity: true,
+  hoverType: 'DARK',
 };

--- a/frontend/src/components/_common/TextButton/TextButton.stories.tsx
+++ b/frontend/src/components/_common/TextButton/TextButton.stories.tsx
@@ -1,0 +1,37 @@
+import { Meta, StoryFn } from '@storybook/react';
+
+import TextButton from '@/components/_common/TextButton/TextButton';
+import { TextButtonProps } from '@/components/_common/TextButton/TextButton.type';
+
+export default {
+  title: 'component/common/TextButton',
+  component: TextButton,
+  argTypes: {
+    size: { control: { type: 'text', options: ['sm', 'md', 'lg', 'xl'] } },
+    color: { control: 'color' },
+    disabled: { control: 'boolean' },
+  },
+} as Meta;
+
+const Template: StoryFn<TextButtonProps> = (args: TextButtonProps) => <TextButton {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  text: '기본 텍스트 버튼',
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  text: 'Github로 로그인',
+  size: 'lg',
+  disabled: true,
+};
+
+export const CustomButton = Template.bind({});
+CustomButton.args = {
+  text: '커스텀 컬러',
+  size: 'md',
+  color: '#a21321',
+  underline: true,
+  opacity: true,
+};

--- a/frontend/src/components/_common/TextButton/TextButton.styles.ts
+++ b/frontend/src/components/_common/TextButton/TextButton.styles.ts
@@ -60,9 +60,19 @@ export const Layout = styled.button<StyleTextButtonProps>`
   }
 
   &:disabled {
-    color: ${theme.color.black[100]};
+    color: ${theme.color.black[500]};
 
     cursor: default;
+
+    &:hover {
+      opacity: none;
+      text-decoration: none;
+    }
+
+    &:active {
+      opacity: none;
+      text-decoration: none;
+    }
   }
 
   ${({ $css }) => $css}

--- a/frontend/src/components/_common/TextButton/TextButton.styles.ts
+++ b/frontend/src/components/_common/TextButton/TextButton.styles.ts
@@ -81,7 +81,7 @@ export const Layout = styled.button<StyleTextButtonProps>`
   color: ${({ $color }) => $color};
   text-decoration: ${({ $underline }) => ($underline ? 'underline' : 'none')};
 
-  transition: all 0.1s;
+  transition: 0.2s;
 
   cursor: pointer;
 

--- a/frontend/src/components/_common/TextButton/TextButton.styles.ts
+++ b/frontend/src/components/_common/TextButton/TextButton.styles.ts
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { StyleTextButtonProps } from '@/components/_common/TextButton/TextButton.type';
+import { HoverType, StyleTextButtonProps } from '@/components/_common/TextButton/TextButton.type';
 
 import { theme } from '@/styles/theme';
 
@@ -37,8 +37,44 @@ const fontSize = ({ $size }: { $size: string }) => {
   `;
 };
 
+const hoverType = ({ $hoverType }: { $hoverType: HoverType }) => {
+  return css`
+    ${(() => {
+      switch ($hoverType) {
+        case 'DARK':
+          return css`
+            &:hover {
+              filter: brightness(0.8);
+
+              text-decoration: underline;
+            }
+
+            &:active {
+              filter: brightness(0.6);
+
+              text-decoration: underline;
+            }
+          `;
+        case 'LIGHT':
+          return css`
+            &:hover {
+              opacity: 0.7;
+              text-decoration: underline;
+            }
+
+            &:active {
+              opacity: 0.5;
+              text-decoration: underline;
+            }
+          `;
+      }
+    })()}
+  `;
+};
+
 export const Layout = styled.button<StyleTextButtonProps>`
   ${fontSize};
+  ${hoverType}
   justify-content: center;
   align-items: center;
 
@@ -49,16 +85,6 @@ export const Layout = styled.button<StyleTextButtonProps>`
 
   cursor: pointer;
 
-  &:hover {
-    opacity: ${({ $opacity }) => ($opacity ? 0.7 : 1)};
-    text-decoration: underline;
-  }
-
-  &:active {
-    opacity: ${({ $opacity }) => ($opacity ? 0.5 : 1)};
-    text-decoration: underline;
-  }
-
   &:disabled {
     color: ${theme.color.black[500]};
 
@@ -67,11 +93,13 @@ export const Layout = styled.button<StyleTextButtonProps>`
     &:hover {
       opacity: none;
       text-decoration: none;
+      filter: none;
     }
 
     &:active {
       opacity: none;
       text-decoration: none;
+      filter: none;
     }
   }
 

--- a/frontend/src/components/_common/TextButton/TextButton.styles.ts
+++ b/frontend/src/components/_common/TextButton/TextButton.styles.ts
@@ -1,0 +1,69 @@
+import styled, { css } from 'styled-components';
+
+import { StyleTextButtonProps } from '@/components/_common/TextButton/TextButton.type';
+
+import { theme } from '@/styles/theme';
+
+const fontSize = ({ $size }: { $size: string }) => {
+  return css`
+    ${(() => {
+      switch ($size) {
+        case 'base':
+          return css`
+            font-size: ${theme.fontSize.base};
+          `;
+        case 'sm':
+          return css`
+            font-size: ${theme.fontSize.sm};
+          `;
+        case 'md':
+          return css`
+            font-size: ${theme.fontSize.md};
+          `;
+        case 'lg':
+          return css`
+            font-size: ${theme.fontSize.lg};
+          `;
+        case 'xl':
+          return css`
+            font-size: ${theme.fontSize.h6};
+          `;
+        default:
+          return css`
+            font-size: ${$size};
+          `;
+      }
+    })()}
+  `;
+};
+
+export const Layout = styled.button<StyleTextButtonProps>`
+  ${fontSize};
+  justify-content: center;
+  align-items: center;
+
+  color: ${({ $color }) => $color};
+  text-decoration: ${({ $underline }) => ($underline ? 'underline' : 'none')};
+
+  transition: all 0.1s;
+
+  cursor: pointer;
+
+  &:hover {
+    opacity: ${({ $opacity }) => ($opacity ? 0.7 : 1)};
+    text-decoration: underline;
+  }
+
+  &:active {
+    opacity: ${({ $opacity }) => ($opacity ? 0.5 : 1)};
+    text-decoration: underline;
+  }
+
+  &:disabled {
+    color: ${theme.color.black[100]};
+
+    cursor: default;
+  }
+
+  ${({ $css }) => $css}
+`;

--- a/frontend/src/components/_common/TextButton/TextButton.tsx
+++ b/frontend/src/components/_common/TextButton/TextButton.tsx
@@ -1,5 +1,7 @@
 import { TextButtonProps } from '@/components/_common/TextButton/TextButton.type';
 
+import { theme } from '@/styles/theme';
+
 import * as S from './TextButton.styles';
 
 const TextButton = ({
@@ -7,7 +9,7 @@ const TextButton = ({
   size = 'base',
   $css,
   onClick,
-  color = '#000000',
+  color = theme.color.black[800],
   disabled = false,
   underline = false,
   opacity = false,

--- a/frontend/src/components/_common/TextButton/TextButton.tsx
+++ b/frontend/src/components/_common/TextButton/TextButton.tsx
@@ -8,7 +8,6 @@ const TextButton = ({
   text,
   size = 'base',
   $css,
-  onClick,
   color = theme.color.black[800],
   disabled = false,
   underline = false,
@@ -23,10 +22,6 @@ const TextButton = ({
       $underline={underline}
       $opacity={opacity}
       disabled={disabled}
-      onClick={(event) => {
-        event.stopPropagation();
-        onClick && onClick();
-      }}
       {...props}
     >
       {text}

--- a/frontend/src/components/_common/TextButton/TextButton.tsx
+++ b/frontend/src/components/_common/TextButton/TextButton.tsx
@@ -1,0 +1,34 @@
+import { TextButtonProps } from '@/components/_common/TextButton/TextButton.type';
+
+import * as S from './TextButton.styles';
+
+const TextButton = ({
+  text,
+  size = 'base',
+  $css,
+  onClick,
+  color = '#000000',
+  disabled = false,
+  underline = false,
+  opacity = false,
+  ...props
+}: TextButtonProps) => {
+  return (
+    <S.Layout
+      $css={$css}
+      $size={size}
+      $color={color}
+      $underline={underline}
+      $opacity={opacity}
+      disabled={disabled}
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick && onClick();
+      }}
+      {...props}
+    >
+      {text}
+    </S.Layout>
+  );
+};
+export default TextButton;

--- a/frontend/src/components/_common/TextButton/TextButton.tsx
+++ b/frontend/src/components/_common/TextButton/TextButton.tsx
@@ -11,7 +11,7 @@ const TextButton = ({
   color = theme.color.black[800],
   disabled = false,
   underline = false,
-  opacity = false,
+  hoverType = 'LIGHT',
   ...props
 }: TextButtonProps) => {
   return (
@@ -20,7 +20,7 @@ const TextButton = ({
       $size={size}
       $color={color}
       $underline={underline}
-      $opacity={opacity}
+      $hoverType={hoverType}
       disabled={disabled}
       {...props}
     >

--- a/frontend/src/components/_common/TextButton/TextButton.type.ts
+++ b/frontend/src/components/_common/TextButton/TextButton.type.ts
@@ -1,0 +1,22 @@
+import { css } from 'styled-components';
+
+type ButtonSize = 'base' | 'sm' | 'md' | 'lg' | 'xl' | string;
+
+export interface TextButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  text: string;
+  size?: ButtonSize;
+  color?: string;
+  $css?: ReturnType<typeof css>;
+  onClick?: () => void;
+  disabled?: boolean;
+  underline?: boolean;
+  opacity?: boolean;
+}
+
+export interface StyleTextButtonProps {
+  $size: ButtonSize;
+  $color: string;
+  $css?: ReturnType<typeof css>;
+  $underline: boolean;
+  $opacity: boolean;
+}

--- a/frontend/src/components/_common/TextButton/TextButton.type.ts
+++ b/frontend/src/components/_common/TextButton/TextButton.type.ts
@@ -7,7 +7,6 @@ export interface TextButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
   size?: ButtonSize;
   color?: string;
   $css?: ReturnType<typeof css>;
-  onClick?: () => void;
   disabled?: boolean;
   underline?: boolean;
   opacity?: boolean;

--- a/frontend/src/components/_common/TextButton/TextButton.type.ts
+++ b/frontend/src/components/_common/TextButton/TextButton.type.ts
@@ -1,7 +1,7 @@
 import { css } from 'styled-components';
 
 type ButtonSize = 'base' | 'sm' | 'md' | 'lg' | 'xl' | string;
-
+export type HoverType = 'LIGHT' | 'DARK';
 export interface TextButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   text: string;
   size?: ButtonSize;
@@ -9,7 +9,7 @@ export interface TextButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
   $css?: ReturnType<typeof css>;
   disabled?: boolean;
   underline?: boolean;
-  opacity?: boolean;
+  hoverType?: HoverType;
 }
 
 export interface StyleTextButtonProps {
@@ -17,5 +17,5 @@ export interface StyleTextButtonProps {
   $color: string;
   $css?: ReturnType<typeof css>;
   $underline: boolean;
-  $opacity: boolean;
+  $hoverType: HoverType;
 }


### PR DESCRIPTION
## 연관된 이슈

- closes: #960 

## 구현한 기능
TextButton 구현 

## 상세 설명
- props : text, size, color, underline, opacity
  - boolean default 는 전부 false 로 했습니다.
  - active, hover 일 때 underline 이 들어가고, underline 에 true 를 넣어주면 hover 상태가 아닐때도 underline이 들어갑니다.
- TextButton 이 Link 태그로 되어있는 부분이 많았는데(코딩해듀오 시작하기, 레포지토리로 이동) 
  Link 로 되어있는 부분들을 Button 으로 바꾸기에는 통일성이 없고, 버튼의 역할과 조금 다른 것 같아서 이 부분은 바꾸지 않았습니다.

---

=> opacity 에서 hoverType 받도록 수정했습니다, default 는 LIGHT입니다