### PR TITLE
[BE] 페어룸 접속, 타이머 변경 시 웹소켓 메세지 전송

### DIFF
--- a/backend/src/main/java/site/coduo/pairroom/controller/PairRoomController.java
+++ b/backend/src/main/java/site/coduo/pairroom/controller/PairRoomController.java
@@ -29,6 +29,7 @@ import site.coduo.pairroom.service.dto.PairRoomExistResponse;
 import site.coduo.pairroom.service.dto.PairRoomMemberResponse;
 import site.coduo.pairroom.service.dto.PairRoomReadRequest;
 import site.coduo.pairroom.service.dto.PairRoomStatusUpdateRequest;
+import site.coduo.sync.service.SchedulerService;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -36,6 +37,7 @@ import site.coduo.pairroom.service.dto.PairRoomStatusUpdateRequest;
 public class PairRoomController implements PairRoomDocs {
 
     private final PairRoomService pairRoomService;
+    private final SchedulerService schedulerService;
 
     @PostMapping("/pair-room")
     public ResponseEntity<PairRoomCreateResponse> createPairRoom(
@@ -72,7 +74,7 @@ public class PairRoomController implements PairRoomDocs {
             @Valid @PathVariable("accessCode") final PairRoomReadRequest request
     ) {
         final PairRoomEntireResponse entirePairRoom = pairRoomService.findEntirePairRoom(request.accessCode());
-
+        schedulerService.notifyTimerStatus(request.accessCode());
         return ResponseEntity.ok(entirePairRoom);
     }
 

--- a/backend/src/main/java/site/coduo/sync/service/SchedulerService.java
+++ b/backend/src/main/java/site/coduo/sync/service/SchedulerService.java
@@ -10,7 +10,6 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.support.PeriodicTrigger;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.socket.WebSocketSession;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,9 +18,8 @@ import site.coduo.timer.domain.TimerStatus;
 import site.coduo.timer.repository.TimerEntity;
 import site.coduo.timer.repository.TimerRepository;
 import site.coduo.timer.service.TimestampRegistry;
-import site.coduo.timer.service.dto.TimerResponse;
-import site.coduo.websocket.PairRoomWebSocketService;
-import site.coduo.websocket.message.EventAndDataMessage;
+import site.coduo.timer.service.dto.TimerStartResponse;
+import site.coduo.timer.service.dto.TimerStatusResponse;
 
 @Transactional
 @Slf4j
@@ -32,7 +30,6 @@ public class SchedulerService {
     public static final Duration DELAY_SECOND = Duration.of(1, ChronoUnit.SECONDS);
 
     private final SimpMessagingTemplate messagingTemplate;
-    private final PairRoomWebSocketService pairRoomWebSocketService;
     private final ThreadPoolTaskScheduler taskScheduler;
     private final SchedulerRegistry schedulerRegistry;
     private final TimestampRegistry timestampRegistry;
@@ -44,7 +41,7 @@ public class SchedulerService {
         }
         messagingTemplate.convertAndSend(
                 "/topic/" + key + "/timer/status",
-                new TimerResponse(TimerStatus.START.getName())
+                new TimerStatusResponse(TimerStatus.START.getName(), null)
         );
         if (isInitial(key)) {
             final Timer timer = timerRepository.fetchTimerByAccessCode(key)
@@ -80,7 +77,7 @@ public class SchedulerService {
         timer.decreaseRemainingTime(DELAY_SECOND.toMillis());
         messagingTemplate.convertAndSend(
                 "/topic/" + key + "/timer",
-                new TimerResponse(timer.getRemainingTime())
+                new TimerStartResponse(timer.getRemainingTime())
         );
     }
 
@@ -94,21 +91,23 @@ public class SchedulerService {
         pauseTimer(key);
         messagingTemplate.convertAndSend(
                 "/topic/" + key + "/timer/status",
-                new TimerResponse(TimerStatus.PAUSE.getName()));
+                new TimerStatusResponse(TimerStatus.PAUSE.getName(), null));
     }
 
     private void stop(final String key, final Timer timer) {
         messagingTemplate.convertAndSend(
                 "/topic/" + key + "/timer/status",
-                new TimerResponse(TimerStatus.PAUSE.getName()));
+                new TimerStatusResponse(TimerStatus.PAUSE.getName(), null));
         schedulerRegistry.release(key);
         final Timer initalTimer = new Timer(timer.getAccessCode(), timer.getDuration(), timer.getDuration());
         timestampRegistry.register(key, initalTimer);
     }
 
-    public void notifyTimerStatus(final WebSocketSession session, final String pairRoomAccessCode) {
-        if (schedulerRegistry.isActive(pairRoomAccessCode)) {
-            pairRoomWebSocketService.sendPairRoomSession(session, new EventAndDataMessage("timer", "running"));
+    public void notifyTimerStatus(final String key) {
+        if (schedulerRegistry.isActive(key)) {
+            messagingTemplate.convertAndSend(
+                    "/topic/" + key + "/timer/status",
+                    new TimerStatusResponse(TimerStatus.RUNNING.getName(), null));
         }
     }
 

--- a/backend/src/main/java/site/coduo/timer/domain/TimerStatus.java
+++ b/backend/src/main/java/site/coduo/timer/domain/TimerStatus.java
@@ -9,6 +9,7 @@ public enum TimerStatus {
 
     START("start"),
     PAUSE("pause"),
+    RUNNING("running"),
     UPDATE("update");
 
     private final String name;

--- a/backend/src/main/java/site/coduo/timer/service/TimerService.java
+++ b/backend/src/main/java/site/coduo/timer/service/TimerService.java
@@ -12,7 +12,7 @@ import site.coduo.timer.domain.Timer;
 import site.coduo.timer.domain.TimerStatus;
 import site.coduo.timer.repository.TimerEntity;
 import site.coduo.timer.repository.TimerRepository;
-import site.coduo.timer.service.dto.TimerResponse;
+import site.coduo.timer.service.dto.TimerStatusResponse;
 import site.coduo.timer.service.dto.TimerUpdateRequest;
 
 @Transactional(readOnly = true)
@@ -48,7 +48,7 @@ public class TimerService {
         timestampRegistry.register(accessCode, newTimer);
         messagingTemplate.convertAndSend(
                 "/topic/" + accessCode + "/timer/status",
-                new TimerResponse(TimerStatus.UPDATE.getName())
+                new TimerStatusResponse(TimerStatus.UPDATE.getName(), newTimer.getDuration())
         );
     }
 }

--- a/backend/src/main/java/site/coduo/timer/service/dto/TimerResponse.java
+++ b/backend/src/main/java/site/coduo/timer/service/dto/TimerResponse.java
@@ -1,6 +1,0 @@
-package site.coduo.timer.service.dto;
-
-public record TimerResponse(
-        Object data
-) {
-}

--- a/backend/src/main/java/site/coduo/timer/service/dto/TimerStartResponse.java
+++ b/backend/src/main/java/site/coduo/timer/service/dto/TimerStartResponse.java
@@ -1,0 +1,6 @@
+package site.coduo.timer.service.dto;
+
+public record TimerStartResponse(
+        long data
+) {
+}

--- a/backend/src/main/java/site/coduo/timer/service/dto/TimerStatusResponse.java
+++ b/backend/src/main/java/site/coduo/timer/service/dto/TimerStatusResponse.java
@@ -1,0 +1,7 @@
+package site.coduo.timer.service.dto;
+
+public record TimerStatusResponse(
+        String status,
+        Long data
+) {
+}

--- a/backend/src/main/java/site/coduo/websocket/WebSocketBrokerConfig.java
+++ b/backend/src/main/java/site/coduo/websocket/WebSocketBrokerConfig.java
@@ -19,8 +19,9 @@ public class WebSocketBrokerConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOrigins("wss://localhost", "wss://coduo.site", "wss://test.coduo.site",
-                        "http://localhost", "http://coduo.site", "http://test.coduo.site",
-                        "https://localhost", "https://coduo.site", "https://test.coduo.site");
+                .setAllowedOrigins("*");
+//                .setAllowedOrigins("wss://localhost", "wss://coduo.site", "wss://test.coduo.site",
+//                        "http://localhost", "http://coduo.site", "http://test.coduo.site",
+//                        "https://localhost", "https://coduo.site", "https://test.coduo.site");
     }
 }

--- a/backend/src/main/java/site/coduo/websocket/WebSocketHandler.java
+++ b/backend/src/main/java/site/coduo/websocket/WebSocketHandler.java
@@ -22,7 +22,7 @@ public class WebSocketHandler extends TextWebSocketHandler {
     public void afterConnectionEstablished(final WebSocketSession session) {
         final String pairRoomAccessCode = parsePairRoomAccessCode(session);
         pairRoomWebSocketSessionStore.addSession(pairRoomAccessCode, session);
-        schedulerService.notifyTimerStatus(session, pairRoomAccessCode);
+        schedulerService.notifyTimerStatus(pairRoomAccessCode);
         log.info("연결 성공 : {}", session.getId());
     }
 

--- a/backend/src/test/java/site/coduo/sync/service/SchedulerServiceTest.java
+++ b/backend/src/test/java/site/coduo/sync/service/SchedulerServiceTest.java
@@ -22,15 +22,11 @@ import site.coduo.timer.domain.Timer;
 import site.coduo.timer.repository.TimerEntity;
 import site.coduo.timer.repository.TimerRepository;
 import site.coduo.timer.service.TimestampRegistry;
-import site.coduo.websocket.PairRoomWebSocketService;
 
 @Disabled
 @SpringBootTest
 class SchedulerServiceTest {
 
-    @Autowired
-    private PairRoomWebSocketService pairRoomWebSocketService;
-    
     private ThreadPoolTaskScheduler taskScheduler;
 
     @Autowired
@@ -46,11 +42,9 @@ class SchedulerServiceTest {
     @BeforeEach
     void setUp() {
         timerRepository = mock(TimerRepository.class);
-        pairRoomWebSocketService = mock(PairRoomWebSocketService.class);
 
         schedulerService = new SchedulerService(
                 messagingTemplate,
-                pairRoomWebSocketService,
                 taskScheduler,
                 schedulerRegistry,
                 timestampRegistry,


### PR DESCRIPTION
## 연관된 이슈

- closes: #1067 

## 구현한 기능
- 페어룸 접속 시 해당 페어룸의 타이머가 실행중이면 status: running, data: null 웹소켓 메세지로 전송
- 타이머 시간 변경 시 status: update, data: 변경한 시간 웹소켓 메세지로 전송

## 상세 설명
