### PR TITLE
[FE] 중복 getTimer api 삭제 및 타이머 웹소켓 연결

### DIFF
--- a/frontend/src/apis/pairRoom.ts
+++ b/frontend/src/apis/pairRoom.ts
@@ -10,8 +10,10 @@ export interface GetPairRoomResponse {
   id: number;
   driver: string;
   navigator: string;
-  missionUrl: string;
   status: PairRoomStatus;
+  duration: number;
+  remainingTime: number;
+  missionUrl: string;
 }
 
 export const getPairRoom = async (accessCode: string): Promise<GetPairRoomResponse> => {

--- a/frontend/src/apis/timer.ts
+++ b/frontend/src/apis/timer.ts
@@ -7,21 +7,6 @@ export const getConnection = (accessCode: string) => {
   return new WebSocket(`${SOCKET_URL}/wss-connect?accesscode=${accessCode}`);
 };
 
-export interface GetTimerResponse {
-  id: number;
-  duration: number;
-  remainingTime: number;
-}
-
-export const getTimer = async (accessCode: string): Promise<GetTimerResponse> => {
-  const response = await fetcher.get({
-    url: `${API_URL}/${accessCode}/timer`,
-    errorMessage: '',
-  });
-
-  return response.json();
-};
-
 interface UpdateDurationRequest {
   duration: string;
   accessCode: string;

--- a/frontend/src/apis/timer.ts
+++ b/frontend/src/apis/timer.ts
@@ -4,7 +4,7 @@ const API_URL = process.env.REACT_APP_API_URL;
 const SOCKET_URL = process.env.REACT_SOCKET_API_URL;
 
 export const getConnection = (accessCode: string) => {
-  return new WebSocket(`${SOCKET_URL}/ws-connect?accesscode=${accessCode}`);
+  return new WebSocket(`${SOCKET_URL}/wss-connect?accesscode=${accessCode}`);
 };
 
 export interface GetTimerResponse {

--- a/frontend/src/queries/PairRoom/usePairRoomQuery.ts
+++ b/frontend/src/queries/PairRoom/usePairRoomQuery.ts
@@ -3,7 +3,6 @@ import { useEffect } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { getPairRoom } from '@/apis/pairRoom';
-import { getTimer } from '@/apis/timer';
 
 import { QUERY_KEYS } from '@/constants/queryKeys';
 
@@ -20,12 +19,6 @@ const usePairRoomQuery = (accessCode: string) => {
     refetchOnWindowFocus: false,
   });
 
-  const { data: timer, isFetching: isTimerFetching } = useQuery({
-    queryKey: [QUERY_KEYS.GET_PAIR_ROOM_TIMER, accessCode],
-    queryFn: () => getTimer(accessCode),
-    refetchOnWindowFocus: false,
-  });
-
   useEffect(() => {
     queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.GET_PAIR_ROOM, QUERY_KEYS.GET_PAIR_ROOM_TIMER] });
   }, [accessCode]);
@@ -35,9 +28,9 @@ const usePairRoomQuery = (accessCode: string) => {
     navigator: pairRoom?.navigator || '',
     status: pairRoom?.status || '',
     missionUrl: pairRoom?.missionUrl || '',
-    duration: timer?.duration || 0,
-    remainingTime: timer?.remainingTime || 0,
-    isFetching: (isPairRoomFetching && !isPairRoomReFetching) || isTimerFetching,
+    duration: pairRoom?.duration || 0,
+    remainingTime: pairRoom?.remainingTime || 0,
+    isFetching: isPairRoomFetching && !isPairRoomReFetching,
   };
 };
 


### PR DESCRIPTION
## 연관된 이슈

- closes: #1021 

## 구현한 기능

중복 getTimer api 삭제 및 타이머 웹소켓 연결

## 상세 설명

getPairRoom과 getTimer 두 곳에서 똑같은 타이머 정보를 불러오고 있어 getTimer 함수를 삭제하고 그에 맞게 코드를 리팩터링했습니다.
파일명 등은 추후 수정할 예정입니다.