### PR TITLE
[FE] 테스트 서버 색상 수정

### DIFF
--- a/frontend/src/components/PairRoom/GuideModal/GuideModal.stories.tsx
+++ b/frontend/src/components/PairRoom/GuideModal/GuideModal.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import GuideModal from '@/components/PairRoom/GuideModal/GuideModal';
+
+const ACCESS_CODE = 'CODUO';
+
+const meta = {
+  title: 'component/PairRoom/GuideModal',
+  component: GuideModal,
+
+  argTypes: {
+    isOpen: {
+      control: 'boolean',
+    },
+  },
+} satisfies Meta<typeof GuideModal>;
+
+export default meta;
+
+type Story = StoryObj<typeof GuideModal>;
+
+export const Default: Story = {
+  args: {
+    isOpen: true,
+    accessCode: ACCESS_CODE,
+  },
+};

--- a/frontend/src/components/PairRoom/PairListCard/CompleteRoomButton/CompleteRoomButton.stories.tsx
+++ b/frontend/src/components/PairRoom/PairListCard/CompleteRoomButton/CompleteRoomButton.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import CompleteRoomButton from '@/components/PairRoom/PairListCard/CompleteRoomButton/CompleteRoomButton';
+
+import useUserStore from '@/stores/userStore';
+
+const USER_NAME = 'CODUO';
+
+const meta = {
+  title: 'component/PairRoom/PairListCard/CompleteRoomButton',
+  component: CompleteRoomButton,
+  decorators: [
+    (Story) => {
+      const { setUser } = useUserStore.getState();
+      setUser(USER_NAME, 'SIGNED_IN');
+
+      return <Story />;
+    },
+  ],
+  argTypes: {
+    isOpen: {
+      control: 'boolean',
+    },
+  },
+} satisfies Meta<typeof CompleteRoomButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof CompleteRoomButton>;
+
+export const LoggedIn: Story = {
+  args: {
+    isOpen: true,
+  },
+};
+
+export const ClosedLoggedIn: Story = {
+  args: {
+    isOpen: false,
+  },
+};
+
+export const LoggedOut: Story = {
+  decorators: [
+    (Story) => {
+      const { resetUser } = useUserStore.getState();
+      resetUser();
+      return <Story />;
+    },
+  ],
+  args: {
+    isOpen: true,
+  },
+};

--- a/frontend/src/components/PairRoom/PairListCard/CompleteRoomButton/CompleteRoomButton.styles.ts
+++ b/frontend/src/components/PairRoom/PairListCard/CompleteRoomButton/CompleteRoomButton.styles.ts
@@ -17,8 +17,8 @@ export const Layout = styled.button<{ disabled: boolean }>`
   margin-top: auto;
   border-radius: 0 0 2rem 2rem;
 
-  background-color: ${({ theme, disabled }) => (disabled ? theme.color.black[100] : theme.color.danger[200])};
-  color: ${({ theme, disabled }) => (disabled ? theme.color.black[400] : theme.color.danger[600])};
+  background-color: ${({ theme, disabled }) => (disabled ? theme.color.black[100] : theme.color.danger[100])};
+  color: ${({ theme, disabled }) => (disabled ? theme.color.black[400] : theme.color.danger[500])};
   font-size: ${({ theme }) => theme.fontSize.base};
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/frontend/src/components/Retrospect/Textarea/Textarea.stories.tsx
+++ b/frontend/src/components/Retrospect/Textarea/Textarea.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Textarea from '@/components/Retrospect/Textarea/Textarea';
+
+const meta = {
+  title: 'component/Retrospect/Textarea',
+  component: Textarea,
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+
+type Story = StoryObj<typeof Textarea>;
+
+export const Default: Story = {};

--- a/frontend/src/pages/CompletedPairRoom/CompletedPairRoom.styles.ts
+++ b/frontend/src/pages/CompletedPairRoom/CompletedPairRoom.styles.ts
@@ -53,7 +53,7 @@ export const PairInfoWrapper = styled.div`
   padding: 1.2rem 1.5rem;
   border-radius: 1rem;
 
-  background-color: ${({ theme }) => theme.color.black[300]};
+  background-color: ${({ theme }) => theme.color.black[200]};
   color: ${({ theme }) => theme.color.black[700]};
   font-size: ${({ theme }) => theme.fontSize.base};
   font-weight: ${({ theme }) => theme.fontWeight.medium};


### PR DESCRIPTION
## 연관된 이슈

- closes: #973 

## 구현한 기능
색상 변경 및 스토리북 구현

## 상세 설명
스토리북에서 확인해주세요~~~
완료된 페이지가 네트워크 요청 부분이 있어서 스토리북으로 구현하려면 addon 설치해서 MSW 구현해 줘야 할 것 같아요 
그래서 얘기해봐야 될 것같아서 일단 ,, "aa 와(과) ff의 기록이에요" 부분 색상 연하게 바꿔놨어요