### PR TITLE
[BE] 투두 웹소켓 예외 처리 기능  구현

### DIFF
--- a/backend/src/main/java/site/coduo/todo/controller/TodoExceptionHandler.java
+++ b/backend/src/main/java/site/coduo/todo/controller/TodoExceptionHandler.java
@@ -3,18 +3,25 @@ package site.coduo.todo.controller;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import site.coduo.common.controller.response.ApiErrorResponse;
 import site.coduo.todo.controller.error.TodoApiError;
 import site.coduo.todo.exception.TodoException;
+import site.coduo.todo.exception.TodoWebSocketException;
 
 @Slf4j
+@RequiredArgsConstructor
 @RestControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class TodoExceptionHandler {
+
+    private final SimpMessagingTemplate simpMessagingTemplate;
 
     @ExceptionHandler(TodoException.class)
     public ResponseEntity<ApiErrorResponse> handleTodoException(final TodoException e) {
@@ -22,5 +29,12 @@ public class TodoExceptionHandler {
 
         return ResponseEntity.status(TodoApiError.INVALID_TODO_REQUEST.getHttpStatus())
                 .body(new ApiErrorResponse(e.getMessage()));
+    }
+
+    @MessageExceptionHandler(TodoWebSocketException.class)
+    public void handleTodoWebSocketException(final TodoWebSocketException e) {
+        log.warn(e.getMessage());
+
+        simpMessagingTemplate.convertAndSend(e.getTopic(), e.getMessage());
     }
 }

--- a/backend/src/main/java/site/coduo/todo/controller/TodoWebSocketController.java
+++ b/backend/src/main/java/site/coduo/todo/controller/TodoWebSocketController.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import site.coduo.todo.service.TodoService;
+import site.coduo.todo.service.TodoServiceFacade;
 import site.coduo.todo.service.dto.CreateTodoRequest;
 import site.coduo.todo.service.dto.TodoReadResponse;
 import site.coduo.todo.service.dto.UpdateTodoContentRequest;
@@ -20,14 +20,13 @@ import site.coduo.todo.service.dto.UpdateTodoOrderRequest;
 @RequiredArgsConstructor
 public class TodoWebSocketController {
 
-    private final TodoService todoService;
+    private final TodoServiceFacade todoServiceFacade;
 
     @MessageMapping("/{accessCode}/todo/post")
     @SendTo("/topic/{accessCode}/todo")
     public List<TodoReadResponse> createTodo(final CreateTodoRequest request,
                                              @DestinationVariable("accessCode") final String accessCode) {
-        todoService.createTodo(accessCode, request.contents());
-        return todoService.getAllOrderBySort(accessCode);
+        return todoServiceFacade.createTodo(request, accessCode);
     }
 
     @MessageMapping("/{accessCode}/todo/update/{todoId}/order")
@@ -35,8 +34,7 @@ public class TodoWebSocketController {
     public List<TodoReadResponse> modifyTodoOrder(final UpdateTodoOrderRequest request,
                                                   @DestinationVariable("accessCode") final String accessCode,
                                                   @DestinationVariable("todoId") final Long id) {
-        todoService.updateTodoSort(id, request.order());
-        return todoService.getAllOrderBySort(accessCode);
+        return todoServiceFacade.updateTodoOrder(request, accessCode, id);
     }
 
     @MessageMapping("/{accessCode}/todo/update/{todoId}/contents")
@@ -44,21 +42,20 @@ public class TodoWebSocketController {
     public List<TodoReadResponse> modifyTodoContent(@DestinationVariable("todoId") final long todoId,
                                                     @DestinationVariable("accessCode") final String accessCode,
                                                     final UpdateTodoContentRequest request) {
-        todoService.updateTodoContent(todoId, request.contents());
-        return todoService.getAllOrderBySort(accessCode);
+        return todoServiceFacade.updateTodoContent(request, accessCode, todoId);
     }
 
     @MessageMapping("/{accessCode}/todo/update/{todoId}/checked")
     @SendTo("/topic/{accessCode}/todo")
-    public List<TodoReadResponse> modifyTodoCheck(@DestinationVariable("todoId") final long todoId,
+    public List<TodoReadResponse> modifyTodoCheck(@DestinationVariable("todoId") final Long todoId,
                                                   @DestinationVariable("accessCode") final String accessCode) {
-        todoService.toggleTodoChecked(todoId);
-        return todoService.getAllOrderBySort(accessCode);
+        return todoServiceFacade.updateTodoChecked(todoId, accessCode);
     }
 
     @MessageMapping("/todo/{accessCode}/{todoId}/delete")
     @SendTo("/topic/{accessCode}/todo")
-    public List<TodoReadResponse> delete(@DestinationVariable("todoId") final long todoId) {
-        return todoService.deleteTodo(todoId);
+    public List<TodoReadResponse> delete(@DestinationVariable("todoId") final long todoId,
+                                         @DestinationVariable("accessCode") final String accessCode) {
+        return todoServiceFacade.deleteTodo(todoId, accessCode);
     }
 }

--- a/backend/src/main/java/site/coduo/todo/controller/TodoWebSocketController.java
+++ b/backend/src/main/java/site/coduo/todo/controller/TodoWebSocketController.java
@@ -52,7 +52,7 @@ public class TodoWebSocketController {
         return todoServiceFacade.updateTodoChecked(todoId, accessCode);
     }
 
-    @MessageMapping("/todo/{accessCode}/{todoId}/delete")
+    @MessageMapping("{accessCode}/todo/delete/{todoId}")
     @SendTo("/topic/{accessCode}/todo")
     public List<TodoReadResponse> delete(@DestinationVariable("todoId") final Long todoId,
                                          @DestinationVariable("accessCode") final String accessCode) {

--- a/backend/src/main/java/site/coduo/todo/controller/TodoWebSocketController.java
+++ b/backend/src/main/java/site/coduo/todo/controller/TodoWebSocketController.java
@@ -54,7 +54,7 @@ public class TodoWebSocketController {
 
     @MessageMapping("/todo/{accessCode}/{todoId}/delete")
     @SendTo("/topic/{accessCode}/todo")
-    public List<TodoReadResponse> delete(@DestinationVariable("todoId") final long todoId,
+    public List<TodoReadResponse> delete(@DestinationVariable("todoId") final Long todoId,
                                          @DestinationVariable("accessCode") final String accessCode) {
         return todoServiceFacade.deleteTodo(todoId, accessCode);
     }

--- a/backend/src/main/java/site/coduo/todo/domain/TodoContent.java
+++ b/backend/src/main/java/site/coduo/todo/domain/TodoContent.java
@@ -6,6 +6,9 @@ import site.coduo.todo.exception.InvalidTodoContentException;
 @Getter
 public class TodoContent {
 
+    private static final int MIN_LENGTH = 0;
+    private static final int MAX_LENGTH = 255;
+
     private final String content;
 
     public TodoContent(final String content) {
@@ -16,6 +19,9 @@ public class TodoContent {
     private void validateContent(final String content) {
         if (content == null || content.isBlank()) {
             throw new InvalidTodoContentException("투두 아이템 내용이 null이거나 공백일 수 없습니다.");
+        }
+        if (content.length() < MIN_LENGTH || content.length() > MAX_LENGTH) {
+            throw new InvalidTodoContentException("투두의 내용은 %d ~ %d 사이여야 합니다.".formatted(MIN_LENGTH, MAX_LENGTH));
         }
     }
 }

--- a/backend/src/main/java/site/coduo/todo/exception/TodoWebSocketException.java
+++ b/backend/src/main/java/site/coduo/todo/exception/TodoWebSocketException.java
@@ -1,0 +1,14 @@
+package site.coduo.todo.exception;
+
+import lombok.Getter;
+
+@Getter
+public class TodoWebSocketException extends RuntimeException {
+
+    private final String topic;
+
+    public TodoWebSocketException(final String topic, final String message) {
+        super(message);
+        this.topic = topic;
+    }
+}

--- a/backend/src/main/java/site/coduo/todo/service/TodoService.java
+++ b/backend/src/main/java/site/coduo/todo/service/TodoService.java
@@ -87,16 +87,11 @@ public class TodoService {
         todoRepository.save(new TodoEntity(updated, targetTodo.getPairRoomEntity()));
     }
 
-    public List<TodoReadResponse> deleteTodo(final Long todoId) {
+    public void deleteTodo(final Long todoId) {
         final TodoEntity todoEntity = todoRepository.findById(todoId)
                 .orElseThrow(() -> new TodoNotFoundException("존재하지 않은 todo id입니다." + todoId));
         checkPairRoomIsActive(todoEntity.getPairRoomEntity());
         todoRepository.deleteById(todoId);
-        final List<Todo> todos = todoRepository.findAllByPairRoomEntity(todoEntity.getPairRoomEntity())
-                .stream()
-                .map(TodoEntity::toDomain)
-                .toList();
-        return TodoReadResponse.of(todos);
     }
 
     private void checkPairRoomIsActive(final PairRoomEntity pairRoomEntity) {

--- a/backend/src/main/java/site/coduo/todo/service/TodoServiceFacade.java
+++ b/backend/src/main/java/site/coduo/todo/service/TodoServiceFacade.java
@@ -1,0 +1,55 @@
+package site.coduo.todo.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import site.coduo.todo.exception.TodoException;
+import site.coduo.todo.exception.TodoWebSocketException;
+import site.coduo.todo.service.dto.CreateTodoRequest;
+import site.coduo.todo.service.dto.TodoReadResponse;
+import site.coduo.todo.service.dto.UpdateTodoContentRequest;
+import site.coduo.todo.service.dto.UpdateTodoOrderRequest;
+
+@RequiredArgsConstructor
+@Component
+public class TodoServiceFacade {
+
+    private static final String TOPIC_FORMAT = "/topic/%s/todo";
+
+    private final TodoService todoService;
+
+    public List<TodoReadResponse> createTodo(final CreateTodoRequest request, final String accessCode) {
+        return execute(() -> todoService.createTodo(accessCode, request.contents()), accessCode);
+    }
+
+    private List<TodoReadResponse> execute(final Runnable runnable, final String accessCode) {
+        try {
+            runnable.run();
+            return todoService.getAllOrderBySort(accessCode);
+        } catch (final TodoException e) {
+            throw new TodoWebSocketException(String.format(TOPIC_FORMAT, accessCode), e.getMessage());
+        }
+    }
+
+    public List<TodoReadResponse> updateTodoOrder(final UpdateTodoOrderRequest request,
+                                                  final String accessCode,
+                                                  final Long id) {
+        return execute(() -> todoService.updateTodoSort(id, request.order()), accessCode);
+    }
+
+    public List<TodoReadResponse> updateTodoContent(final UpdateTodoContentRequest request,
+                                                    final String accessCode,
+                                                    final Long id) {
+        return execute(() -> todoService.updateTodoContent(id, request.contents()), accessCode);
+    }
+
+    public List<TodoReadResponse> updateTodoChecked(final Long todoId, final String accessCode) {
+        return execute(() -> todoService.toggleTodoChecked(todoId), accessCode);
+    }
+
+    public List<TodoReadResponse> deleteTodo(final Long todoId, final String accessCode) {
+        return execute(() -> todoService.deleteTodo(todoId), accessCode);
+    }
+}

--- a/backend/src/main/java/site/coduo/websocket/stomp/WebSocketBrokerConfig.java
+++ b/backend/src/main/java/site/coduo/websocket/stomp/WebSocketBrokerConfig.java
@@ -19,6 +19,7 @@ public class WebSocketBrokerConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOrigins("http://localhost:3000", "https://coduo.site", "https://test.coduo.site");
+                .setAllowedOrigins("http://localhost:3000", "https://coduo.site", "https://test.coduo.site",
+                        "https://cdiptangshu.github.io");
     }
 }

--- a/backend/src/main/java/site/coduo/websocket/stomp/WebSocketBrokerConfig.java
+++ b/backend/src/main/java/site/coduo/websocket/stomp/WebSocketBrokerConfig.java
@@ -19,7 +19,6 @@ public class WebSocketBrokerConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOrigins("http://localhost:3000", "https://coduo.site", "https://test.coduo.site",
-                        "https://cdiptangshu.github.io");
+                .setAllowedOrigins("http://localhost:3000", "https://coduo.site", "https://test.coduo.site");
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- closes: #1098

## 구현한 기능
웹소켓 예외처리를 위한 예시 코드 의견(?) 자유롭게 피드백해주세요. 투두에만 일단 빠르게 구현가능한대로 구현해봤습니다.
웹소켓 예외 처리를위해 퍼사드를 추가한 이유는 다음과 같아요.
+ 웹 소켓 통신도 Service 계층을 사용함
+ 웹소캣을 @ControllerAdivce 에서 잡고 해당 topic에 전달하기 위해 SimpleMessageTemplate을 ControllerAdvice에서 사용해햐는데, 우리는 토픽이 accessCOde 단위이기 때문에 각 예외에 accessCode 담아 한번 감싸 ControllerAdvice로 보내야함.왜냐하면 ControllerAdvice는 매개변수로 예외만 기본적으로 잡기때문이에요.


## 상세 설명
