### PR TITLE
[BE] 페어룸 입장 시 발생되는 하위 정보 한 API로 병합 (#1034)

### DIFF
--- a/backend/src/main/java/site/coduo/pairroom/controller/PairRoomController.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/PairRoomController.java
@@ -20,14 +20,14 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import site.coduo.pairroom.controller.docs.PairRoomDocs;
-import site.coduo.pairroom.controller.dto.request.ExistMemberInPairRoomResponse;
 import site.coduo.pairroom.service.PairRoomService;
+import site.coduo.pairroom.service.dto.ExistMemberInPairRoomResponse;
 import site.coduo.pairroom.service.dto.PairRoomCreateRequest;
 import site.coduo.pairroom.service.dto.PairRoomCreateResponse;
+import site.coduo.pairroom.service.dto.PairRoomEntireResponse;
 import site.coduo.pairroom.service.dto.PairRoomExistResponse;
 import site.coduo.pairroom.service.dto.PairRoomMemberResponse;
 import site.coduo.pairroom.service.dto.PairRoomReadRequest;
-import site.coduo.pairroom.service.dto.PairRoomReadResponse;
 import site.coduo.pairroom.service.dto.PairRoomStatusUpdateRequest;
 
 @Slf4j
@@ -68,12 +68,12 @@ public class PairRoomController implements PairRoomDocs {
     }
 
     @GetMapping("/pair-room/{accessCode}")
-    public ResponseEntity<PairRoomReadResponse> getPairRoom(
+    public ResponseEntity<PairRoomEntireResponse> getPairRoom(
             @Valid @PathVariable("accessCode") final PairRoomReadRequest request
     ) {
-        final PairRoomReadResponse response = pairRoomService.findPairRoomAndTimer(request.accessCode());
+        final PairRoomEntireResponse entirePairRoom = pairRoomService.findEntirePairRoom(request.accessCode());
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(entirePairRoom);
     }
 
     @GetMapping("/my-pair-rooms")

--- a/backend/src/main/java/site/coduo/pairroom/controller/docs/PairRoomDocs.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/docs/PairRoomDocs.java
@@ -12,22 +12,21 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import site.coduo.pairroom.controller.dto.request.ExistMemberInPairRoomResponse;
+import site.coduo.pairroom.service.dto.ExistMemberInPairRoomResponse;
 import site.coduo.pairroom.service.dto.PairRoomCreateRequest;
 import site.coduo.pairroom.service.dto.PairRoomCreateResponse;
+import site.coduo.pairroom.service.dto.PairRoomEntireResponse;
 import site.coduo.pairroom.service.dto.PairRoomExistResponse;
 import site.coduo.pairroom.service.dto.PairRoomMemberResponse;
 import site.coduo.pairroom.service.dto.PairRoomReadRequest;
-import site.coduo.pairroom.service.dto.PairRoomReadResponse;
 import site.coduo.pairroom.service.dto.PairRoomStatusUpdateRequest;
 
 @Tag(name = "페어룸 API")
 public interface PairRoomDocs {
 
     @Operation(summary = "페어룸과 해당 페어룸의 타이머 정보를 함께 조회한다.")
-    @ApiResponse(responseCode = "200", description = "페어룸 & 타이머 조회 성공", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-            schema = @Schema(implementation = PairRoomReadResponse.class)))
-    ResponseEntity<PairRoomReadResponse> getPairRoom(
+    @ApiResponse(responseCode = "200", description = "페어룸 & 타이머 조회 성공")
+    ResponseEntity<PairRoomEntireResponse> getPairRoom(
             @Parameter(description = "페어룸 접근 코드", required = true)
             PairRoomReadRequest request
     );

--- a/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
@@ -27,11 +27,18 @@ import site.coduo.pairroom.repository.PairRoomMember;
 import site.coduo.pairroom.repository.PairRoomMemberRepository;
 import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.pairroom.service.dto.PairRoomCreateRequest;
+import site.coduo.pairroom.service.dto.PairRoomEntireResponse;
 import site.coduo.pairroom.service.dto.PairRoomMemberResponse;
 import site.coduo.pairroom.service.dto.PairRoomReadResponse;
+import site.coduo.referencelink.service.CategoryService;
+import site.coduo.referencelink.service.ReferenceLinkService;
+import site.coduo.referencelink.service.dto.CategoryReadResponse;
+import site.coduo.referencelink.service.dto.ReferenceLinkResponse;
 import site.coduo.timer.domain.Timer;
 import site.coduo.timer.repository.TimerEntity;
 import site.coduo.timer.repository.TimerRepository;
+import site.coduo.todo.service.TodoService;
+import site.coduo.todo.service.dto.TodoReadResponse;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -41,6 +48,9 @@ public class PairRoomService {
 
     private final PairRoomRepository pairRoomRepository;
     private final TimerRepository timerRepository;
+    private final CategoryService categoryService;
+    private final TodoService todoService;
+    private final ReferenceLinkService referenceLinkService;
     private final PairRoomMemberRepository pairRoomMemberRepository;
     private final MemberService memberService;
     private final MemberRepository memberRepository;
@@ -115,11 +125,19 @@ public class PairRoomService {
         pairRoomEntity.updateStatus(status);
     }
 
-    public PairRoomReadResponse findPairRoomAndTimer(final String accessCode) {
+    public PairRoomEntireResponse findEntirePairRoom(final String accessCode) {
         final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCode);
         checkPairRoomIsDeleted(pairRoomEntity);
-        final TimerEntity timerEntity = timerRepository.fetchTimerByPairRoomEntity(pairRoomEntity);
-        return PairRoomReadResponse.of(pairRoomEntity.toDomain(), timerEntity.toDomain());
+        final Timer timer = timerRepository.fetchTimerByPairRoomEntity(pairRoomEntity).toDomain();
+        final List<CategoryReadResponse> categoryReadResponses = categoryService.findAllByPairRoomAccessCode(
+                pairRoomEntity.getAccessCode());
+        final List<ReferenceLinkResponse> referenceLinkResponses = referenceLinkService
+                .findAllReferenceLinkByAccessCode(accessCode);
+        final List<TodoReadResponse> todoReadResponses = todoService.getAllOrderBySort(accessCode);
+
+        final PairRoomReadResponse pairRoomReadResponse = PairRoomReadResponse.of(pairRoomEntity.toDomain(), timer);
+        return PairRoomEntireResponse.of(pairRoomReadResponse, todoReadResponses, categoryReadResponses,
+                referenceLinkResponses);
     }
 
     private void checkPairRoomIsActive(final PairRoomEntity pairRoomEntity) {

--- a/backend/src/main/java/site/coduo/pairroom/service/dto/ExistMemberInPairRoomResponse.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/dto/ExistMemberInPairRoomResponse.java
@@ -1,4 +1,4 @@
-package site.coduo.pairroom.controller.dto.request;
+package site.coduo.pairroom.service.dto;
 
 public record ExistMemberInPairRoomResponse(boolean exists) {
 }

--- a/backend/src/main/java/site/coduo/pairroom/service/dto/PairRoomEntireResponse.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/dto/PairRoomEntireResponse.java
@@ -1,0 +1,24 @@
+package site.coduo.pairroom.service.dto;
+
+import java.util.List;
+
+import site.coduo.referencelink.service.dto.CategoryReadResponse;
+import site.coduo.referencelink.service.dto.ReferenceLinkResponse;
+import site.coduo.todo.service.dto.TodoReadResponse;
+
+public record PairRoomEntireResponse(
+        PairRoomReadResponse pairRoomInfo,
+        List<TodoReadResponse> todoInfo,
+        List<CategoryReadResponse> categoryInfo,
+        List<ReferenceLinkResponse> referenceInfo) {
+
+    public static PairRoomEntireResponse of(
+            PairRoomReadResponse pairRoomReadResponse,
+            List<TodoReadResponse> todoResponses,
+            List<CategoryReadResponse> categoryReadResponses,
+            List<ReferenceLinkResponse> referenceLinkResponses
+    ) {
+        return new PairRoomEntireResponse(pairRoomReadResponse, todoResponses, categoryReadResponses,
+                referenceLinkResponses);
+    }
+}

--- a/backend/src/main/java/site/coduo/referencelink/controller/ReferenceLinkController.java
+++ b/backend/src/main/java/site/coduo/referencelink/controller/ReferenceLinkController.java
@@ -43,7 +43,8 @@ public class ReferenceLinkController implements ReferenceLinkDocs {
     public ResponseEntity<List<ReferenceLinkResponse>> getReferenceLinks(
             @PathVariable("accessCode") final String accessCodeText
     ) {
-        final List<ReferenceLinkResponse> responses = referenceLinkService.readAllReferenceLink(accessCodeText);
+        final List<ReferenceLinkResponse> responses = referenceLinkService.findAllReferenceLinkByAccessCode(
+                accessCodeText);
 
         return ResponseEntity.ok(responses);
     }

--- a/backend/src/main/java/site/coduo/referencelink/controller/docs/ReferenceLinkDocs.java
+++ b/backend/src/main/java/site/coduo/referencelink/controller/docs/ReferenceLinkDocs.java
@@ -27,7 +27,7 @@ public interface ReferenceLinkDocs {
     );
 
     @Operation(summary = "모든 레퍼런스 링크를 조회한다.")
-    @ApiResponse(responseCode = "200", description = "레퍼런스 링크 조회 성공", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ReferenceLinkResponse.class)))
+    @ApiResponse(responseCode = "200", description = "레퍼런스 링크 조회 성공")
     @ApiResponse(responseCode = "4xx", description = "레퍼런스 링크 조회 실패", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ApiErrorResponse.class)))
     ResponseEntity<List<ReferenceLinkResponse>> getReferenceLinks(String accessCode);
 

--- a/backend/src/main/java/site/coduo/referencelink/repository/CategoryEntity.java
+++ b/backend/src/main/java/site/coduo/referencelink/repository/CategoryEntity.java
@@ -44,6 +44,10 @@ public class CategoryEntity extends BaseTimeEntity {
         this.categoryName = categoryName;
     }
 
+    public Category toDomain() {
+        return new Category(categoryName);
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -64,9 +68,9 @@ public class CategoryEntity extends BaseTimeEntity {
     @Override
     public String toString() {
         return "CategoryEntity{" +
-               "id=" + id +
-               ", categoryId='" + categoryName + '\'' +
-               ", pairRoom=" + pairRoomEntity +
-               '}';
+                "id=" + id +
+                ", categoryId='" + categoryName + '\'' +
+                ", pairRoom=" + pairRoomEntity +
+                '}';
     }
 }

--- a/backend/src/main/java/site/coduo/referencelink/repository/ReferenceLinkEntity.java
+++ b/backend/src/main/java/site/coduo/referencelink/repository/ReferenceLinkEntity.java
@@ -1,5 +1,7 @@
 package site.coduo.referencelink.repository;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Objects;
 
 import jakarta.persistence.Column;
@@ -19,6 +21,7 @@ import site.coduo.pairroom.domain.accesscode.AccessCode;
 import site.coduo.pairroom.repository.PairRoomEntity;
 import site.coduo.referencelink.domain.Category;
 import site.coduo.referencelink.domain.ReferenceLink;
+import site.coduo.referencelink.exception.InvalidUrlFormatException;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -77,6 +80,14 @@ public class ReferenceLinkEntity extends BaseTimeEntity {
             return null;
         }
         return categoryEntity.getCategoryName();
+    }
+
+    public ReferenceLink toDomain() {
+        try {
+            return new ReferenceLink(new URL(url), new AccessCode(pairRoomEntity.getAccessCode()));
+        } catch (MalformedURLException e) {
+            throw new InvalidUrlFormatException("링크 형식이 맞지 않습니다.");
+        }
     }
 
     @Override

--- a/backend/src/main/java/site/coduo/referencelink/service/ReferenceLinkService.java
+++ b/backend/src/main/java/site/coduo/referencelink/service/ReferenceLinkService.java
@@ -72,8 +72,8 @@ public class ReferenceLinkService {
     }
 
     @Transactional(readOnly = true)
-    public List<ReferenceLinkResponse> readAllReferenceLink(final String accessCodeText) {
-        final PairRoomEntity pairRoom = pairRoomRepository.fetchByAccessCode(accessCodeText);
+    public List<ReferenceLinkResponse> findAllReferenceLinkByAccessCode(final String accessCode) {
+        final PairRoomEntity pairRoom = pairRoomRepository.fetchByAccessCode(accessCode);
 
         final List<ReferenceLinkEntity> referenceLinkEntities = referenceLinkRepository.findByPairRoomEntity(pairRoom);
 

--- a/backend/src/main/java/site/coduo/todo/controller/TodoController.java
+++ b/backend/src/main/java/site/coduo/todo/controller/TodoController.java
@@ -2,7 +2,6 @@ package site.coduo.todo.controller;
 
 import java.net.URI;
 import java.util.List;
-import java.util.stream.IntStream;
 
 import jakarta.validation.Valid;
 
@@ -17,12 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import site.coduo.todo.controller.docs.TodoDocs;
-import site.coduo.todo.controller.request.CreateTodoRequest;
-import site.coduo.todo.controller.request.UpdateTodoContentRequest;
-import site.coduo.todo.controller.request.UpdateTodoOrderRequest;
-import site.coduo.todo.controller.response.GetTodoResponse;
-import site.coduo.todo.domain.Todo;
 import site.coduo.todo.service.TodoService;
+import site.coduo.todo.service.dto.CreateTodoRequest;
+import site.coduo.todo.service.dto.TodoReadResponse;
+import site.coduo.todo.service.dto.UpdateTodoContentRequest;
+import site.coduo.todo.service.dto.UpdateTodoOrderRequest;
 
 @RequiredArgsConstructor
 @RestController
@@ -31,11 +29,8 @@ public class TodoController implements TodoDocs {
     private final TodoService todoService;
 
     @GetMapping("/{accessCode}/todos")
-    public List<GetTodoResponse> getTodos(@PathVariable("accessCode") final String accessCode) {
-        final List<Todo> allTodos = todoService.getAllOrderBySort(accessCode);
-        return IntStream.range(0, allTodos.size())
-                .mapToObj(index -> GetTodoResponse.from(allTodos.get(index), index))
-                .toList();
+    public List<TodoReadResponse> getTodos(@PathVariable("accessCode") final String accessCode) {
+        return todoService.getAllOrderBySort(accessCode);
     }
 
     @PostMapping("/{accessCode}/todos")

--- a/backend/src/main/java/site/coduo/todo/controller/docs/TodoDocs.java
+++ b/backend/src/main/java/site/coduo/todo/controller/docs/TodoDocs.java
@@ -10,17 +10,17 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import site.coduo.todo.controller.request.CreateTodoRequest;
-import site.coduo.todo.controller.request.UpdateTodoContentRequest;
-import site.coduo.todo.controller.request.UpdateTodoOrderRequest;
-import site.coduo.todo.controller.response.GetTodoResponse;
+import site.coduo.todo.service.dto.CreateTodoRequest;
+import site.coduo.todo.service.dto.TodoReadResponse;
+import site.coduo.todo.service.dto.UpdateTodoContentRequest;
+import site.coduo.todo.service.dto.UpdateTodoOrderRequest;
 
 @Tag(name = "투두 API")
 public interface TodoDocs {
 
     @Operation(summary = "특정 페어룸의 투두 목록을 조회한다.")
     @ApiResponse(responseCode = "200", description = "투두 목록 조회 성공")
-    List<GetTodoResponse> getTodos(
+    List<TodoReadResponse> getTodos(
             @Parameter(description = "페어룸 접근 코드", required = true)
             String accessCode
     );

--- a/backend/src/main/java/site/coduo/todo/service/TodoService.java
+++ b/backend/src/main/java/site/coduo/todo/service/TodoService.java
@@ -1,6 +1,7 @@
 package site.coduo.todo.service;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +16,7 @@ import site.coduo.todo.domain.TodoSortComparator;
 import site.coduo.todo.exception.TodoNotFoundException;
 import site.coduo.todo.repository.TodoEntity;
 import site.coduo.todo.repository.TodoRepository;
+import site.coduo.todo.service.dto.TodoReadResponse;
 
 @RequiredArgsConstructor
 @Service
@@ -28,12 +30,16 @@ public class TodoService {
     private final TodoRepository todoRepository;
 
     @Transactional(readOnly = true)
-    public List<Todo> getAllOrderBySort(final String accessCode) {
+    public List<TodoReadResponse> getAllOrderBySort(final String accessCode) {
         final PairRoomEntity pairRoom = pairRoomRepository.fetchByAccessCode(accessCode);
-        return todoRepository.findAllByPairRoomEntity(pairRoom)
+        final List<Todo> todos = todoRepository.findAllByPairRoomEntity(pairRoom)
                 .stream()
                 .map(TodoEntity::toDomain)
                 .sorted(new TodoSortComparator())
+                .toList();
+        
+        return IntStream.range(0, todos.size())
+                .mapToObj(index -> TodoReadResponse.from(todos.get(index), index))
                 .toList();
     }
 

--- a/backend/src/main/java/site/coduo/todo/service/dto/CreateTodoRequest.java
+++ b/backend/src/main/java/site/coduo/todo/service/dto/CreateTodoRequest.java
@@ -1,4 +1,4 @@
-package site.coduo.todo.controller.request;
+package site.coduo.todo.service.dto;
 
 import jakarta.validation.constraints.NotBlank;
 

--- a/backend/src/main/java/site/coduo/todo/service/dto/TodoReadResponse.java
+++ b/backend/src/main/java/site/coduo/todo/service/dto/TodoReadResponse.java
@@ -1,15 +1,15 @@
-package site.coduo.todo.controller.response;
+package site.coduo.todo.service.dto;
 
 import site.coduo.todo.domain.Todo;
 
-public record GetTodoResponse(
+public record TodoReadResponse(
         Long id,
         String content,
         boolean isChecked,
         int order
 ) {
-    public static GetTodoResponse from(final Todo todo, final int order) {
-        return new GetTodoResponse(
+    public static TodoReadResponse from(final Todo todo, final int order) {
+        return new TodoReadResponse(
                 todo.getId(),
                 todo.getContent().getContent(),
                 todo.getIsChecked().isChecked(),

--- a/backend/src/main/java/site/coduo/todo/service/dto/UpdateTodoContentRequest.java
+++ b/backend/src/main/java/site/coduo/todo/service/dto/UpdateTodoContentRequest.java
@@ -1,4 +1,4 @@
-package site.coduo.todo.controller.request;
+package site.coduo.todo.service.dto;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/src/main/java/site/coduo/todo/service/dto/UpdateTodoOrderRequest.java
+++ b/backend/src/main/java/site/coduo/todo/service/dto/UpdateTodoOrderRequest.java
@@ -1,4 +1,4 @@
-package site.coduo.todo.controller.request;
+package site.coduo.todo.service.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/backend/src/test/java/site/coduo/pairroom/service/PairRoomServiceTest.java
+++ b/backend/src/test/java/site/coduo/pairroom/service/PairRoomServiceTest.java
@@ -35,8 +35,8 @@ import site.coduo.pairroom.repository.PairRoomMember;
 import site.coduo.pairroom.repository.PairRoomMemberRepository;
 import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.pairroom.service.dto.PairRoomCreateRequest;
+import site.coduo.pairroom.service.dto.PairRoomEntireResponse;
 import site.coduo.pairroom.service.dto.PairRoomMemberResponse;
-import site.coduo.pairroom.service.dto.PairRoomReadResponse;
 import site.coduo.timer.domain.Timer;
 import site.coduo.timer.repository.TimerEntity;
 import site.coduo.timer.repository.TimerRepository;
@@ -68,7 +68,7 @@ class PairRoomServiceTest {
         final String accessCode = pairRoomService.savePairRoom(request, null);
 
         // then
-        assertThatCode(() -> pairRoomService.findPairRoomAndTimer(accessCode))
+        assertThatCode(() -> pairRoomService.findEntirePairRoom(accessCode))
                 .doesNotThrowAnyException();
     }
 
@@ -93,7 +93,7 @@ class PairRoomServiceTest {
         final String notSavedAccessCode = "123456";
 
         // when & then
-        assertThatThrownBy(() -> pairRoomService.findPairRoomAndTimer(notSavedAccessCode))
+        assertThatThrownBy(() -> pairRoomService.findEntirePairRoom(notSavedAccessCode))
                 .isExactlyInstanceOf(PairRoomNotFoundException.class);
     }
 
@@ -108,7 +108,7 @@ class PairRoomServiceTest {
         pairRoomEntity.updateStatus(PairRoomStatus.DELETED);
 
         // when & then
-        assertThatThrownBy(() -> pairRoomService.findPairRoomAndTimer(accessCode))
+        assertThatThrownBy(() -> pairRoomService.findEntirePairRoom(accessCode))
                 .isExactlyInstanceOf(InactivePairRoomException.class);
     }
 
@@ -123,7 +123,7 @@ class PairRoomServiceTest {
         pairRoomService.updatePairRoomStatus(accessCode, PairRoomStatus.COMPLETED.name());
 
         // then
-        assertThat(PairRoomStatus.findByName(pairRoomService.findPairRoomAndTimer(accessCode).status()))
+        assertThat(PairRoomStatus.findByName(pairRoomService.findEntirePairRoom(accessCode).pairRoomInfo().status()))
                 .isEqualTo(PairRoomStatus.COMPLETED);
     }
 
@@ -258,12 +258,13 @@ class PairRoomServiceTest {
         timerRepository.save(new TimerEntity(timer, pairRoomEntity));
 
         // when
-        final PairRoomReadResponse actual = pairRoomService.findPairRoomAndTimer(
+        final PairRoomEntireResponse actual = pairRoomService.findEntirePairRoom(
                 pairRoomEntity.getAccessCode());
 
         // then
         assertThat(actual)
-                .extracting("navigator", "driver", "status", "duration", "remainingTime")
+                .extracting("pairRoomInfo.navigator", "pairRoomInfo.driver", "pairRoomInfo.status",
+                        "pairRoomInfo.duration", "pairRoomInfo.remainingTime")
                 .contains(pairRoomEntity.getNavigator(), pairRoomEntity.getDriver(),
                         pairRoomEntity.getStatus().toString(), timer.getDuration(), timer.getRemainingTime());
     }

--- a/backend/src/test/java/site/coduo/referencelink/service/ReferenceLinkServiceTest.java
+++ b/backend/src/test/java/site/coduo/referencelink/service/ReferenceLinkServiceTest.java
@@ -84,7 +84,8 @@ class ReferenceLinkServiceTest extends CascadeCleaner {
                 () -> assertThat(openGraphRepository.findAll()).hasSize(1),
                 () -> {
                     final ReferenceLinkResponse referenceLinkResponses =
-                            referenceLinkService.readAllReferenceLink(pairRoomEntity.getAccessCode()).get(0);
+                            referenceLinkService.findAllReferenceLinkByAccessCode(pairRoomEntity.getAccessCode())
+                                    .get(0);
                     assertThat(referenceLinkResponses)
                             .extracting("url", "headTitle", "openGraphTitle", "description", "image", "categoryName")
                             .contains(request.url(), "헤드 타이틀", "오픈그래프 타이틀", "오픈그래프 설명", "오픈그래프 이미지", "스프링");
@@ -114,7 +115,7 @@ class ReferenceLinkServiceTest extends CascadeCleaner {
         referenceLinkRepository.save(generateReferenceLink(reactCategory));
 
         // when
-        final List<ReferenceLinkResponse> responses = referenceLinkService.readAllReferenceLink(
+        final List<ReferenceLinkResponse> responses = referenceLinkService.findAllReferenceLinkByAccessCode(
                 accessCode.getValue());
         // then
         assertThat(responses).hasSize(3);

--- a/backend/src/test/java/site/coduo/todo/service/TodoServiceTest.java
+++ b/backend/src/test/java/site/coduo/todo/service/TodoServiceTest.java
@@ -28,6 +28,7 @@ import site.coduo.todo.domain.TodoSortComparator;
 import site.coduo.todo.exception.TodoNotFoundException;
 import site.coduo.todo.repository.TodoEntity;
 import site.coduo.todo.repository.TodoRepository;
+import site.coduo.todo.service.dto.TodoReadResponse;
 
 @SpringBootTest
 @Transactional
@@ -250,16 +251,15 @@ class TodoServiceTest {
         final List<String> expectOrder = List.of("투두2!!", "투두4!!", "투두3!!", "투두1!!");
 
         // When
-        final List<Todo> all = todoService.getAllOrderBySort(accessCode);
+        final List<TodoReadResponse> actual = todoService.getAllOrderBySort(accessCode);
 
         // Then
-        final List<String> contents = all.stream()
-                .map(Todo::getContent)
-                .map(TodoContent::getContent)
+        final List<String> contents = actual.stream()
+                .map(TodoReadResponse::content)
                 .toList();
 
         assertSoftly(softAssertions -> {
-            softAssertions.assertThat(all).hasSize(expectSize);
+            softAssertions.assertThat(contents).hasSize(expectSize);
             softAssertions.assertThat(contents).isEqualTo(expectOrder);
         });
     }


### PR DESCRIPTION
* refactor: 컨벤션 위반 패키지 구조 수정

* refactor: 컨벤션 위반 패키지 구조 수정

* feat: 페어룸 조회시 todo, category, referenceLink, timer 연관 객체 정보 함께 서빙

* docs: 문서화 오류 및 변경에 따른 수정

## 연관된 이슈

- closes: (이슈 번호)

## 구현한 기능

## 상세 설명
