### PR TITLE
[BE] CD 스크립트 중복 제거

### DIFF
--- a/.github/workflows/be_cd-production.yml
+++ b/.github/workflows/be_cd-production.yml
@@ -77,6 +77,11 @@ jobs:
 
       - name: Extract secrets as .be_app-env file
         run: |
+          chmod +x ./deploy.sh # 스크립트에 실행 권한 부여 
+          source ./deploy.sh
+          echo "BLUE_PORT=$BLUE_PORT" >> $GITHUB_ENV
+          echo "GREEN_PORT=$GREEN_PORT" >> $GITHUB_ENV
+
           IFS=":" read -r INSTANCE_NAME INSTANCE_PREFIX <<< "${{ matrix.instance }}"
           cat <<EOF > ${{ secrets.DOCKER_COMPOSE_YAML_PATH }}/.be_app-env
           DOCKER_IMAGE_VERSION=latest

--- a/.github/workflows/be_cd-production.yml
+++ b/.github/workflows/be_cd-production.yml
@@ -67,9 +67,9 @@ jobs:
           path: ${{ github.workspace }}/backend
 
       # 왜 안됨...
-      - name: Ensure target directory exists
-        run: |
-          sudo mkdir -p ${{ secrets.DOCKER_COMPOSE_YAML_PATH }}
+      # - name: Ensure target directory exists
+      #   run: |
+      #     sudo mkdir -p ${{ secrets.DOCKER_COMPOSE_YAML_PATH }}
       
       - name: Move docker-compose YAML
         run: |

--- a/.github/workflows/be_cd-production.yml
+++ b/.github/workflows/be_cd-production.yml
@@ -2,7 +2,7 @@ name: Coduo Backend Production Server CD
 
 on:
   push:
-    branches: [ "production" ]
+    branches: [ "production", "BE/feature/#977" ]
 
 jobs:
   build:

--- a/.github/workflows/be_cd-production.yml
+++ b/.github/workflows/be_cd-production.yml
@@ -67,9 +67,13 @@ jobs:
           path: ${{ github.workspace }}/backend
 
       # 왜 안됨...
-      # - name: Move docker-compose YAML
-      #   run: |
-      #     sudo mv be_app-docker-compose.yml ${{ secrets.DOCKER_COMPOSE_YAML_PATH }}/
+      - name: Ensure target directory exists
+        run: |
+          sudo mkdir -p ${{ secrets.DOCKER_COMPOSE_YAML_PATH }}
+      
+      - name: Move docker-compose YAML
+        run: |
+          sudo mv be_app-docker-compose.yml ${{ secrets.DOCKER_COMPOSE_YAML_PATH }}/
 
       - name: Extract secrets as .be_app-env file
         run: |

--- a/.github/workflows/be_cd-production.yml
+++ b/.github/workflows/be_cd-production.yml
@@ -2,7 +2,7 @@ name: Coduo Backend Production Server CD
 
 on:
   push:
-    branches: [ "production", "BE/feature/#977" ]
+    branches: [ "production" ]
 
 jobs:
   build:

--- a/.github/workflows/be_cd-production.yml
+++ b/.github/workflows/be_cd-production.yml
@@ -65,11 +65,6 @@ jobs:
         with:
           name: docker-compose
           path: ${{ github.workspace }}/backend
-
-      # 왜 안됨...
-      # - name: Ensure target directory exists
-      #   run: |
-      #     sudo mkdir -p ${{ secrets.DOCKER_COMPOSE_YAML_PATH }}
       
       - name: Move docker-compose YAML
         run: |
@@ -77,16 +72,19 @@ jobs:
 
       - name: Extract secrets as .be_app-env file
         run: |
-          chmod +x ./deploy.sh # 스크립트에 실행 권한 부여 
+          chmod +x ./deploy.sh
           source ./deploy.sh
           echo "BLUE_PORT=$BLUE_PORT" >> $GITHUB_ENV
           echo "GREEN_PORT=$GREEN_PORT" >> $GITHUB_ENV
 
           IFS=":" read -r INSTANCE_NAME INSTANCE_PREFIX <<< "${{ matrix.instance }}"
           cat <<EOF > ${{ secrets.DOCKER_COMPOSE_YAML_PATH }}/.be_app-env
+
+          # Docker Hub info from Github Secrets
           DOCKER_IMAGE_VERSION=latest
           DOCKER_REPO_NAME=${{ secrets.DOCKER_REPO_NAME }}
 
+          # DB Configuration secrets info from Github Secrets
           MYSQL_TIME_ZONE=${{ secrets.MYSQL_TIME_ZONE }}
           DB_BINDING_PORT=${{ secrets.DB_BINDING_PORT }}
           DOCKER_DATA_PATH=${{ secrets.DOCKER_DATA_PATH }}
@@ -98,12 +96,16 @@ jobs:
           SLAVE_DB_PASSWORD=${{ secrets.SLAVE_DB_PASSWORD }}
           DDL_AUTO=${{ secrets.DDL_AUTO }}
 
+          # OAUTH & JWT
           CLIENT_ID=${{ secrets.CLIENT_ID }}
           CLIENT_SECRET=${{ secrets.CLIENT_SECRET }}
           CLIENT_REDIRECT_URI=${{ secrets.CLIENT_REDIRECT_URI }}
           JWT_KEY=${{ secrets.JWT_KEY }}
-
+          
+          # INSTANCE NAME
           INSTANCE_NAME=$INSTANCE_NAME
