### PR TITLE
[FE] 🚀 웹소켓 프로토콜 wss에서 ws로 복구

### DIFF
--- a/frontend/src/apis/timer.ts
+++ b/frontend/src/apis/timer.ts
@@ -4,7 +4,7 @@ const API_URL = process.env.REACT_APP_API_URL;
 const SOCKET_URL = process.env.REACT_SOCKET_API_URL;
 
 export const getConnection = (accessCode: string) => {
-  return new WebSocket(`${SOCKET_URL}/wss-connect?accesscode=${accessCode}`);
+  return new WebSocket(`${SOCKET_URL}/ws-connect?accesscode=${accessCode}`);
 };
 
 interface UpdateDurationRequest {


### PR DESCRIPTION
## 상세 설명
wss 연결을 설정하려면 서버에서 추가적인 인증 확인 과정이 필요하다고 합니다. 일단 다시 ws 프로토콜로 복구하겠습니다.