### PR TITLE
[BE] 카테고리 버그 수정

### DIFF
--- a/backend/src/main/java/site/coduo/referencelink/service/CategoryService.java
+++ b/backend/src/main/java/site/coduo/referencelink/service/CategoryService.java
@@ -64,7 +64,7 @@ public class CategoryService {
         validateDuplicated(request.value(), pairRoomEntity);
         final CategoryEntity categoryEntity = categoryRepository.fetchByPairRoomAndCategoryId(pairRoomEntity,
                 categoryId);
-        final Category category = new Category(categoryEntity.getCategoryName());
+        final Category category = new Category(request.value());
         categoryEntity.updateCategoryName(category);
         return new CategoryUpdateResponse(categoryEntity.getCategoryName());
     }

--- a/backend/src/test/java/site/coduo/acceptance/CategoryAcceptanceTest.java
+++ b/backend/src/test/java/site/coduo/acceptance/CategoryAcceptanceTest.java
@@ -2,7 +2,6 @@ package site.coduo.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -59,7 +58,6 @@ class CategoryAcceptanceTest extends AcceptanceFixture {
                 .statusCode(200);
     }
 
-    @Disabled
     @Test
     @DisplayName("카테고리를 업데이트 한다.")
     void update_category() {


### PR DESCRIPTION
## 연관된 이슈

- closes: (이슈 번호) #1122 

## 구현한 기능

## 상세 설명

이전 PR(#1116)에서 카테고리 이름을 수정할때,
수정할 카테고리 이름의 길이를 검증하고자 new Category(수정할 카테고리 이름)를 추가해야 하는데 
실수로 new Category(기존 카테고리 이름) 으로 코드를 작성했습니다.

new Category(수정할 카테고리 이름) 안에서 수정할 카테고리 이름에 대한 길이 검증을 하고 있습니다.