+          
+          # Server App
           BLUE_SERVER_BINDING_PORT=$BLUE_PORT
           GREEN_SERVER_BINDING_PORT=$GREEN_PORT
           SERVER_LOGS_PATH=${{ secrets.SERVER_LOGS_PATH }}

--- a/.github/workflows/be_cd-production.yml
+++ b/.github/workflows/be_cd-production.yml
@@ -51,11 +51,11 @@ jobs:
 
   deploy:
     environment: production
-    runs-on: coduo-prod
+    runs-on: ${{ matrix.instance }}
     needs: build
     strategy:
       matrix:
-        instance: [ "InstanceA:INSTANCE_A", "InstanceB:INSTANCE_B" ]
+        instance: [ "coduo-prod-a", "coduo-prod-b" ]
     defaults:
       run:
         working-directory: ./backend

--- a/.github/workflows/be_cd-production.yml
+++ b/.github/workflows/be_cd-production.yml
@@ -65,14 +65,11 @@ jobs:
         with:
           name: docker-compose
           path: ${{ github.workspace }}/backend
-          
-      - name: Debug Print DOCKER_COMPOSE_YAML_PATH
-        run: |
-          echo "${{ secrets.DOCKER_COMPOSE_YAML_PATH }}"
 
-      - name: Move docker-compose YAML
-        run: |
-          sudo mv be_app-docker-compose.yml ${{ secrets.DOCKER_COMPOSE_YAML_PATH }}/
+      # 왜 안됨...
+      # - name: Move docker-compose YAML
+      #   run: |
+      #     sudo mv be_app-docker-compose.yml ${{ secrets.DOCKER_COMPOSE_YAML_PATH }}/
 
       - name: Extract secrets as .be_app-env file
         run: |

--- a/.github/workflows/be_cd-production.yml
+++ b/.github/workflows/be_cd-production.yml
@@ -79,9 +79,16 @@ jobs:
 
       - name: Extract secrets as .be_app-env file
         run: |
-          IFS=":" read -r INSTANCE_NAME INSTANCE_PREFIX <<< "${{ matrix.instance }}"
-          cat <<EOF > ${{ secrets.DOCKER_COMPOSE_YAML_PATH }}/.be_app-env
+          if [ "${{ matrix.instance }}" = "coduo-prod-a" ]; then
+            INSTANCE_NAME=${{ secrets.INSTANCE_A_NAME }}
+          elif [ "${{ matrix.instance }}" = "coduo-prod-b" ]; then
+            INSTANCE_NAME=${{ secrets.INSTANCE_B_NAME }}
+          else
+            echo "Unknown instance: ${{ matrix.instance }}"
+            exit 1
+          fi
 
+          cat <<EOF > ${{ secrets.DOCKER_COMPOSE_YAML_PATH }}/.be_app-env
           # Docker Hub info from Github Secrets
           DOCKER_IMAGE_VERSION=latest
           DOCKER_REPO_NAME=${{ secrets.DOCKER_REPO_NAME }}

--- a/.github/workflows/be_cd-production.yml
+++ b/.github/workflows/be_cd-production.yml
@@ -51,7 +51,7 @@ jobs:
 
   deploy:
     environment: production
-    runs-on: ubuntu-latest
+    runs-on: coduo-prod
     needs: build
     strategy:
       matrix:

--- a/.github/workflows/be_cd-production.yml
+++ b/.github/workflows/be_cd-production.yml
@@ -65,6 +65,10 @@ jobs:
         with:
           name: docker-compose
           path: ${{ github.workspace }}/backend
+          
+      - name: Debug Print DOCKER_COMPOSE_YAML_PATH
+        run: |
+          echo "${{ secrets.DOCKER_COMPOSE_YAML_PATH }}"
 
       - name: Move docker-compose YAML
         run: |

--- a/.github/workflows/be_cd-production.yml
+++ b/.github/workflows/be_cd-production.yml
@@ -70,13 +70,15 @@ jobs:
         run: |
           sudo mv be_app-docker-compose.yml ${{ secrets.DOCKER_COMPOSE_YAML_PATH }}/
 
-      - name: Extract secrets as .be_app-env file
+      - name: Run deploy script
         run: |
           chmod +x ./deploy.sh
           source ./deploy.sh
           echo "BLUE_PORT=$BLUE_PORT" >> $GITHUB_ENV
           echo "GREEN_PORT=$GREEN_PORT" >> $GITHUB_ENV
 
+      - name: Extract secrets as .be_app-env file
+        run: |
           IFS=":" read -r INSTANCE_NAME INSTANCE_PREFIX <<< "${{ matrix.instance }}"
           cat <<EOF > ${{ secrets.DOCKER_COMPOSE_YAML_PATH }}/.be_app-env
 


### PR DESCRIPTION
## 연관된 이슈

- closes: #977 

## 구현한 기능

이전 pr에서 (#978) 실패한 스크립트 정상화시켰습니다. 

## 상세 설명

실패했던 이유는 runs-on의 이름이 우리가 만들었던 깃헙 액션 이름으로 되어 있지 않아 발생했던 오류였습니다. 
그래서 runs-on에 "coduo-prod-a", "coduo-prod-b"이 올 수 있도록 변경하였고, INSTANCE_NAME는 "coduo-prod-a", "coduo-prod-b" 가 아닌 우리가 설정했던 값(깃헙 시크릿에 저장되어 있는)을 각 서버마다 다르게 바라볼 수 있도록 스크립트를 작성했습니다. 
