### PR TITLE
[BE] 링크 조회 n+1 문제 해결

### DIFF
--- a/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
@@ -132,7 +132,7 @@ public class PairRoomService {
         final List<CategoryReadResponse> categoryReadResponses = categoryService.findAllByPairRoomAccessCode(
                 pairRoomEntity.getAccessCode());
         final List<ReferenceLinkResponse> referenceLinkResponses = referenceLinkService
-                .findAllReferenceLinkByAccessCode(accessCode);
+                .findAllReferenceLinkWithOpenGraphByAccessCode(accessCode);
         final List<TodoReadResponse> todoReadResponses = todoService.getAllOrderBySort(accessCode);
 
         final PairRoomReadResponse pairRoomReadResponse = PairRoomReadResponse.of(pairRoomEntity.toDomain(), timer);

--- a/backend/src/main/java/site/coduo/referencelink/controller/ReferenceLinkController.java
+++ b/backend/src/main/java/site/coduo/referencelink/controller/ReferenceLinkController.java
@@ -43,7 +43,7 @@ public class ReferenceLinkController implements ReferenceLinkDocs {
     public ResponseEntity<List<ReferenceLinkResponse>> getReferenceLinks(
             @PathVariable("accessCode") final String accessCodeText
     ) {
-        final List<ReferenceLinkResponse> responses = referenceLinkService.findAllReferenceLinkByAccessCode(
+        final List<ReferenceLinkResponse> responses = referenceLinkService.findAllReferenceLinkWithOpenGraphByAccessCode(
                 accessCodeText);
 
         return ResponseEntity.ok(responses);

--- a/backend/src/main/java/site/coduo/referencelink/repository/OpenGraphRepository.java
+++ b/backend/src/main/java/site/coduo/referencelink/repository/OpenGraphRepository.java
@@ -1,12 +1,20 @@
 package site.coduo.referencelink.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import site.coduo.pairroom.repository.PairRoomEntity;
 
 public interface OpenGraphRepository extends JpaRepository<OpenGraphEntity, Long> {
 
     void deleteByReferenceLinkEntity(ReferenceLinkEntity referenceLinkEntity);
 
     Optional<OpenGraphEntity> findByReferenceLinkEntityId(Long id);
+
+    @Query("SELECT og FROM OpenGraphEntity og JOIN FETCH og.referenceLinkEntity rl WHERE rl.pairRoomEntity =:pairRoomEntity")
+    List<OpenGraphEntity> findAllByPairRoomEntity(@Param(value = "pairRoomEntity") PairRoomEntity pairRoomEntity);
 }

--- a/backend/src/main/java/site/coduo/referencelink/service/OpenGraphService.java
+++ b/backend/src/main/java/site/coduo/referencelink/service/OpenGraphService.java
@@ -1,12 +1,14 @@
 package site.coduo.referencelink.service;
 
 import java.net.URL;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import site.coduo.pairroom.repository.PairRoomEntity;
 import site.coduo.referencelink.domain.OpenGraph;
 import site.coduo.referencelink.repository.OpenGraphEntity;
 import site.coduo.referencelink.repository.OpenGraphRepository;
@@ -34,6 +36,11 @@ public class OpenGraphService {
             return openGraphEntity.get().toDomain();
         }
         return new OpenGraph();
+    }
+
+    @Transactional(readOnly = true)
+    public List<OpenGraphEntity> findAllByPairRoomEntity(final PairRoomEntity pairRoomEntity) {
+        return openGraphRepository.findAllByPairRoomEntity(pairRoomEntity);
     }
 
     public void deleteByReferenceLink(final ReferenceLinkEntity referenceLinkEntity) {

--- a/backend/src/main/java/site/coduo/referencelink/service/ReferenceLinkService.java
+++ b/backend/src/main/java/site/coduo/referencelink/service/ReferenceLinkService.java
@@ -19,6 +19,7 @@ import site.coduo.referencelink.domain.ReferenceLink;
 import site.coduo.referencelink.exception.InvalidUrlFormatException;
 import site.coduo.referencelink.repository.CategoryEntity;
 import site.coduo.referencelink.repository.CategoryRepository;
+import site.coduo.referencelink.repository.OpenGraphEntity;
 import site.coduo.referencelink.repository.ReferenceLinkEntity;
 import site.coduo.referencelink.repository.ReferenceLinkRepository;
 import site.coduo.referencelink.service.dto.ReferenceLinkCreateRequest;
@@ -72,31 +73,29 @@ public class ReferenceLinkService {
     }
 
     @Transactional(readOnly = true)
-    public List<ReferenceLinkResponse> findAllReferenceLinkByAccessCode(final String accessCode) {
-        final PairRoomEntity pairRoom = pairRoomRepository.fetchByAccessCode(accessCode);
-
-        final List<ReferenceLinkEntity> referenceLinkEntities = referenceLinkRepository.findByPairRoomEntity(pairRoom);
-
-        return referenceLinkEntities.stream()
-                .map(this::makeReferenceLinkResponse)
-                .toList();
-    }
-
-    @Transactional(readOnly = true)
     public List<ReferenceLinkResponse> findReferenceLinksByCategory(
             final String accessCodeText,
             final Long categoryId
     ) {
-        final AccessCode accessCode = new AccessCode(accessCodeText);
-        final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCode);
+        final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCodeText);
         final CategoryEntity categoryEntity = categoryRepository.fetchByPairRoomAndCategoryId(pairRoomEntity,
                 categoryId);
-        final Category category = new Category(categoryEntity.getCategoryName());
+        final List<ReferenceLinkResponse> allReferenceLinks = findAllReferenceLinkWithOpenGraphByAccessCode(
+                accessCodeText);
+        return filterByCategoryName(allReferenceLinks, categoryEntity.getCategoryName());
+    }
 
-        return referenceLinkRepository.findByPairRoomEntity(pairRoomEntity)
-                .stream()
-                .filter(link -> link.isSameCategory(category))
-                .map(this::makeReferenceLinkResponse)
+    @Transactional(readOnly = true)
+    public List<ReferenceLinkResponse> findAllReferenceLinkWithOpenGraphByAccessCode(final String accessCode) {
+        final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCode);
+        final List<OpenGraphEntity> openGraphEntities = openGraphService.findAllByPairRoomEntity(pairRoomEntity);
+        return ReferenceLinkResponse.from(openGraphEntities);
+    }
+
+    private List<ReferenceLinkResponse> filterByCategoryName(final List<ReferenceLinkResponse> allReferenceLinks,
+                                                             final String categoryName) {
+        return allReferenceLinks.stream()
+                .filter(referenceLink -> referenceLink.categoryName().equals(categoryName))
                 .toList();
     }
 
@@ -115,11 +114,6 @@ public class ReferenceLinkService {
                 .stream()
                 .filter(link -> link.isSameCategory(category))
                 .toList();
-    }
-
-    private ReferenceLinkResponse makeReferenceLinkResponse(final ReferenceLinkEntity referenceLinkEntity) {
-        final OpenGraph openGraph = openGraphService.findOpenGraph(referenceLinkEntity.getId());
-        return new ReferenceLinkResponse(referenceLinkEntity, openGraph);
     }
 
     public void deleteReferenceLink(final String accessCodeText, final long id) {

--- a/backend/src/main/java/site/coduo/referencelink/service/dto/ReferenceLinkResponse.java
+++ b/backend/src/main/java/site/coduo/referencelink/service/dto/ReferenceLinkResponse.java
@@ -1,9 +1,12 @@
 package site.coduo.referencelink.service.dto;
 
+import java.util.List;
+
 import jakarta.validation.constraints.NotBlank;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import site.coduo.referencelink.domain.OpenGraph;
+import site.coduo.referencelink.repository.OpenGraphEntity;
 import site.coduo.referencelink.repository.ReferenceLinkEntity;
 
 @Schema(description = "레퍼런스 링크 응답")
@@ -54,5 +57,13 @@ public record ReferenceLinkResponse(
                 openGraph.getImage(),
                 referenceLinkEntity.getCategoryName()
         );
+    }
+
+    public static List<ReferenceLinkResponse> from(final List<OpenGraphEntity> openGraphEntities) {
+        return openGraphEntities.stream()
+                .map(openGraphEntity -> new ReferenceLinkResponse(
+                        openGraphEntity.getReferenceLinkEntity(), openGraphEntity.toDomain()
+                ))
+                .toList();
     }
 }

