### PR TITLE
[FE] 버그 해결

### DIFF
--- a/frontend/src/components/Main/PairRoomCreateModal/PairRoomCreateModal.tsx
+++ b/frontend/src/components/Main/PairRoomCreateModal/PairRoomCreateModal.tsx
@@ -3,6 +3,8 @@ import { Link } from 'react-router-dom';
 import Button from '@/components/_common/Button/Button';
 import { Modal } from '@/components/_common/Modal';
 
+import useClickEnterKey from '@/hooks/_common/customEvent/useClickEnterKey';
+
 import { theme } from '@/styles/theme';
 
 import * as S from './PairRoomCreateModal.styles';
@@ -13,6 +15,8 @@ interface PairRoomCreateModalProps {
 }
 
 const PairRoomCreateModal = ({ isOpen, closeModal }: PairRoomCreateModalProps) => {
+  const { buttonRef } = useClickEnterKey(isOpen);
+
   return (
     <Modal isOpen={isOpen} close={closeModal} size="60rem">
       <Modal.Header title="페어룸 선택" subTitle="어떤 방식으로 페어룸을 만들까요?" />
@@ -26,7 +30,7 @@ const PairRoomCreateModal = ({ isOpen, closeModal }: PairRoomCreateModalProps) =
           to="/onboarding?mission=true"
           aria-label="코딩해듀오가 깃허브 리포지토리로 제공하는 미션과 함께 시작할래요"
         >
-          <Button size="lg" width="100%" height="6rem" fontSize={theme.fontSize.lg} color="secondary">
+          <Button ref={buttonRef} size="lg" width="100%" height="6rem" fontSize={theme.fontSize.lg} color="secondary">
             미션과 함께 시작할래요
           </Button>
         </Link>

--- a/frontend/src/components/Main/PairRoomEntryModal/PairRoomEntryModal.tsx
+++ b/frontend/src/components/Main/PairRoomEntryModal/PairRoomEntryModal.tsx
@@ -8,6 +8,7 @@ import useToastStore from '@/stores/toastStore';
 
 import { getPairRoomExists } from '@/apis/pairRoom';
 
+import useClickEnterKey from '@/hooks/_common/customEvent/useClickEnterKey';
 import useInput from '@/hooks/_common/useInput';
 
 interface PairRoomEntryModal {
@@ -19,7 +20,9 @@ const PairRoomEntryModal = ({ isOpen, closeModal }: PairRoomEntryModal) => {
   const navigate = useNavigate();
 
   const { addToast } = useToastStore();
+
   const { value, resetValue, handleChange } = useInput();
+  const { buttonRef } = useClickEnterKey(isOpen);
 
   const enterPairRoom = async () => {
     const { exists } = await getPairRoomExists(value);
@@ -50,7 +53,7 @@ const PairRoomEntryModal = ({ isOpen, closeModal }: PairRoomEntryModal) => {
         <Button size="lg" onClick={closeModal} filled={false}>
           닫기
         </Button>
-        <Button size="lg" disabled={!value} onClick={enterPairRoom}>
+        <Button ref={buttonRef} size="lg" disabled={!value} onClick={enterPairRoom}>
           완료
         </Button>
       </Modal.Footer>

--- a/frontend/src/components/PairRoom/GuideModal/GuideModal.tsx
+++ b/frontend/src/components/PairRoom/GuideModal/GuideModal.tsx
@@ -9,6 +9,7 @@ import { Modal } from '@/components/_common/Modal';
 
 import useToastStore from '@/stores/toastStore';
 
+import useClickEnterKey from '@/hooks/_common/customEvent/useClickEnterKey';
 import useCopyClipBoard from '@/hooks/_common/useCopyClipboard';
 
 import { theme } from '@/styles/theme';
@@ -27,6 +28,7 @@ const GuideModal = ({ isOpen, close, accessCode }: GuideModalProps) => {
   const { addToast } = useToastStore();
 
   const [, onCopy] = useCopyClipBoard();
+  const { buttonRef } = useClickEnterKey(isOpen);
 
   const checkPermission = () => {
     if (Notification.permission !== 'granted') {
@@ -104,7 +106,7 @@ const GuideModal = ({ isOpen, close, accessCode }: GuideModalProps) => {
         <Modal.Footer position="CENTER">
           <S.ButtonContainer>
             <p>모두 확인하셨나요?</p>
-            <Button width="18rem" size="lg" onClick={close}>
+            <Button ref={buttonRef} width="18rem" size="lg" onClick={close}>
               시작하기
             </Button>
           </S.ButtonContainer>

--- a/frontend/src/components/PairRoomOnboarding/AddPairModal/AddPairModal.tsx
+++ b/frontend/src/components/PairRoomOnboarding/AddPairModal/AddPairModal.tsx
@@ -8,6 +8,7 @@ import useToastStore from '@/stores/toastStore';
 
 import { getMemberName } from '@/apis/member';
 
+import useClickEnterKey from '@/hooks/_common/customEvent/useClickEnterKey';
 import useInput from '@/hooks/_common/useInput';
 
 import { validatePairInfo } from '@/validations/validatePairName';
@@ -21,8 +22,10 @@ interface AddPairModalProps {
 }
 
 const AddPairModal = ({ isOpen, closeModal, onPairData }: AddPairModalProps) => {
-  const { value, status, message, handleChange, resetValue } = useInput();
   const { addToast } = useToastStore();
+
+  const { value, status, message, handleChange, resetValue } = useInput();
+  const { buttonRef } = useClickEnterKey(isOpen);
 
   const handleCloseModal = () => {
     resetValue();
@@ -62,7 +65,12 @@ const AddPairModal = ({ isOpen, closeModal, onPairData }: AddPairModalProps) => 
         <Button size="lg" onClick={handleCloseModal} filled={false}>
           닫기
         </Button>
-        <Button size="lg" disabled={value.trim() === '' || status === 'ERROR'} onClick={() => connectPairData(value)}>
+        <Button
+          ref={buttonRef}
+          size="lg"
+          disabled={value.trim() === '' || status === 'ERROR'}
+          onClick={() => connectPairData(value)}
+        >
           연동하기
         </Button>
       </S.Footer>

--- a/frontend/src/components/PairRoomOnboarding/AddPairModal/AddPairModal.tsx
+++ b/frontend/src/components/PairRoomOnboarding/AddPairModal/AddPairModal.tsx
@@ -59,7 +59,7 @@ const AddPairModal = ({ isOpen, closeModal, onPairData }: AddPairModalProps) => 
         </InputField>
       </S.Body>
       <S.Footer>
-        <Button onClick={handleCloseModal} filled={false}>
+        <Button size="lg" onClick={handleCloseModal} filled={false}>
           닫기
         </Button>
         <Button size="lg" disabled={value.trim() === '' || status === 'ERROR'} onClick={() => connectPairData(value)}>

--- a/frontend/src/components/_common/Button/Button.tsx
+++ b/frontend/src/components/_common/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { ButtonHTMLAttributes } from 'react';
+import { ButtonHTMLAttributes, forwardRef } from 'react';
 
 import { css } from 'styled-components';
 
@@ -22,44 +22,52 @@ interface ButtonProp extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
 }
 
-const Button = ({
-  $css,
-  size = 'md',
-  width,
-  height,
-  borderRadius,
-  fontSize,
-  fontWeight,
-  textAlign,
-  filled = true,
-  rounded = false,
-  animation = false,
-  color = 'primary',
-  disabled = false,
-  children,
-  ...props
-}: React.PropsWithChildren<ButtonProp>) => {
-  return (
-    <S.Button
-      type="button"
-      $size={size}
-      $width={width}
-      $height={height}
-      $borderRadius={borderRadius}
-      $fontSize={fontSize}
-      $fontWeight={fontWeight}
-      $textAlign={textAlign}
-      $filled={filled}
-      $rounded={rounded}
-      $animation={animation}
-      $color={color}
-      $css={$css}
-      disabled={disabled}
-      {...props}
-    >
-      {children}
-    </S.Button>
-  );
-};
+const Button = forwardRef<HTMLButtonElement, ButtonProp>(
+  (
+    {
+      $css,
+      size = 'md',
+      width,
+      height,
+      borderRadius,
+      fontSize,
+      fontWeight,
+      textAlign,
+      filled = true,
+      rounded = false,
+      animation = false,
+      color = 'primary',
+      disabled = false,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <S.Button
+        ref={ref}
+        type="button"
+        $size={size}
+        $width={width}
+        $height={height}
+        $borderRadius={borderRadius}
+        $fontSize={fontSize}
+        $fontWeight={fontWeight}
+        $textAlign={textAlign}
+        $filled={filled}
+        $rounded={rounded}
+        $animation={animation}
+        $color={color}
+        $css={$css}
+        disabled={disabled}
+        {...props}
+      >
+        {children}
+      </S.Button>
+    );
+  },
+);
+
+Button.displayName = 'Button';
 
 export default Button;

--- a/frontend/src/components/_common/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/components/_common/ConfirmModal/ConfirmModal.tsx
@@ -23,7 +23,7 @@ const ConfirmModal = ({
   onConfirm,
 }: ConfirmModalProps) => {
   return (
-    <Modal isOpen={isOpen} close={close} size="sm">
+    <Modal isOpen={isOpen} close={close} size="fit-content">
       <Modal.CloseButton close={close} />
       <S.Container $type={type}>
         <p>{title}</p>

--- a/frontend/src/components/_common/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/components/_common/ConfirmModal/ConfirmModal.tsx
@@ -1,6 +1,8 @@
 import Button from '@/components/_common/Button/Button';
 import { Modal } from '@/components/_common/Modal';
 
+import useClickEnterKey from '@/hooks/_common/customEvent/useClickEnterKey';
+
 import * as S from './ConfirmModal.styles';
 
 interface ConfirmModalProps {
@@ -22,6 +24,8 @@ const ConfirmModal = ({
   confirmText = '확인',
   onConfirm,
 }: ConfirmModalProps) => {
+  const { buttonRef } = useClickEnterKey(isOpen);
+
   return (
     <Modal isOpen={isOpen} close={close} size="fit-content">
       <Modal.CloseButton close={close} />
@@ -33,7 +37,7 @@ const ConfirmModal = ({
         <Button size="lg" fontSize="1.4rem" color="black" onClick={close}>
           취소
         </Button>
-        <Button size="lg" fontSize="1.4rem" onClick={onConfirm}>
+        <Button ref={buttonRef} size="lg" fontSize="1.4rem" onClick={onConfirm}>
           {confirmText}
         </Button>
       </Modal.Footer>

--- a/frontend/src/hooks/_common/customEvent/useClickEnterKey.ts
+++ b/frontend/src/hooks/_common/customEvent/useClickEnterKey.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react';
+
+const useClickEnterKey = (isOpen: boolean) => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleEnterPress = (event: KeyboardEvent) => {
+      if (event.key === 'Enter' && buttonRef.current) buttonRef.current.click();
+    };
+
+    document.addEventListener('keydown', handleEnterPress);
+
+    return () => document.removeEventListener('keydown', handleEnterPress);
+  }, [isOpen]);
+
+  return { buttonRef };
+};
+
+export default useClickEnterKey;

--- a/frontend/src/pages/RetrospectForm/RetrospectForm.styles.ts
+++ b/frontend/src/pages/RetrospectForm/RetrospectForm.styles.ts
@@ -1,15 +1,5 @@
 import styled from 'styled-components';
 
-export const ButtonContainer = styled.div`
-  position: fixed;
-  bottom: 0;
-  left: 50%;
-
-  width: 60%;
-
-  transform: translate(-50%);
-`;
-
 export const Layout = styled.div`
   display: flex;
   justify-content: center;
@@ -46,4 +36,19 @@ export const Form = styled.form`
   gap: 4rem;
 
   width: 100%;
+`;
+
+export const ButtonContainer = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 50%;
+
+  width: 60%;
+  min-width: 76.8rem;
+
+  transform: translate(-50%);
+
+  @media (max-width: ${({ theme }) => theme.deviceWidth.mobile}) {
+    width: 100%;
+  }
 `;


### PR DESCRIPTION
## 연관된 이슈

- closes: #986 

## 구현한 기능
- [x] `회고 작성하기` 페이지의 크기를 줄였을 때 작성 완료 버튼이 작아지는 문제 해결
- [x] `페어 정보 연동하기` 모달의 버튼 모양 통일
- [x] 모달 크기를 줄였을 때 닫기 버튼에 가려져서 컨텐츠가 안 보이는 문제 해결
- [x] 모달에서 엔터를 눌렀을 때 `primary button` 이 눌리도록 처리

## 상세 설명
- 모달에서 엔터를 눌렀을 때 버튼이 눌리도록 처리하기 위해서 `useClickEnterKey` 커스텀 훅을 추가했습니다.
- `useClickEnterKey` 에서 반환하는 `buttonRef` 를 버튼에 추가해서 사용할 수 있습니다. (모달이 `children` 으로 버튼을 받고 있어서 일괄 적용은 못했습니다 🥹)

```jsx
const { buttonRef } = useClickEnterKey(isOpen);

<Button ref={buttonRef} size="lg" disabled={!value} onClick={enterPairRoom}>
  완료
</Button>
```

- 이를 구현하기 위해 `Button` 컴포넌트에 `forwardRef` 를 추가했습니다.