### PR TITLE
[BE] 타이머 구독을 새로 한 사람에게만 STOMP 메세지를 전송하도록 수정

### DIFF
--- a/backend/src/main/java/site/coduo/timer/service/SchedulerService.java
+++ b/backend/src/main/java/site/coduo/timer/service/SchedulerService.java
@@ -87,9 +87,9 @@ public class SchedulerService {
         timestampRegistry.register(key, initalTimer);
     }
 
-    public void notifyTimerStatus(final String key) {
+    public void notifyTimerStatus(final String key, final String sessionId) {
         if (schedulerRegistry.isActive(key)) {
-            timerStompManager.sendStatus(key, TimerStatus.RUNNING);
+            timerStompManager.sendStatusToUser(sessionId, key, TimerStatus.RUNNING);
         }
     }
 

--- a/backend/src/main/java/site/coduo/timer/service/TimerStompManager.java
+++ b/backend/src/main/java/site/coduo/timer/service/TimerStompManager.java
@@ -26,6 +26,14 @@ public class TimerStompManager {
         );
     }
 
+    public void sendStatusToUser(final String sessionId, final String accessCode, final TimerStatus status) {
+        simpMessagingTemplate.convertAndSendToUser(
+                sessionId,
+                String.format(STATUS_DESTINATION, accessCode),
+                new TimerStatusResponse(status.getMessage(), null)
+        );
+    }
+
     public void sendTime(final String accessCode, final long time) {
         simpMessagingTemplate.convertAndSend(String.format(TIME_DESTINATION, accessCode), new TimerStartResponse(time));
     }

--- a/backend/src/main/java/site/coduo/websocket/WebSocketHandler.java
+++ b/backend/src/main/java/site/coduo/websocket/WebSocketHandler.java
@@ -22,7 +22,6 @@ public class WebSocketHandler extends TextWebSocketHandler {
     public void afterConnectionEstablished(final WebSocketSession session) {
         final String pairRoomAccessCode = parsePairRoomAccessCode(session);
         pairRoomWebSocketSessionStore.addSession(pairRoomAccessCode, session);
-        schedulerService.notifyTimerStatus(pairRoomAccessCode);
         log.info("연결 성공 : {}", session.getId());
     }
 

--- a/backend/src/main/java/site/coduo/websocket/stomp/StompEventListener.java
+++ b/backend/src/main/java/site/coduo/websocket/stomp/StompEventListener.java
@@ -31,7 +31,8 @@ public class StompEventListener {
         }
         final String key = parsePairRoomKey(destination);
         if (timerStompManager.isTimerStatusDestination(key, destination)) {
-            schedulerService.notifyTimerStatus(key);
+            String sessionId = headerAccessor.getSessionId();
+            schedulerService.notifyTimerStatus(key, sessionId);
         }
     }
 

--- a/backend/src/main/java/site/coduo/websocket/stomp/StompEventListener.java
+++ b/backend/src/main/java/site/coduo/websocket/stomp/StompEventListener.java
@@ -31,7 +31,7 @@ public class StompEventListener {
         }
         final String key = parsePairRoomKey(destination);
         if (timerStompManager.isTimerStatusDestination(key, destination)) {
-            String sessionId = headerAccessor.getSessionId();
+            final String sessionId = headerAccessor.getSessionId();
             schedulerService.notifyTimerStatus(key, sessionId);
         }
     }


### PR DESCRIPTION
## 연관된 이슈

- closes: #1172

## 구현한 기능
- 모든 구독자들에게 타이머 상태를 전송하지 않고, 새로 구독을 한 사람에게만 전송하도록 수정
- convertAndSend -> convertAndSendToUser 로 특정 세션에만 전송

## 상세 설명
