### PR TITLE
[BE] 페어룸 & 타이머 상태 대문자로 변경 및 리팩토링

### DIFF
--- a/backend/src/main/java/site/coduo/pairroom/domain/PairRoomStatus.java
+++ b/backend/src/main/java/site/coduo/pairroom/domain/PairRoomStatus.java
@@ -13,13 +13,12 @@ import site.coduo.pairroom.exception.InvalidPairRoomStatusException;
 @Getter
 public enum PairRoomStatus {
 
-    IN_PROGRESS("in_progress"),
-    COMPLETED("completed"),
-    DELETED("deleted");
+    IN_PROGRESS,
+    COMPLETED,
+    DELETED;
 
     private static final Map<String, PairRoomStatus> STATUS = Arrays.stream(values())
             .collect(Collectors.toMap(PairRoomStatus::name, Function.identity()));
-    private final String name;
 
     public static PairRoomStatus findByName(String value) {
         if (STATUS.containsKey(value)) {

--- a/backend/src/main/java/site/coduo/pairroom/domain/PairRoomStatus.java
+++ b/backend/src/main/java/site/coduo/pairroom/domain/PairRoomStatus.java
@@ -13,12 +13,13 @@ import site.coduo.pairroom.exception.InvalidPairRoomStatusException;
 @Getter
 public enum PairRoomStatus {
 
-    IN_PROGRESS,
-    COMPLETED,
-    DELETED;
+    IN_PROGRESS("IN_PROGRESS"),
+    COMPLETED("COMPLETED"),
+    DELETED("DELETED");
 
     private static final Map<String, PairRoomStatus> STATUS = Arrays.stream(values())
             .collect(Collectors.toMap(PairRoomStatus::name, Function.identity()));
+    private final String message;
 
     public static PairRoomStatus findByName(String value) {
         if (STATUS.containsKey(value)) {

--- a/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/PairRoomService.java
@@ -173,7 +173,7 @@ public class PairRoomService {
         final PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(accessCode);
         checkPairRoomIsActive(pairRoomEntity);
         pairRoomEntity.updateStatus(PairRoomStatus.COMPLETED);
-        pairRoomStompManager.send(accessCode, PairRoomStatus.COMPLETED);
+        pairRoomStompManager.sendStatus(accessCode, PairRoomStatus.COMPLETED);
     }
 
     private void checkPairRoomIsDeleted(final PairRoomEntity pairRoomEntity) {

--- a/backend/src/main/java/site/coduo/pairroom/service/PairRoomStompManager.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/PairRoomStompManager.java
@@ -18,7 +18,7 @@ public class PairRoomStompManager {
     public void send(final String accessCode, final PairRoomStatus pairRoomStatus) {
         simpMessagingTemplate.convertAndSend(
                 String.format(STATUS_DESTINATION, accessCode),
-                new PairRoomStatusResponse(pairRoomStatus.getName())
+                new PairRoomStatusResponse(pairRoomStatus.name())
         );
     }
 }

--- a/backend/src/main/java/site/coduo/pairroom/service/PairRoomStompManager.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/PairRoomStompManager.java
@@ -15,7 +15,7 @@ public class PairRoomStompManager {
 
     private final SimpMessagingTemplate simpMessagingTemplate;
 
-    public void send(final String accessCode, final PairRoomStatus pairRoomStatus) {
+    public void sendStatus(final String accessCode, final PairRoomStatus pairRoomStatus) {
         simpMessagingTemplate.convertAndSend(
                 String.format(STATUS_DESTINATION, accessCode),
                 new PairRoomStatusResponse(pairRoomStatus.name())

--- a/backend/src/main/java/site/coduo/pairroom/service/PairRoomStompManager.java
+++ b/backend/src/main/java/site/coduo/pairroom/service/PairRoomStompManager.java
@@ -18,7 +18,7 @@ public class PairRoomStompManager {
     public void sendStatus(final String accessCode, final PairRoomStatus pairRoomStatus) {
         simpMessagingTemplate.convertAndSend(
                 String.format(STATUS_DESTINATION, accessCode),
-                new PairRoomStatusResponse(pairRoomStatus.name())
+                new PairRoomStatusResponse(pairRoomStatus.getMessage())
         );
     }
 }

--- a/backend/src/main/java/site/coduo/timer/controller/TimerController.java
+++ b/backend/src/main/java/site/coduo/timer/controller/TimerController.java
@@ -24,14 +24,14 @@ public class TimerController implements TimerDocs {
     private final SchedulerService schedulerService;
 
     @PatchMapping("/{accessCode}/timer/start")
-    public ResponseEntity<Void> createTimerStart(@PathVariable("accessCode") final String accessCode) {
+    public ResponseEntity<Void> startTimer(@PathVariable("accessCode") final String accessCode) {
         schedulerService.start(accessCode);
         return ResponseEntity.noContent()
                 .build();
     }
 
-    @PatchMapping("/{accessCode}/timer/stop")
-    public ResponseEntity<Void> createTimerStop(@PathVariable("accessCode") final String accessCode) {
+    @PatchMapping("/{accessCode}/timer/pause")
+    public ResponseEntity<Void> pauseTimer(@PathVariable("accessCode") final String accessCode) {
         schedulerService.pause(accessCode);
         return ResponseEntity.noContent()
                 .build();

--- a/backend/src/main/java/site/coduo/timer/controller/docs/TimerDocs.java
+++ b/backend/src/main/java/site/coduo/timer/controller/docs/TimerDocs.java
@@ -18,12 +18,12 @@ public interface TimerDocs {
     @Operation(summary = "타이머를 시작한다.")
     @ApiResponse(responseCode = "204", description = "타이머 시작 성공")
     @ApiResponse(responseCode = "4xx", description = "페어룸 시작 실패", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ApiErrorResponse.class)))
-    ResponseEntity<Void> createTimerStart(String accessCode);
+    ResponseEntity<Void> startTimer(String accessCode);
 
     @Operation(summary = "타이머를 중지한다.")
     @ApiResponse(responseCode = "204", description = "타이머 즁자 성공")
     @ApiResponse(responseCode = "4xx", description = "페어룸 중지 실패", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ApiErrorResponse.class)))
-    ResponseEntity<Void> createTimerStop(String accessCode);
+    ResponseEntity<Void> pauseTimer(String accessCode);
 
     @Operation(summary = "타이머를 업데이트한다.")
     @ApiResponse(responseCode = "204", description = "타이머 업데이트 성공", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))

--- a/backend/src/main/java/site/coduo/timer/domain/TimerStatus.java
+++ b/backend/src/main/java/site/coduo/timer/domain/TimerStatus.java
@@ -7,11 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum TimerStatus {
 
-    START("start"),
-    PAUSE("pause"),
-    STOP("stop"),
-    RUNNING("running"),
-    UPDATE("update");
-
-    private final String name;
+    START,
+    PAUSE,
+    STOP,
+    RUNNING,
+    UPDATE
 }

--- a/backend/src/main/java/site/coduo/timer/domain/TimerStatus.java
+++ b/backend/src/main/java/site/coduo/timer/domain/TimerStatus.java
@@ -7,9 +7,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum TimerStatus {
 
-    START,
-    PAUSE,
-    STOP,
-    RUNNING,
-    UPDATE
+    START("START"),
+    PAUSE("PAUSE"),
+    STOP("STOP"),
+    RUNNING("RUNNING"),
+    UPDATE("UPDATE");
+
+    private final String message;
 }

--- a/backend/src/main/java/site/coduo/timer/service/SchedulerService.java
+++ b/backend/src/main/java/site/coduo/timer/service/SchedulerService.java
@@ -35,7 +35,7 @@ public class SchedulerService {
         if (schedulerRegistry.isActive(key)) {
             return;
         }
-        timerStompManager.send(key, TimerStatus.START);
+        timerStompManager.sendStatus(key, TimerStatus.START);
         if (isInitial(key)) {
             final Timer timer = timerRepository.fetchTimerByAccessCode(key)
                     .toDomain();
@@ -67,14 +67,14 @@ public class SchedulerService {
             return;
         }
         timer.decreaseRemainingTime(DELAY_SECOND.toMillis());
-        timerStompManager.send(key, timer.getRemainingTime());
+        timerStompManager.sendTime(key, timer.getRemainingTime());
     }
 
     public void pause(final String key) {
         if (schedulerRegistry.isActive(key)) {
             schedulerRegistry.release(key);
         }
-        timerStompManager.send(key, TimerStatus.PAUSE);
+        timerStompManager.sendStatus(key, TimerStatus.PAUSE);
     }
 
     private void reset(final String key, final Timer timer) {
@@ -85,7 +85,7 @@ public class SchedulerService {
 
     public void notifyTimerStatus(final String key) {
         if (schedulerRegistry.isActive(key)) {
-            timerStompManager.send(key, TimerStatus.RUNNING);
+            timerStompManager.sendStatus(key, TimerStatus.RUNNING);
         }
     }
 

--- a/backend/src/main/java/site/coduo/timer/service/SchedulerService.java
+++ b/backend/src/main/java/site/coduo/timer/service/SchedulerService.java
@@ -16,8 +16,6 @@ import site.coduo.timer.domain.Timer;
 import site.coduo.timer.domain.TimerStatus;
 import site.coduo.timer.repository.TimerEntity;
 import site.coduo.timer.repository.TimerRepository;
-import site.coduo.timer.service.dto.TimerStartResponse;
-import site.coduo.timer.service.dto.TimerStatusResponse;
 
 @Transactional
 @Slf4j
@@ -37,7 +35,7 @@ public class SchedulerService {
         if (schedulerRegistry.isActive(key)) {
             return;
         }
-        timerStompManager.send(key, new TimerStatusResponse(TimerStatus.START.getName(), null));
+        timerStompManager.send(key, TimerStatus.START);
         if (isInitial(key)) {
             final Timer timer = timerRepository.fetchTimerByAccessCode(key)
                     .toDomain();
@@ -61,30 +59,25 @@ public class SchedulerService {
 
     private void runTimer(final String key, final Timer timer) {
         if (timer.isTimeUp() && schedulerRegistry.has(key)) {
-            stop(key, timer);
+            reset(key, timer);
             return;
         }
-        if (timerStompManager.isTimerIdle(key) && schedulerRegistry.has(key)) {
-            pauseTimer(key);
+        if (timerStompManager.isTimerIdle(key) && schedulerRegistry.isActive(key)) {
+            schedulerRegistry.release(key);
             return;
         }
         timer.decreaseRemainingTime(DELAY_SECOND.toMillis());
-        timerStompManager.send(key, new TimerStartResponse(timer.getRemainingTime()));
-    }
-
-    private void pauseTimer(final String key) {
-        if (schedulerRegistry.isActive(key)) {
-            schedulerRegistry.release(key);
-        }
+        timerStompManager.send(key, timer.getRemainingTime());
     }
 
     public void pause(final String key) {
-        pauseTimer(key);
-        timerStompManager.send(key, new TimerStatusResponse(TimerStatus.PAUSE.getName(), null));
+        if (schedulerRegistry.isActive(key)) {
+            schedulerRegistry.release(key);
+        }
+        timerStompManager.send(key, TimerStatus.PAUSE);
     }
 
-    private void stop(final String key, final Timer timer) {
-        // timerStompManager.send(key, new TimerStatusResponse(TimerStatus.STOP.getName(), null));
+    private void reset(final String key, final Timer timer) {
         schedulerRegistry.release(key);
         final Timer initalTimer = new Timer(timer.getAccessCode(), timer.getDuration(), timer.getDuration());
         timestampRegistry.register(key, initalTimer);
@@ -92,7 +85,7 @@ public class SchedulerService {
 
     public void notifyTimerStatus(final String key) {
         if (schedulerRegistry.isActive(key)) {
-            timerStompManager.send(key, new TimerStatusResponse(TimerStatus.RUNNING.getName(), null));
+            timerStompManager.send(key, TimerStatus.RUNNING);
         }
     }
 

--- a/backend/src/main/java/site/coduo/timer/service/TimerService.java
+++ b/backend/src/main/java/site/coduo/timer/service/TimerService.java
@@ -44,6 +44,6 @@ public class TimerService {
         );
         timerEntity.updateTimer(newTimer);
         timestampRegistry.register(accessCode, newTimer);
-        timerStompManager.sendInfo(accessCode, TimerStatus.UPDATE, newTimer.getDuration());
+        timerStompManager.sendStatusAndTime(accessCode, TimerStatus.UPDATE, newTimer.getDuration());
     }
 }

--- a/backend/src/main/java/site/coduo/timer/service/TimerService.java
+++ b/backend/src/main/java/site/coduo/timer/service/TimerService.java
@@ -44,6 +44,6 @@ public class TimerService {
         );
         timerEntity.updateTimer(newTimer);
         timestampRegistry.register(accessCode, newTimer);
-        timerStompManager.send(accessCode, TimerStatus.UPDATE, newTimer.getDuration());
+        timerStompManager.sendInfo(accessCode, TimerStatus.UPDATE, newTimer.getDuration());
     }
 }

--- a/backend/src/main/java/site/coduo/timer/service/TimerService.java
+++ b/backend/src/main/java/site/coduo/timer/service/TimerService.java
@@ -11,7 +11,6 @@ import site.coduo.timer.domain.Timer;
 import site.coduo.timer.domain.TimerStatus;
 import site.coduo.timer.repository.TimerEntity;
 import site.coduo.timer.repository.TimerRepository;
-import site.coduo.timer.service.dto.TimerStatusResponse;
 import site.coduo.timer.service.dto.TimerUpdateRequest;
 
 @Transactional(readOnly = true)
@@ -45,7 +44,6 @@ public class TimerService {
         );
         timerEntity.updateTimer(newTimer);
         timestampRegistry.register(accessCode, newTimer);
-        timerStompManager.send(accessCode,
-                new TimerStatusResponse(TimerStatus.UPDATE.getName(), newTimer.getDuration()));
+        timerStompManager.send(accessCode, TimerStatus.UPDATE, newTimer.getDuration());
     }
 }

--- a/backend/src/main/java/site/coduo/timer/service/TimerStompManager.java
+++ b/backend/src/main/java/site/coduo/timer/service/TimerStompManager.java
@@ -4,6 +4,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
+import site.coduo.timer.domain.TimerStatus;
 import site.coduo.timer.service.dto.TimerStartResponse;
 import site.coduo.timer.service.dto.TimerStatusResponse;
 import site.coduo.websocket.stomp.StompSubscriptionService;
@@ -18,12 +19,22 @@ public class TimerStompManager {
     private final StompSubscriptionService stompSubscriptionService;
     private final SimpMessagingTemplate simpMessagingTemplate;
 
-    public void send(final String accessCode, final TimerStatusResponse payload) {
-        simpMessagingTemplate.convertAndSend(String.format(STATUS_DESTINATION, accessCode), payload);
+    public void send(final String accessCode, final TimerStatus status) {
+        simpMessagingTemplate.convertAndSend(
+                String.format(STATUS_DESTINATION, accessCode),
+                new TimerStatusResponse(status.name(), null)
+        );
     }
 
-    public void send(final String accessCode, final TimerStartResponse payload) {
-        simpMessagingTemplate.convertAndSend(String.format(TIME_DESTINATION, accessCode), payload);
+    public void send(final String accessCode, final TimerStatus status, final long data) {
+        simpMessagingTemplate.convertAndSend(
+                String.format(STATUS_DESTINATION, accessCode),
+                new TimerStatusResponse(status.name(), data)
+        );
+    }
+
+    public void send(final String accessCode, final long data) {
+        simpMessagingTemplate.convertAndSend(String.format(TIME_DESTINATION, accessCode), new TimerStartResponse(data));
     }
 
     public boolean isTimerIdle(final String accessCode) {

--- a/backend/src/main/java/site/coduo/timer/service/TimerStompManager.java
+++ b/backend/src/main/java/site/coduo/timer/service/TimerStompManager.java
@@ -22,19 +22,19 @@ public class TimerStompManager {
     public void sendStatus(final String accessCode, final TimerStatus status) {
         simpMessagingTemplate.convertAndSend(
                 String.format(STATUS_DESTINATION, accessCode),
-                new TimerStatusResponse(status.name(), null)
+                new TimerStatusResponse(status.getMessage(), null)
         );
     }
 
-    public void sendInfo(final String accessCode, final TimerStatus status, final long data) {
+    public void sendTime(final String accessCode, final long time) {
+        simpMessagingTemplate.convertAndSend(String.format(TIME_DESTINATION, accessCode), new TimerStartResponse(time));
+    }
+
+    public void sendStatusAndTime(final String accessCode, final TimerStatus status, final long time) {
         simpMessagingTemplate.convertAndSend(
                 String.format(STATUS_DESTINATION, accessCode),
-                new TimerStatusResponse(status.name(), data)
+                new TimerStatusResponse(status.getMessage(), time)
         );
-    }
-
-    public void sendTime(final String accessCode, final long data) {
-        simpMessagingTemplate.convertAndSend(String.format(TIME_DESTINATION, accessCode), new TimerStartResponse(data));
     }
 
     public boolean isTimerIdle(final String accessCode) {

--- a/backend/src/main/java/site/coduo/timer/service/TimerStompManager.java
+++ b/backend/src/main/java/site/coduo/timer/service/TimerStompManager.java
@@ -19,21 +19,21 @@ public class TimerStompManager {
     private final StompSubscriptionService stompSubscriptionService;
     private final SimpMessagingTemplate simpMessagingTemplate;
 
-    public void send(final String accessCode, final TimerStatus status) {
+    public void sendStatus(final String accessCode, final TimerStatus status) {
         simpMessagingTemplate.convertAndSend(
                 String.format(STATUS_DESTINATION, accessCode),
                 new TimerStatusResponse(status.name(), null)
         );
     }
 
-    public void send(final String accessCode, final TimerStatus status, final long data) {
+    public void sendInfo(final String accessCode, final TimerStatus status, final long data) {
         simpMessagingTemplate.convertAndSend(
                 String.format(STATUS_DESTINATION, accessCode),
                 new TimerStatusResponse(status.name(), data)
         );
     }
 
-    public void send(final String accessCode, final long data) {
+    public void sendTime(final String accessCode, final long data) {
         simpMessagingTemplate.convertAndSend(String.format(TIME_DESTINATION, accessCode), new TimerStartResponse(data));
     }
 

--- a/backend/src/main/java/site/coduo/websocket/stomp/WebSocketBrokerConfig.java
+++ b/backend/src/main/java/site/coduo/websocket/stomp/WebSocketBrokerConfig.java
@@ -11,13 +11,13 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 public class WebSocketBrokerConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
-    public void configureMessageBroker(MessageBrokerRegistry config) {
+    public void configureMessageBroker(final MessageBrokerRegistry config) {
         config.enableSimpleBroker("/topic");
         config.setApplicationDestinationPrefixes("/send");
     }
 
     @Override
-    public void registerStompEndpoints(StompEndpointRegistry registry) {
+    public void registerStompEndpoints(final StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
                 .setAllowedOrigins("http://localhost:3000", "https://coduo.site", "https://test.coduo.site");
     }


### PR DESCRIPTION
## 연관된 이슈

- closes: #1111 

## 구현한 기능
- 타이머 & 페어룸 상태를 STOMP 메세지로 보낼 때 소문자 -> 대문자로 변경
- 타이머 관련 메서드명 변경 & 그 외 리팩토링
- 타이머 일시정지 엔드포인트 `/{accessCode}/timer/stop` -> `/{accessCode}/timer/pause` 으로 변경
  - 타이머 일시정지 시 STOMP 메세지로 `status: PAUSE` 를 전송하기 때문에 엔드포인트도 pause로 동일하게 수정
