### PR TITLE
[BE] 페어룸 종료 시 completed STOMP 메세지 전송

### DIFF
--- a/backend/src/main/java/site/coduo/pairroom/domain/PairRoomStatus.java
+++ b/backend/src/main/java/site/coduo/pairroom/domain/PairRoomStatus.java
@@ -6,17 +6,20 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import site.coduo.pairroom.exception.InvalidPairRoomStatusException;
 
+@RequiredArgsConstructor
 @Getter
 public enum PairRoomStatus {
 
-    IN_PROGRESS,
-    COMPLETED,
-    DELETED;
+    IN_PROGRESS("in_progress"),
+    COMPLETED("completed"),
+    DELETED("deleted");
 
     private static final Map<String, PairRoomStatus> STATUS = Arrays.stream(values())
             .collect(Collectors.toMap(PairRoomStatus::name, Function.identity()));
+    private final String name;
 
     public static PairRoomStatus findByName(String value) {
         if (STATUS.containsKey(value)) {

--- a/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
@@ -46,6 +46,7 @@ import site.coduo.todo.service.dto.TodoReadResponse;
 @Service
 public class PairRoomService {
 
+    private final PairRoomStompManager pairRoomStompManager;
     private final PairRoomRepository pairRoomRepository;
     private final TimerRepository timerRepository;
     private final CategoryService categoryService;
@@ -172,6 +173,7 @@ public class PairRoomService {
         final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCode);
         checkPairRoomIsActive(pairRoomEntity);
         pairRoomEntity.updateStatus(PairRoomStatus.COMPLETED);
+        pairRoomStompManager.send(accessCode, PairRoomStatus.COMPLETED);
     }
 
     private void checkPairRoomIsDeleted(final PairRoomEntity pairRoomEntity) {

--- a/backend/src/main/java/site/coduo/pairroom/service/PairRoomStompManager.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/PairRoomStompManager.java
@@ -18,7 +18,7 @@ public class PairRoomStompManager {
     public void send(final String accessCode, final PairRoomStatus pairRoomStatus) {
         simpMessagingTemplate.convertAndSend(
                 String.format(STATUS_DESTINATION, accessCode),
-                new PairRoomStatusResponse(pairRoomStatus.name())
+                new PairRoomStatusResponse(pairRoomStatus.getName())
         );
     }
 }

--- a/backend/src/main/java/site/coduo/pairroom/service/PairRoomStompManager.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/PairRoomStompManager.java
@@ -1,0 +1,24 @@
+package site.coduo.pairroom.service;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import site.coduo.pairroom.domain.PairRoomStatus;
+import site.coduo.pairroom.service.dto.PairRoomStatusResponse;
+
+@RequiredArgsConstructor
+@Component
+public class PairRoomStompManager {
+
+    private static final String STATUS_DESTINATION = "/topic/%s/pair-room/status";
+
+    private final SimpMessagingTemplate simpMessagingTemplate;
+
+    public void send(final String accessCode, final PairRoomStatus pairRoomStatus) {
+        simpMessagingTemplate.convertAndSend(
+                String.format(STATUS_DESTINATION, accessCode),
+                new PairRoomStatusResponse(pairRoomStatus.name())
+        );
+    }
+}

--- a/backend/src/main/java/site/coduo/pairroom/service/dto/PairRoomStatusResponse.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/dto/PairRoomStatusResponse.java
@@ -1,0 +1,4 @@
+package site.coduo.pairroom.service.dto;
+
+public record PairRoomStatusResponse(String status) {
+}


### PR DESCRIPTION
## 연관된 이슈

- closes: #1111 

## 구현한 기능
- 페어룸 종료 시 completed STOMP 메세지를 전송하여 페어룸에 있는 모든 사용자가 종료된 페어룸 상태를 갖도록 함
