### PR TITLE
[BE] 페어룸 완료 시 타이머 종료 

### DIFF
--- a/backend/src/main/java/site/coduo/pairroom/repository/PairRoomEntity.java
+++ b/backend/src/main/java/site/coduo/pairroom/repository/PairRoomEntity.java
@@ -106,6 +106,10 @@ public class PairRoomEntity extends BaseTimeEntity {
         return status != PairRoomStatus.COMPLETED && status != PairRoomStatus.DELETED;
     }
 
+    public boolean isCompleted() {
+        return status == PairRoomStatus.COMPLETED;
+    }
+
     public boolean isDeleted() {
         return status == PairRoomStatus.DELETED;
     }

--- a/backend/src/main/java/site/coduo/timer/service/SchedulerService.java
+++ b/backend/src/main/java/site/coduo/timer/service/SchedulerService.java
@@ -12,6 +12,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import site.coduo.pairroom.repository.PairRoomEntity;
+import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.timer.domain.Timer;
 import site.coduo.timer.domain.TimerStatus;
 import site.coduo.timer.repository.TimerEntity;
@@ -30,6 +32,7 @@ public class SchedulerService {
     private final SchedulerRegistry schedulerRegistry;
     private final TimestampRegistry timestampRegistry;
     private final TimerRepository timerRepository;
+    private final PairRoomRepository pairRoomRepository;
 
     public void start(final String key) {
         if (schedulerRegistry.isActive(key)) {
@@ -62,7 +65,8 @@ public class SchedulerService {
             reset(key, timer);
             return;
         }
-        if (timerStompManager.isTimerIdle(key) && schedulerRegistry.isActive(key)) {
+        PairRoomEntity pairRoomEntity = pairRoomRepository.fetchByAccessCode(key);
+        if (timerStompManager.isTimerIdle(key) && schedulerRegistry.isActive(key) || pairRoomEntity.isCompleted()) {
             schedulerRegistry.release(key);
             return;
         }

--- a/backend/src/test/java/site/coduo/timer/service/SchedulerServiceTest.java
+++ b/backend/src/test/java/site/coduo/timer/service/SchedulerServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import site.coduo.pairroom.domain.accesscode.AccessCode;
 import site.coduo.pairroom.repository.PairRoomEntity;
+import site.coduo.pairroom.repository.PairRoomRepository;
 import site.coduo.timer.domain.Timer;
 import site.coduo.timer.repository.TimerEntity;
 import site.coduo.timer.repository.TimerRepository;
@@ -25,6 +26,7 @@ import site.coduo.timer.repository.TimerRepository;
 @SpringBootTest
 class SchedulerServiceTest {
 
+    @Autowired
     private ThreadPoolTaskScheduler taskScheduler;
 
     @Autowired
@@ -33,8 +35,15 @@ class SchedulerServiceTest {
     @Autowired
     private TimestampRegistry timestampRegistry;
 
+    @Autowired
+    private PairRoomRepository pairRoomRepository;
+
+    @Autowired
     private TimerStompManager timerStompManager;
+
+    @Autowired
     private TimerRepository timerRepository;
+
     private SchedulerService schedulerService;
 
     @BeforeEach
@@ -46,7 +55,8 @@ class SchedulerServiceTest {
                 taskScheduler,
                 schedulerRegistry,
                 timestampRegistry,
-                timerRepository
+                timerRepository,
+                pairRoomRepository
         );
     }
 


### PR DESCRIPTION
## 연관된 이슈

- closes: #1143 

## 구현한 기능
페어룸 사용을 완료하면 사용하고 있는 타이머 정보를 삭제한다.

## 상세 설명