--- a/backend/src/test/java/site/coduo/referencelink/service/ReferenceLinkServiceTest.java
+++ b/backend/src/test/java/site/coduo/referencelink/service/ReferenceLinkServiceTest.java
@@ -84,8 +84,8 @@ class ReferenceLinkServiceTest extends CascadeCleaner {
                 () -> assertThat(openGraphRepository.findAll()).hasSize(1),
                 () -> {
                     final ReferenceLinkResponse referenceLinkResponses =
-                            referenceLinkService.findAllReferenceLinkByAccessCode(pairRoomEntity.getAccessCode())
-                                    .get(0);
+                            referenceLinkService.findAllReferenceLinkWithOpenGraphByAccessCode(
+                                    pairRoomEntity.getAccessCode()).get(0);
                     assertThat(referenceLinkResponses)
                             .extracting("url", "headTitle", "openGraphTitle", "description", "image", "categoryName")
                             .contains(request.url(), "헤드 타이틀", "오픈그래프 타이틀", "오픈그래프 설명", "오픈그래프 이미지", "스프링");
@@ -107,16 +107,20 @@ class ReferenceLinkServiceTest extends CascadeCleaner {
 
     @Test
     @DisplayName("모든 레퍼런스 링크를 조회한다.")
-    void search_all_reference_link() throws MalformedURLException {
+    void search_all_reference_link() {
         // given
-        final AccessCode accessCode = new AccessCode(pairRoomEntity.getAccessCode());
-        referenceLinkRepository.save(generateReferenceLink(springCategory));
-        referenceLinkRepository.save(generateReferenceLink(springCategory));
-        referenceLinkRepository.save(generateReferenceLink(reactCategory));
+        final String accessCode = pairRoomEntity.getAccessCode();
+        referenceLinkService.createReferenceLink(accessCode,
+                new ReferenceLinkCreateRequest(FakeServer.testUrl, springCategory.getId()));
+        referenceLinkService.createReferenceLink(accessCode,
+                new ReferenceLinkCreateRequest(FakeServer.testUrl, springCategory.getId()));
+        referenceLinkService.createReferenceLink(accessCode,
+                new ReferenceLinkCreateRequest(FakeServer.testUrl, reactCategory.getId()));
 
         // when
-        final List<ReferenceLinkResponse> responses = referenceLinkService.findAllReferenceLinkByAccessCode(
-                accessCode.getValue());
+        final List<ReferenceLinkResponse> responses = referenceLinkService.findAllReferenceLinkWithOpenGraphByAccessCode(
+                accessCode);
+
         // then
         assertThat(responses).hasSize(3);
     }
@@ -157,13 +161,13 @@ class ReferenceLinkServiceTest extends CascadeCleaner {
     @DisplayName("카테고리가 일치하는 모든 레퍼런스 링크를 조회한다.")
     void find_reference_links_by_category() throws MalformedURLException {
         // given
-        final ReferenceLinkEntity reactReferenceLink = generateReferenceLink(reactCategory);
-        final ReferenceLinkEntity reactReferenceLink2 = generateReferenceLink(reactCategory);
-        final ReferenceLinkEntity springReferenceLink = generateReferenceLink(springCategory);
-
-        referenceLinkRepository.save(reactReferenceLink);
-        referenceLinkRepository.save(reactReferenceLink2);
-        referenceLinkRepository.save(springReferenceLink);
+        final String accessCode = pairRoomEntity.getAccessCode();
+        referenceLinkService.createReferenceLink(accessCode,
+                new ReferenceLinkCreateRequest(FakeServer.testUrl, reactCategory.getId()));
+        referenceLinkService.createReferenceLink(accessCode,
+                new ReferenceLinkCreateRequest(FakeServer.testUrl, reactCategory.getId()));
+        referenceLinkService.createReferenceLink(accessCode,
+                new ReferenceLinkCreateRequest(FakeServer.testUrl, springCategory.getId()));
 
         // when
         final List<ReferenceLinkResponse> referenceLinksByCategory = referenceLinkService.findReferenceLinksByCategory(


### PR DESCRIPTION
## 연관된 이슈

- closes: #1084 

## 구현한 기능

레퍼런스 링크 전체 조회 및 카테고리 필터링 로직에서 발생한 N+1 문제를 해결하기 위해 조회 메서드를 수정했습니다.

## 상세 설명

링크 와 오픈그래프 테이블을 병합하는게 더 좋을것 같지만 작업 규모가 커서 우선 fetch join으로 해결합니다.