### PR TITLE
[BE] 타이머 status에 대한 구독/구독 취소에만 타이머 상태 전송 및 db 동기화 하기

### DIFF
--- a/backend/src/main/java/site/coduo/timer/service/TimerStompManager.java
+++ b/backend/src/main/java/site/coduo/timer/service/TimerStompManager.java
@@ -40,4 +40,8 @@ public class TimerStompManager {
     public boolean isTimerIdle(final String accessCode) {
         return stompSubscriptionService.hasSubscription(String.format(TIME_DESTINATION, accessCode));
     }
+
+    public boolean isTimerStatusDestination(final String accessCode, final String destination) {
+        return String.format(STATUS_DESTINATION, accessCode).equals(destination);
+    }
 }

--- a/backend/src/main/java/site/coduo/websocket/stomp/StompEventListener.java
+++ b/backend/src/main/java/site/coduo/websocket/stomp/StompEventListener.java
@@ -9,6 +9,7 @@ import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
 
 import lombok.RequiredArgsConstructor;
 import site.coduo.timer.service.SchedulerService;
+import site.coduo.timer.service.TimerStompManager;
 import site.coduo.websocket.exception.NotFoundAccessCodeInQueryException;
 
 @Component
@@ -19,6 +20,7 @@ public class StompEventListener {
     private static final String PATH = "/";
 
     private final SchedulerService schedulerService;
+    private final TimerStompManager timerStompManager;
 
     @EventListener
     public void onSubscription(final SessionSubscribeEvent event) {
@@ -28,7 +30,9 @@ public class StompEventListener {
             throw new NotFoundAccessCodeInQueryException("STOMP 헤더에 simpDestination이 존재하지 않습니다.");
         }
         final String key = parsePairRoomKey(destination);
-        schedulerService.notifyTimerStatus(key);
+        if (timerStompManager.isTimerStatusDestination(destination, key)) {
+            schedulerService.notifyTimerStatus(key);
+        }
     }
 
     @EventListener
@@ -39,7 +43,9 @@ public class StompEventListener {
             throw new NotFoundAccessCodeInQueryException("STOMP 헤더에 simpSubscriptionId가 존재하지 않습니다.");
         }
         final String key = parsePairRoomKey(destination);
-        schedulerService.syncTimerWithDatabase(key);
+        if (timerStompManager.isTimerStatusDestination(destination, key)) {
+            schedulerService.syncTimerWithDatabase(key);
+        }
     }
 
     private String parsePairRoomKey(final String destination) {


### PR DESCRIPTION
## 연관된 이슈

- closes: (이슈 번호)

## 구현한 기능
- 이전에는 모든 구독이 발생할 때마다 타이머 상태를 보내주었음. 그래서 여러번 안내창이 나타났었는데, 현재 destination이 timer/status인 구독 요청에만 타이머 상태를 보내주는 것으로 수정
- timestamp db 동기화도 id가 timer/status 인 구독 취소 이벤트가 발생할 때만 동기화 하도록 수정
