### PR TITLE
[BE] 전체 subscribe를 대상으로 타이머 status를 전송하도록 롤백

### DIFF
--- a/backend/src/main/java/site/coduo/websocket/stomp/StompEventListener.java
+++ b/backend/src/main/java/site/coduo/websocket/stomp/StompEventListener.java
@@ -30,9 +30,7 @@ public class StompEventListener {
             throw new NotFoundAccessCodeInQueryException("STOMP 헤더에 simpDestination이 존재하지 않습니다.");
         }
         final String key = parsePairRoomKey(destination);
-        if (timerStompManager.isTimerStatusDestination(destination, key)) {
-            schedulerService.notifyTimerStatus(key);
-        }
+        schedulerService.notifyTimerStatus(key);
     }
 
     @EventListener
@@ -43,9 +41,7 @@ public class StompEventListener {
             throw new NotFoundAccessCodeInQueryException("STOMP 헤더에 simpSubscriptionId가 존재하지 않습니다.");
         }
         final String key = parsePairRoomKey(destination);
-        if (timerStompManager.isTimerStatusDestination(destination, key)) {
-            schedulerService.syncTimerWithDatabase(key);
-        }
+        schedulerService.syncTimerWithDatabase(key);
     }
 
     private String parsePairRoomKey(final String destination) {


### PR DESCRIPTION
## 연관된 이슈

- closes: (이슈 번호)

## 구현한 기능
- 타이머 status를 destination으로 한 subscribe가 발생할 때만 타이머 status 전송 -> 전체 subscribe를 대상으로 롤백
- 타이머 status를 destination으로 한 unsubscribe가 발생할 때만 timestamp를 db에 반영 -> 전체 unsubscribe를 대상으로 롤백

## 상세 설명
